### PR TITLE
Enable support for generics in trait-less impl

### DIFF
--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -137,12 +137,6 @@ fn check_item<'tcx>(
                     "unsupported impl of trait",
                     item
                 );
-                unsupported_err_unless!(
-                    impll.generics.params.len() == 0,
-                    item.span,
-                    "unsupported impl of non-trait with generics",
-                    item
-                );
                 match impll.self_ty.kind {
                     TyKind::Path(QPath::Resolved(
                         None,
@@ -166,7 +160,6 @@ fn check_item<'tcx>(
                                                 impl_item_visibility,
                                                 ctxt.tcx.hir().attrs(impl_item.hir_id()),
                                                 sig,
-                                                // TODO: make sure this is correct once supported
                                                 &impll.generics,
                                                 body_id,
                                             )?;

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -41,6 +41,7 @@ fn check_item<'tcx>(
                 visibility,
                 ctxt.tcx.hir().attrs(item.hir_id()),
                 sig,
+                None,
                 generics,
                 body_id,
             )?;
@@ -160,7 +161,8 @@ fn check_item<'tcx>(
                                                 impl_item_visibility,
                                                 ctxt.tcx.hir().attrs(impl_item.hir_id()),
                                                 sig,
-                                                &impll.generics,
+                                                Some(&impll.generics),
+                                                &impl_item.generics,
                                                 body_id,
                                             )?;
                                         }

--- a/source/rust_verify/tests/impl.rs
+++ b/source/rust_verify/tests/impl.rs
@@ -90,3 +90,37 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+const IMPL_GENERIC_SHARED: &str = code_str! {
+    #[derive(PartialEq, Eq)]
+    struct Wrapper<A> {
+        v: A,
+    }
+
+    impl<A> Wrapper<A> {
+        #[spec]
+        pub fn take(self) -> A {
+            self.v
+        }
+    }
+};
+
+test_verify_one_file! {
+    #[test] test_impl_generic_pass IMPL_GENERIC_SHARED.to_string() + code_str! {
+        #[proof]
+        fn test_impl_1(a: int) {
+            let w = Wrapper { v: a };
+            assert(w.take() == a);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_impl_generic_fail IMPL_GENERIC_SHARED.to_string() + code_str! {
+        #[proof]
+        fn test_impl_1(a: int) {
+            let w = Wrapper { v: a };
+            assert(w.take() != a); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}

--- a/source/rust_verify/tests/impl.rs
+++ b/source/rust_verify/tests/impl.rs
@@ -124,3 +124,31 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_one_fails(err)
 }
+
+test_verify_one_file! {
+    #[test] test_impl_generic_param code! {
+        #[derive(PartialEq, Eq, Structural)]
+        struct Two<A, B> {
+            a: A,
+            b: B,
+        }
+
+        #[derive(PartialEq, Eq)]
+        struct Wrapper<A> {
+            v: A,
+        }
+
+        impl<A> Wrapper<A> {
+            #[spec]
+            pub fn take<B>(self, b: B) -> Two<A, B> {
+                Two { a: self.v, b: b }
+            }
+        }
+
+        #[proof]
+        fn test_impl_1(a: int) {
+            let w = Wrapper { v: a };
+            assert(w.take(12) == Two { a: a, b: 12 });
+        }
+    } => Ok(())
+}


### PR DESCRIPTION
rust:

```
    struct Wrapper<A> {
        v: A,
    }

    impl<A> Wrapper<A> {
        #[spec]
        pub fn take(self) -> A {
            self.v
        }
    }

    #[proof]
    fn test_impl_1(a: int) {
        let w = Wrapper { v: a };
        assert(w.take() == a);
    }
```

air:

```
 ;; Function-Decl crate::Wrapper::take
 (declare-fun Wrapper.take.? (Type Wrapper.) Poly)

 ;; Function-Axioms crate::Wrapper::take
 (axiom (fuel_bool_default fuel%Wrapper.take.))
 (axiom (=>
   (fuel_bool fuel%Wrapper.take.)
   (forall ((A& Type) (self@ Wrapper.)) (!
     (= (Wrapper.take.? A& self@) (Wrapper./Wrapper/v self@))
     :pattern ((Wrapper.take.? A& self@))
 ))))
 (axiom (forall ((A& Type) (self@ Wrapper.)) (!
    (=>
     (has_type (Poly%Wrapper. self@) (TYPE%Wrapper. A&))
     (has_type (Wrapper.take.? A& self@) A&)
    )
    :pattern ((Wrapper.take.? A& self@))
 )))

 ;; Function-Def crate::test_impl_1
 (check-valid
  (declare-const a@ Int)
  (declare-const tmp%1@ Bool)
  (declare-const tmp%%1@ Wrapper.)
  (declare-const w@ Wrapper.)
  (axiom fuel_defaults)
  (block
   (assume
    (= tmp%%1@ (Wrapper./Wrapper (I a@)))
   )
   (assume
    (= w@ tmp%%1@)
   )
   (assume
    (= tmp%1@ (= (%I (Wrapper.take.? INT w@)) a@))
   )
   (block
    (assert
     "test.rs:21:5: 21:26 (#0)"
     (req%pervasive.assert. tmp%1@)
    )
    (assume
     (ens%pervasive.assert. tmp%1@)
 ))))
```