### PR TITLE
pervasive Set literal

### DIFF
--- a/source/pervasive/set.rs
+++ b/source/pervasive/set.rs
@@ -89,7 +89,7 @@ impl<A> Set<A> {
 
     #[spec]
     #[verifier(pub_abstract)]
-    pub fn cardinality(self) -> nat {
+    pub fn cardinality(self) -> nat { // TODO(utaal): switch to len
         arbitrary()
     }
 
@@ -225,4 +225,24 @@ pub fn axiom_mk_map_domain<K, V, F: Fn(K) -> V>(s: Set<K>, f: F) {
 pub fn axiom_mk_map_index<K, V, F: Fn(K) -> V>(s: Set<K>, f: F, key: K) {
     requires(s.contains(key));
     ensures(equal(s.mk_map(f).index(key), f(key)));
+}
+
+#[macro_export]
+macro_rules! set_insert_rec {
+    [$val:expr;] => {
+        $val
+    };
+    [$val:expr;$elem:expr] => {
+        set_insert_rec![$val.insert($elem);]
+    };
+    [$val:expr;$elem:expr,$($tail:tt)*] => {
+        set_insert_rec![$val.insert($elem);$($tail)*]
+    }
+}
+
+#[macro_export]
+macro_rules! set {
+    [$($tail:tt)*] => {
+        set_insert_rec![$crate::pervasive::set::set_empty();$($tail)*]
+    }
 }

--- a/source/rust_verify/src/erase.rs
+++ b/source/rust_verify/src/erase.rs
@@ -898,6 +898,7 @@ fn erase_item(ctxt: &Ctxt, mctxt: &mut MCtxt, item: &Item) -> Vec<P<Item>> {
             ItemKind::Impl(Box::new(kind))
         }
         ItemKind::Const(..) => item.kind.clone(),
+        ItemKind::MacroDef(..) => item.kind.clone(),
         _ => {
             unsupported!("unsupported item", item)
         }

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -265,7 +265,7 @@ fn check_attr<'tcx>(
 pub fn crate_to_vir<'tcx>(ctxt: &Context<'tcx>) -> Result<Krate, VirErr> {
     let Crate {
         item: _,
-        exported_macros,
+        exported_macros: _,
         non_exported_macro_attrs,
         items,
         trait_items,
@@ -280,11 +280,6 @@ pub fn crate_to_vir<'tcx>(ctxt: &Context<'tcx>) -> Result<Krate, VirErr> {
         attrs,
     } = ctxt.krate;
     let mut vir: KrateX = Default::default();
-    unsupported_unless!(
-        exported_macros.len() == 0,
-        "exported macros from a crate",
-        exported_macros
-    );
     unsupported_unless!(
         non_exported_macro_attrs.len() == 0,
         "non-exported macro attributes",

--- a/source/rust_verify/tests/literals.rs
+++ b/source/rust_verify/tests/literals.rs
@@ -1,0 +1,46 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+test_verify_one_file! {
+    #[test] set_literal_0 code! {
+        #[allow(unused)]
+        use set::*;
+
+        #[proof]
+        fn sl() {
+            let s1: Set<int> = set![];
+            let s2: Set<int> = set![];
+            assert(s1.ext_equal(s2));
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] set_literal_1 code! {
+        #[allow(unused)]
+        use set::*;
+
+        #[proof]
+        fn sl() {
+            let s1 = set![2];
+            let s2 = set![2];
+            assert(s1.ext_equal(s2));
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] set_literal_2 code! {
+        #[allow(unused)]
+        use set::*;
+
+        #[proof]
+        fn sl() {
+            let s1 = set![2, 4];
+            let s2 = set![4, 2];
+            assert(s1.ext_equal(s2));
+        }
+    } => Ok(())
+}


### PR DESCRIPTION
This needs to allow macros as supported items, and preserves them when erasing. I do not believe that can cause unsoundness but it's worth a second look.