### PR TITLE
Support impls of traits for adts when invoked on a concrete type

### DIFF
--- a/source/rust_verify/src/context.rs
+++ b/source/rust_verify/src/context.rs
@@ -11,6 +11,7 @@ pub struct ErasureInfo {
     pub(crate) resolved_pats: Vec<(SpanData, Pattern)>,
     pub(crate) condition_modes: Vec<(SpanData, Mode)>,
     pub(crate) external_functions: Vec<vir::ast::Fun>,
+    pub(crate) ignored_functions: Vec<SpanData>,
 }
 
 type ErasureInfoRef = std::rc::Rc<std::cell::RefCell<ErasureInfo>>;

--- a/source/rust_verify/src/context.rs
+++ b/source/rust_verify/src/context.rs
@@ -10,7 +10,7 @@ pub struct ErasureInfo {
     pub(crate) resolved_exprs: Vec<(SpanData, Expr)>,
     pub(crate) resolved_pats: Vec<(SpanData, Pattern)>,
     pub(crate) condition_modes: Vec<(SpanData, Mode)>,
-    pub(crate) external_functions: Vec<vir::ast::Path>,
+    pub(crate) external_functions: Vec<vir::ast::Fun>,
 }
 
 type ErasureInfoRef = std::rc::Rc<std::cell::RefCell<ErasureInfo>>;

--- a/source/rust_verify/src/erase.rs
+++ b/source/rust_verify/src/erase.rs
@@ -53,8 +53,7 @@ use rustc_ast::ast::{
     AngleBracketedArg, AngleBracketedArgs, Arm, AssocItem, AssocItemKind, Block, Crate, EnumDef,
     Expr, ExprKind, Field, FieldPat, FnDecl, FnKind, FnRetTy, FnSig, GenericArgs, GenericParam,
     Generics, ImplKind, Item, ItemKind, Lit, LitIntType, LitKind, Local, ModKind, NodeId, Param,
-    Pat, PatKind, PathSegment, Stmt, StmtKind, StructField, StructRest, TraitRef, Variant,
-    VariantData,
+    Pat, PatKind, PathSegment, Stmt, StmtKind, StructField, StructRest, Variant, VariantData,
 };
 use rustc_ast::ptr::P;
 use rustc_data_structures::thin_vec::ThinVec;
@@ -68,7 +67,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use vir::ast::{
-    Datatype, ExprX, Function, GenericBoundX, Krate, Mode, Path, Pattern, PatternX, UnaryOpr,
+    Datatype, ExprX, Fun, Function, GenericBoundX, Krate, Mode, Path, Pattern, PatternX, UnaryOpr,
 };
 use vir::ast_util::get_field;
 use vir::modes::{mode_join, ErasureModes};
@@ -81,7 +80,7 @@ pub enum ResolvedCall {
     /// The call is to an operator like == or + that should be compiled.
     CompilableOperator,
     /// The call is to a function, and we record the resolved name of the function here.
-    Call(Path),
+    Call(Fun),
     /// Path and variant of datatype constructor
     Ctor(Path, vir::ast::Ident),
 }
@@ -100,7 +99,7 @@ pub struct ErasureHints {
     pub erasure_modes: ErasureModes,
     /// List of #[verifier(external)] functions.  (These don't appear in vir_crate,
     /// so we need to record them separately here.)
-    pub external_functions: Vec<Path>,
+    pub external_functions: Vec<Fun>,
 }
 
 #[derive(Clone)]
@@ -109,7 +108,7 @@ pub struct Ctxt {
     vir_crate: Krate,
     /// Map each function path to its VIR Function, or to None if it is a #[verifier(external)]
     /// function
-    functions: HashMap<Path, Option<Function>>,
+    functions: HashMap<Fun, Option<Function>>,
     /// Map each datatype path to its VIR Datatype
     datatypes: HashMap<Path, Datatype>,
     /// Map each function span to its VIR Function, excluding #[verifier(external)] functions
@@ -335,10 +334,10 @@ fn erase_call(
     ctxt: &Ctxt,
     mctxt: &mut MCtxt,
     segment: &PathSegment,
-    f_path: &Path,
+    f_name: &Fun,
     args: &Vec<P<Expr>>,
 ) -> Option<Option<(PathSegment, Vec<P<Expr>>)>> {
-    let f = &ctxt.functions[f_path];
+    let f = &ctxt.functions[f_name];
     if let Some(f) = f {
         let mut segment = segment.clone();
         if let Some(args) = &segment.args {
@@ -492,9 +491,9 @@ fn erase_expr_opt(ctxt: &Ctxt, mctxt: &mut MCtxt, expect: Mode, expr: &Expr) -> 
                         return None;
                     }
                 }
-                ResolvedCall::Call(f_path) => {
+                ResolvedCall::Call(f_name) => {
                     let segment = path.segments.last().expect("path with segments");
-                    match erase_call(ctxt, mctxt, segment, f_path, args) {
+                    match erase_call(ctxt, mctxt, segment, f_name, args) {
                         None => return Some(expr.clone()),
                         Some(None) => return None,
                         Some(Some((segment, args))) => {
@@ -824,11 +823,18 @@ fn erase_assoc_item(ctxt: &Ctxt, mctxt: &mut MCtxt, item: &AssocItem) -> Option<
             if vattrs.external {
                 return Some(item.clone());
             }
-            match erase_fn(ctxt, mctxt, f) {
-                None => None,
-                Some(f) => Some(update_item(item, AssocItemKind::Fn(Box::new(f)))),
+            let FnKind(_, sig, _, _) = &**f;
+            // we ignore (not erase) functions for which we do not have a span, this currently
+            // includes impls of builtin traits that are not encoded in vir
+            match ctxt.functions_by_span.get(&sig.span) {
+                Some(_) => {
+                    let erased = erase_fn(ctxt, mctxt, f);
+                    erased.map(|f| update_item(item, AssocItemKind::Fn(Box::new(f))))
+                }
+                None => Some(item.clone()),
             }
         }
+        AssocItemKind::TyAlias(_) => Some(item.clone()),
         _ => panic!("unsupported AssocItemKind"),
     }
 }
@@ -901,9 +907,6 @@ fn erase_item(ctxt: &Ctxt, mctxt: &mut MCtxt, item: &Item) -> Vec<P<Item>> {
             }
         }
         ItemKind::Impl(kind) => {
-            if let Some(TraitRef { .. }) = kind.of_trait {
-                return vec![P(item.clone())];
-            }
             let mut items: Vec<P<AssocItem>> = Vec::new();
             for item in &kind.items {
                 if let Some(item) = erase_assoc_item(ctxt, mctxt, &item) {
@@ -952,7 +955,7 @@ fn mk_ctxt(erasure_hints: &ErasureHints, keep_proofs: bool) -> Ctxt {
     let mut resolved_exprs: HashMap<Span, vir::ast::Expr> = HashMap::new();
     let mut resolved_pats: HashMap<Span, Pattern> = HashMap::new();
     for f in &erasure_hints.vir_crate.functions {
-        functions.insert(f.x.path.clone(), Some(f.clone()));
+        functions.insert(f.x.name.clone(), Some(f.clone()));
         functions_by_span.insert(from_raw_span(&f.span.raw_span), f.clone());
     }
     for name in &erasure_hints.external_functions {

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -8,7 +8,7 @@ For soundness's sake, be as defensive as possible:
 
 use crate::context::Context;
 use crate::rust_to_vir_adts::{check_item_enum, check_item_struct};
-use crate::rust_to_vir_base::{def_id_to_vir_path, hack_get_def_name, mk_visibility};
+use crate::rust_to_vir_base::{def_id_to_vir_path, get_mode, hack_get_def_name, mk_visibility};
 use crate::rust_to_vir_func::{check_foreign_item_fn, check_item_fn};
 use crate::util::unsupported_err_span;
 use crate::{err_unless, unsupported_err, unsupported_err_unless, unsupported_unless};
@@ -20,7 +20,7 @@ use rustc_hir::{
 use rustc_middle::ty::TyCtxt;
 use std::collections::HashMap;
 use std::sync::Arc;
-use vir::ast::{Krate, KrateX, Path, VirErr};
+use vir::ast::{Krate, KrateX, Mode, Path, VirErr};
 use vir::ast_util::path_as_rust_name;
 
 fn check_item<'tcx>(
@@ -41,6 +41,7 @@ fn check_item<'tcx>(
                 visibility,
                 ctxt.tcx.hir().attrs(item.hir_id()),
                 sig,
+                None,
                 None,
                 generics,
                 body_id,
@@ -81,16 +82,6 @@ fn check_item<'tcx>(
         ItemKind::Impl(impll) => {
             if let Some(TraitRef { path, hir_ref_id: _ }) = impll.of_trait {
                 let path_name = path_as_rust_name(&def_id_to_vir_path(ctxt.tcx, path.res.def_id()));
-                unsupported_err_unless!(
-                    path_name == "core::marker::StructuralEq"
-                        || path_name == "core::cmp::Eq"
-                        || path_name == "core::marker::StructuralPartialEq"
-                        || path_name == "core::cmp::PartialEq"
-                        || path_name == "builtin::Structural",
-                    item.span,
-                    "non_eq_trait_impl",
-                    path
-                );
                 if path_name == "builtin::Structural" {
                     let ty = {
                         // TODO extract to rust_to_vir_base, or use
@@ -130,60 +121,81 @@ fn check_item<'tcx>(
                         format!("Structural impl for non-structural type {:?}", ty),
                         ty
                     );
+                    return Ok(());
+                } else if path_name == "core::marker::StructuralEq"
+                    || path_name == "core::cmp::Eq"
+                    || path_name == "core::marker::StructuralPartialEq"
+                    || path_name == "core::cmp::PartialEq"
+                    || path_name == "builtin::Structural"
+                {
+                    // TODO SOUNDNESS additional checks of the implementation
+                    return Ok(());
                 }
-            } else {
-                unsupported_err_unless!(
-                    impll.of_trait.is_none(),
-                    item.span,
-                    "unsupported impl of trait",
-                    item
-                );
-                match impll.self_ty.kind {
-                    TyKind::Path(QPath::Resolved(
-                        None,
-                        rustc_hir::Path { res: rustc_hir::def::Res::Def(_, self_def_id), .. },
-                    )) => {
-                        for impl_item_ref in impll.items {
-                            match impl_item_ref.kind {
-                                AssocItemKind::Fn { has_self } if has_self => {
-                                    let impl_item = ctxt.tcx.hir().impl_item(impl_item_ref.id);
-                                    let impl_item_visibility =
-                                        mk_visibility(&Some(module_path.clone()), &impl_item.vis);
-                                    match &impl_item.kind {
-                                        ImplItemKind::Fn(sig, body_id) => {
-                                            let self_path =
-                                                def_id_to_vir_path(ctxt.tcx, *self_def_id);
-                                            check_item_fn(
-                                                ctxt,
-                                                vir,
-                                                Some(self_path),
-                                                impl_item.def_id.to_def_id(),
-                                                impl_item_visibility,
-                                                ctxt.tcx.hir().attrs(impl_item.hir_id()),
-                                                sig,
-                                                Some(&impll.generics),
-                                                &impl_item.generics,
-                                                body_id,
-                                            )?;
-                                        }
-                                        _ => unsupported_err!(
-                                            item.span,
-                                            "unsupported item in impl",
-                                            impl_item_ref
-                                        ),
+            }
+
+            match impll.self_ty.kind {
+                TyKind::Path(QPath::Resolved(
+                    None,
+                    rustc_hir::Path { res: rustc_hir::def::Res::Def(_, self_def_id), .. },
+                )) => {
+                    let self_path = def_id_to_vir_path(ctxt.tcx, *self_def_id);
+                    let trait_path = impll.of_trait.as_ref().map(|TraitRef { path, .. }| {
+                        def_id_to_vir_path(ctxt.tcx, path.res.def_id())
+                    });
+                    let adt_mode = {
+                        let attrs = ctxt.tcx.hir().attrs(
+                            ctxt.tcx
+                                .hir()
+                                .get_if_local(*self_def_id)
+                                .expect("non-local def id of fun")
+                                .hir_id()
+                                .expect("adt must have hir_id"),
+                        );
+                        get_mode(Mode::Exec, attrs)
+                    };
+                    for impl_item_ref in impll.items {
+                        match impl_item_ref.kind {
+                            AssocItemKind::Fn { has_self } if has_self => {
+                                let impl_item = ctxt.tcx.hir().impl_item(impl_item_ref.id);
+                                let impl_item_visibility =
+                                    mk_visibility(&Some(module_path.clone()), &impl_item.vis);
+                                match &impl_item.kind {
+                                    ImplItemKind::Fn(sig, body_id) => {
+                                        check_item_fn(
+                                            ctxt,
+                                            vir,
+                                            Some((self_path.clone(), adt_mode)),
+                                            impl_item.def_id.to_def_id(),
+                                            impl_item_visibility,
+                                            ctxt.tcx.hir().attrs(impl_item.hir_id()),
+                                            sig,
+                                            trait_path.clone(),
+                                            Some(&impll.generics),
+                                            &impl_item.generics,
+                                            body_id,
+                                        )?;
                                     }
+                                    _ => unsupported_err!(
+                                        item.span,
+                                        "unsupported item in impl",
+                                        impl_item_ref
+                                    ),
                                 }
-                                _ => unsupported_err!(
-                                    item.span,
-                                    "unsupported item in impl",
-                                    impl_item_ref
-                                ),
                             }
+                            AssocItemKind::Type => {
+                                let _impl_item = ctxt.tcx.hir().impl_item(impl_item_ref.id);
+                                // the type system handles this for Trait impls
+                            }
+                            _ => unsupported_err!(
+                                item.span,
+                                "unsupported item ref in impl",
+                                impl_item_ref
+                            ),
                         }
                     }
-                    _ => {
-                        unsupported_err!(item.span, "unsupported impl of non-path type", item);
-                    }
+                }
+                _ => {
+                    unsupported_err!(item.span, "unsupported impl of non-path type", item);
                 }
             }
         }
@@ -272,7 +284,7 @@ pub fn crate_to_vir<'tcx>(ctxt: &Context<'tcx>) -> Result<Krate, VirErr> {
         impl_items,
         foreign_items,
         bodies: _,
-        trait_impls,
+        trait_impls: _,
         body_ids: _,
         modules,
         proc_macros,
@@ -307,26 +319,20 @@ pub fn crate_to_vir<'tcx>(ctxt: &Context<'tcx>) -> Result<Krate, VirErr> {
                     || impl_item_ident == "ne"
                     || impl_item_ident == "assert_receiver_is_structural"
                 {
-                    // TODO: check whether these implement the correct trait if
+                    // TODO: check whether these implement the correct trait
                 }
+            }
+            ImplItemKind::TyAlias(_ty) => {
+                // checked by the type system
             }
             _ => {
                 unsupported_err!(impl_item.span, "unsupported_impl_item", impl_item);
             }
         }
     }
-    for (id, _trait_impl) in trait_impls {
-        let id_name = path_as_rust_name(&def_id_to_vir_path(ctxt.tcx, *id));
-        unsupported_unless!(
-            id_name == "core::marker::StructuralEq"
-                || id_name == "core::cmp::Eq"
-                || id_name == "core::marker::StructuralPartialEq"
-                || id_name == "core::cmp::PartialEq"
-                || id_name == "builtin::Structural",
-            "non_eq_trait_impl",
-            id
-        );
-    }
+    // for (id, _trait_impl) in trait_impls {
+    //
+    // }
     unsupported_unless!(proc_macros.len() == 0, "procedural macros", proc_macros);
     // unsupported_unless!(trait_map.iter().all(|(_, v)| v.len() == 0), "traits", trait_map);
     for (id, attr) in attrs {

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -12,7 +12,7 @@ use rustc_middle::ty::TyCtxt;
 use rustc_span::symbol::Ident;
 use rustc_span::Span;
 use std::sync::Arc;
-use vir::ast::{FunctionAttrsX, FunctionX, KrateX, Mode, ParamX, Typ, TypX, VirErr};
+use vir::ast::{FunX, FunctionAttrsX, FunctionX, KrateX, Mode, ParamX, Typ, TypX, VirErr};
 use vir::def::RETURN_VALUE;
 
 pub(crate) fn body_to_vir<'tcx>(
@@ -34,9 +34,7 @@ fn is_self_or_self_ref(span: Span, ty: &rustc_hir::Ty) -> Result<bool, VirErr> {
             rustc_hir::MutTy { ty: rty, mutbl: rustc_hir::Mutability::Not, .. },
         ) => is_self_or_self_ref(span, rty),
         rustc_hir::TyKind::Path(rustc_hir::QPath::Resolved(None, path)) => match path.res {
-            rustc_hir::def::Res::SelfTy(Some(_), _impl_def_id) => {
-                unsupported_err!(span, "trait self", ty)
-            }
+            rustc_hir::def::Res::SelfTy(Some(_), _impl_def_id) => Ok(true),
             rustc_hir::def::Res::SelfTy(None, _) => Ok(true),
             _ => Ok(false),
         },
@@ -86,23 +84,38 @@ fn check_fn_decl<'tcx>(
 pub(crate) fn check_item_fn<'tcx>(
     ctxt: &Context<'tcx>,
     vir: &mut KrateX,
-    self_path: Option<vir::ast::Path>,
+    self_path_mode: Option<(vir::ast::Path, Mode)>,
     id: rustc_span::def_id::DefId,
     visibility: vir::ast::Visibility,
     attrs: &[Attribute],
     sig: &'tcx FnSig<'tcx>,
+    trait_path: Option<vir::ast::Path>,
     self_generics: Option<&'tcx Generics>,
     generics: &'tcx Generics,
     body_id: &BodyId,
 ) -> Result<(), VirErr> {
-    let path = if let Some(self_path) = &self_path {
+    let path = if let Some((self_path, _)) = &self_path_mode {
         let mut full_path = (**self_path).clone();
         Arc::make_mut(&mut full_path.segments).push(def_to_path_ident(ctxt.tcx, id));
         Arc::new(full_path)
     } else {
         def_id_to_vir_path(ctxt.tcx, id)
     };
+    let name = Arc::new(FunX { path, trait_path });
     let mode = get_mode(Mode::Exec, attrs);
+    if let (Some(_), Some((self_path, adt_mode))) = (&name.trait_path, &self_path_mode) {
+        if !vir::modes::mode_le(mode, *adt_mode) {
+            return err_span_string(
+                sig.span,
+                format!(
+                    "{} has mode {}, which must not be lower than the function's mode {} for trait impls",
+                    vir::ast_util::path_as_rust_name(&self_path),
+                    adt_mode,
+                    mode
+                ),
+            );
+        }
+    }
     let self_typ_params =
         if let Some(cg) = self_generics { Some(check_generics(ctxt.tcx, cg)?) } else { None };
     let ret_typ_mode = match sig {
@@ -116,7 +129,7 @@ pub(crate) fn check_item_fn<'tcx>(
                 ctxt.tcx,
                 &sig.span,
                 decl,
-                self_path.clone(),
+                self_path_mode.as_ref().map(|(self_path, _)| self_path.clone()),
                 self_typ_params.clone(),
                 mode,
             )?
@@ -127,7 +140,7 @@ pub(crate) fn check_item_fn<'tcx>(
     let vattrs = get_verifier_attrs(attrs)?;
     if vattrs.external {
         let mut erasure_info = ctxt.erasure_info.borrow_mut();
-        erasure_info.external_functions.push(path);
+        erasure_info.external_functions.push(name);
         return Ok(());
     }
     let body = &ctxt.krate.bodies[body_id];
@@ -154,7 +167,11 @@ pub(crate) fn check_item_fn<'tcx>(
                     Arc::new(TypX::TypParam(t.clone()))
                 });
             Arc::new(TypX::Datatype(
-                self_path.as_ref().expect("a param is Self, so this must be an impl").clone(),
+                self_path_mode
+                    .as_ref()
+                    .map(|(self_path, _)| self_path)
+                    .expect("a param is Self, so this must be an impl")
+                    .clone(),
                 Arc::new(typ_args),
             ))
         } else {
@@ -223,7 +240,7 @@ pub(crate) fn check_item_fn<'tcx>(
         export_as_global_forall: vattrs.export_as_global_forall,
     };
     let func = FunctionX {
-        path,
+        name,
         visibility,
         mode,
         fuel,
@@ -266,6 +283,7 @@ pub(crate) fn check_foreign_item_fn<'tcx>(
         vir_params.push(vir_param);
     }
     let path = def_id_to_vir_path(ctxt.tcx, id);
+    let name = Arc::new(FunX { path, trait_path: None });
     let params = Arc::new(vir_params);
     let (ret_typ, ret_mode) = match ret_typ_mode {
         None => (Arc::new(TypX::Tuple(Arc::new(vec![]))), mode),
@@ -275,7 +293,7 @@ pub(crate) fn check_foreign_item_fn<'tcx>(
         ParamX { name: Arc::new(RETURN_VALUE.to_string()), typ: ret_typ, mode: ret_mode };
     let ret = spanned_new(span, ret_param);
     let func = FunctionX {
-        path,
+        name,
         visibility,
         fuel,
         mode,

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -15,7 +15,7 @@ use std::io::Write;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use vir::ast::{Krate, VirErr, VirErrX, Visibility};
-use vir::ast_util::{is_visible_to, path_as_rust_name};
+use vir::ast_util::{fun_as_rust_dbg, is_visible_to};
 use vir::def::SnapPos;
 
 pub struct Verifier {
@@ -272,7 +272,7 @@ impl Verifier {
             self.run_commands(
                 air_context,
                 &commands,
-                &("Function-Decl ".to_string() + &path_as_rust_name(&function.x.path)),
+                &("Function-Decl ".to_string() + &fun_as_rust_dbg(&function.x.name)),
             );
         }
 
@@ -293,7 +293,7 @@ impl Verifier {
             self.run_commands(
                 air_context,
                 &decl_commands,
-                &("Function-Axioms ".to_string() + &path_as_rust_name(&function.x.path)),
+                &("Function-Axioms ".to_string() + &fun_as_rust_dbg(&function.x.name)),
             );
 
             // Check termination
@@ -306,7 +306,7 @@ impl Verifier {
                 &check_commands,
                 &HashMap::new(),
                 &vec![],
-                &("Function-Termination ".to_string() + &path_as_rust_name(&function.x.path)),
+                &("Function-Termination ".to_string() + &fun_as_rust_dbg(&function.x.name)),
             );
         }
 
@@ -322,7 +322,7 @@ impl Verifier {
                 &commands,
                 &HashMap::new(),
                 &snap_map,
-                &("Function-Def ".to_string() + &path_as_rust_name(&function.x.path)),
+                &("Function-Def ".to_string() + &fun_as_rust_dbg(&function.x.name)),
             );
         }
 
@@ -463,7 +463,7 @@ impl Verifier {
                 writeln!(&mut file).expect("cannot write to vir file");
             }
             for func in vir_crate.functions.iter() {
-                writeln!(&mut file, "fn {} @ {:?}", path_as_rust_name(&func.x.path), func.span)
+                writeln!(&mut file, "fn {} @ {:?}", fun_as_rust_dbg(&func.x.name), func.span)
                     .expect("cannot write to vir file");
                 writeln!(
                     &mut file,

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -444,6 +444,7 @@ impl Verifier {
             resolved_pats: vec![],
             condition_modes: vec![],
             external_functions: vec![],
+            ignored_functions: vec![],
         };
         let erasure_info = std::rc::Rc::new(std::cell::RefCell::new(erasure_info));
         let ctxt = Context { tcx, krate: hir.krate(), erasure_info };
@@ -506,6 +507,7 @@ impl Verifier {
         let resolved_exprs = erasure_info.resolved_exprs.clone();
         let resolved_pats = erasure_info.resolved_pats.clone();
         let external_functions = erasure_info.external_functions.clone();
+        let ignored_functions = erasure_info.ignored_functions.clone();
         let erasure_hints = crate::erase::ErasureHints {
             vir_crate,
             resolved_calls,
@@ -513,6 +515,7 @@ impl Verifier {
             resolved_pats,
             erasure_modes,
             external_functions,
+            ignored_functions,
         };
         self.erasure_hints = Some(erasure_hints);
 

--- a/source/rust_verify/tests/adts.rs
+++ b/source/rust_verify/tests/adts.rs
@@ -176,3 +176,15 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_one_fails(err)
 }
+
+test_verify_one_file! {
+    #[test] test_spec_adt_ctor code! {
+        #[spec]
+        struct SpecStruct { a: nat }
+
+        fn test() {
+            let s = SpecStruct { a: 12 }; // FAILS
+            assert(s.a == 12);
+        }
+    } => Err(_)
+}

--- a/source/rust_verify/tests/impl.rs
+++ b/source/rust_verify/tests/impl.rs
@@ -228,3 +228,15 @@ test_verify_one_file! {
         }
     } => Err(_)
 }
+
+test_verify_one_file! {
+    #[test] test_illegal_trait_impl_2 code! {
+        struct V {
+        }
+
+        impl std::ops::Index<usize> for V {
+            type Output = bool;
+            fn index(&self, #[spec]idx: usize) -> &bool { &true }
+        }
+    } => Err(_)
+}

--- a/source/rust_verify/tests/impl.rs
+++ b/source/rust_verify/tests/impl.rs
@@ -168,3 +168,63 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] test_ops_trait_impl code! {
+        #[derive(PartialEq, Eq)] #[spec]
+        struct V {
+            one: nat,
+            two: nat,
+        }
+
+        impl V {
+            #[spec]
+            fn get_one(self) -> nat {
+                self.one
+            }
+        }
+
+        impl std::ops::Index<int> for V {
+            type Output = nat;
+
+            #[spec]
+            fn index(&self, idx: int) -> &nat {
+                if idx == 0 {
+                    &self.one
+                } else if idx == 1 {
+                    &self.two
+                } else {
+                    arbitrary()
+                }
+            }
+        }
+
+        fn test(v: V) {
+            requires(v[0] == 3);
+
+            assert(v[0] + 1 == 4);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_illegal_trait_impl code! {
+        #[derive(PartialEq, Eq)]
+        struct V {
+            one: nat,
+        }
+
+        impl std::ops::Index<int> for V {
+            type Output = nat;
+
+            #[spec]
+            fn index(&self, idx: int) -> &nat {
+                if idx == 0 {
+                    &self.one
+                } else {
+                    arbitrary()
+                }
+            }
+        }
+    } => Err(_)
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -177,7 +177,7 @@ pub enum HeaderExprX {
     Decreases(Expr),
     /// Make a function f opaque (definition hidden) within the current function body.
     /// (The current function body can later reveal f in specific parts of the current function body if desired.)
-    Hide(Path),
+    Hide(Fun),
 }
 
 /// Primitive constant values
@@ -229,7 +229,7 @@ pub struct ArmX {
 #[derive(Clone, Debug)]
 pub enum CallTarget {
     /// Call a statically known function, passing some type arguments
-    Path(Path, Typs),
+    Static(Fun, Typs),
     /// Call a dynamically computed FnSpec (no type arguments allowed),
     /// where the function type is specified by the GenericBound of typ_param.
     /// Note: this is replaced by Path in ast_simplify.
@@ -278,7 +278,7 @@ pub enum ExprX {
     /// Assign to local variable
     Assign(Expr, Expr),
     /// Reveal definition of an opaque function with some integer fuel amount
-    Fuel(Path, u32),
+    Fuel(Fun, u32),
     /// Header, which must appear at the beginning of a function or while loop.
     /// Note: this only appears temporarily during rust_to_vir construction, and should not
     /// appear in the final Expr produced by rust_to_vir (see vir::headers::read_header).
@@ -335,7 +335,7 @@ pub type FunctionAttrs = Arc<FunctionAttrsX>;
 #[derive(Debug, Default, Clone)]
 pub struct FunctionAttrsX {
     /// List of functions that this function wants to view as opaque
-    pub hidden: Arc<Vec<Path>>,
+    pub hidden: Arc<Vec<Fun>>,
     /// Create a global axiom saying forall params, require ==> ensure
     pub export_as_global_forall: bool,
     /// In triggers_auto, don't use this function as a trigger
@@ -344,12 +344,24 @@ pub struct FunctionAttrsX {
     pub custom_req_err: Option<String>,
 }
 
+/// Static function identifier
+pub type Fun = Arc<FunX>;
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FunX {
+    /// Path of function
+    pub path: Path,
+    /// Path of the trait that defines the function, if any.
+    /// This disambiguates between impls for the same type of multiple traits that define functions
+    /// with the same name.
+    pub trait_path: Option<Path>,
+}
+
 /// Function, including signature and body
 pub type Function = Arc<Spanned<FunctionX>>;
 #[derive(Debug, Clone)]
 pub struct FunctionX {
     /// Name of function
-    pub path: Path,
+    pub name: Fun,
     /// Access control (public/private)
     pub visibility: Visibility,
     /// exec functions are compiled, proof/spec are erased

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1,5 +1,5 @@
 use crate::ast::{
-    BinaryOp, CallTarget, Constant, Expr, ExprX, Function, Ident, Mode, Params, Path, PatternX,
+    BinaryOp, CallTarget, Constant, Expr, ExprX, Fun, Function, Ident, Mode, Params, PatternX,
     SpannedTyped, Stmt, StmtX, Typ, TypX, Typs, UnaryOp, UnaryOpr, VirErr,
 };
 use crate::ast_util::{err_str, err_string};
@@ -139,14 +139,14 @@ fn init_var(span: &Span, x: &UniqueIdent, exp: &Exp) -> Stm {
     Spanned::new(span.clone(), StmX::Assign { lhs, rhs: exp.clone(), is_init: true })
 }
 
-fn get_function(ctx: &Ctx, expr: &Expr, name: &Path) -> Result<Function, VirErr> {
+fn get_function(ctx: &Ctx, expr: &Expr, name: &Fun) -> Result<Function, VirErr> {
     match ctx.func_map.get(name) {
         None => err_string(&expr.span, format!("could not find function {:?}", &name)),
         Some(func) => Ok(func.clone()),
     }
 }
 
-fn function_can_be_exp(ctx: &Ctx, expr: &Expr, path: &Path) -> Result<bool, VirErr> {
+fn function_can_be_exp(ctx: &Ctx, expr: &Expr, path: &Fun) -> Result<bool, VirErr> {
     match get_function(ctx, expr, path)?.x.mode {
         Mode::Spec => Ok(true),
         Mode::Proof | Mode::Exec => Ok(false),
@@ -157,12 +157,12 @@ fn expr_get_call(
     ctx: &Ctx,
     state: &mut State,
     expr: &Expr,
-) -> Result<Option<(Vec<Stm>, Path, Typs, bool, Args)>, VirErr> {
+) -> Result<Option<(Vec<Stm>, Fun, Typs, bool, Args)>, VirErr> {
     match &expr.x {
         ExprX::Call(CallTarget::FnSpec { .. }, _) => {
             panic!("internal error: FnSpec should have been replaced in ast_simplify")
         }
-        ExprX::Call(CallTarget::Path(x, typs), args) => {
+        ExprX::Call(CallTarget::Static(x, typs), args) => {
             let mut stms: Vec<Stm> = Vec::new();
             let mut exps: Vec<Arg> = Vec::new();
             for arg in args.iter() {
@@ -182,9 +182,9 @@ fn expr_must_be_call_stm(
     ctx: &Ctx,
     state: &mut State,
     expr: &Expr,
-) -> Result<Option<(Vec<Stm>, Path, Typs, bool, Args)>, VirErr> {
+) -> Result<Option<(Vec<Stm>, Fun, Typs, bool, Args)>, VirErr> {
     match &expr.x {
-        ExprX::Call(CallTarget::Path(x, _), _) if !function_can_be_exp(ctx, expr, x)? => {
+        ExprX::Call(CallTarget::Static(x, _), _) if !function_can_be_exp(ctx, expr, x)? => {
             expr_get_call(ctx, state, expr)
         }
         _ => Ok(None),
@@ -303,7 +303,7 @@ fn is_small_exp(exp: &Exp) -> bool {
 fn stm_call(
     state: &mut State,
     span: &Span,
-    path: Path,
+    name: Fun,
     typs: Typs,
     args: Args,
     dest: Option<Dest>,
@@ -322,7 +322,7 @@ fn stm_call(
             stms.push(init_var(&arg.0.span, &temp_id, &arg.0));
         }
     }
-    let call = StmX::Call(path, typs, Arc::new(small_args), dest);
+    let call = StmX::Call(name, typs, Arc::new(small_args), dest);
     stms.push(Spanned::new(span.clone(), call));
     stms_to_one_stm(span, stms)
 }

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -1,6 +1,6 @@
 use crate::ast::{
-    BinaryOp, Constant, DatatypeX, Expr, ExprX, FunctionX, Ident, Idents, Mode, Param, Params,
-    Path, PathX, SpannedTyped, Typ, TypX, Variant, Variants, VirErr, VirErrX, Visibility,
+    BinaryOp, Constant, DatatypeX, Expr, ExprX, Fun, FunX, FunctionX, Ident, Idents, Mode, Param,
+    Params, Path, PathX, SpannedTyped, Typ, TypX, Variant, Variants, VirErr, VirErrX, Visibility,
 };
 use crate::def::Spanned;
 use crate::util::vec_map;
@@ -64,6 +64,17 @@ pub fn path_as_rust_name(path: &Path) -> String {
         strings.push(segment.to_string());
     }
     strings.join("::")
+}
+
+pub fn fun_as_rust_dbg(fun: &Fun) -> String {
+    let FunX { path, trait_path } = &**fun;
+    let path_str = path_as_rust_name(path);
+    if let Some(trait_path) = trait_path {
+        let trait_path_str = path_as_rust_name(trait_path);
+        format!("{}<{}>", path_str, trait_path_str)
+    } else {
+        path_str
+    }
 }
 
 // Can source_module see an item owned by owning_module?

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -92,9 +92,9 @@ where
         ExprX::Var(x) => ExprX::Var(x.clone()),
         ExprX::Call(target, es) => {
             let target = match target {
-                CallTarget::Path(x, typs) => {
+                CallTarget::Static(x, typs) => {
                     let typs = vec_map_result(&**typs, |t| (map_typ_visitor_env(t, env, ft)))?;
-                    CallTarget::Path(x.clone(), Arc::new(typs))
+                    CallTarget::Static(x.clone(), Arc::new(typs))
                 }
                 CallTarget::FnSpec { typ_param, fun } => {
                     let fun = map_expr_visitor_env(fun, map, env, fe, fs, ft)?;
@@ -335,7 +335,7 @@ where
     FT: Fn(&mut E, &Typ) -> Result<Typ, VirErr>,
 {
     let FunctionX {
-        path,
+        name,
         visibility,
         mode,
         fuel,
@@ -349,7 +349,7 @@ where
         attrs,
         body,
     } = &function.x;
-    let path = path.clone();
+    let name = name.clone();
     let visibility = visibility.clone();
     let mode = *mode;
     let fuel = *fuel;
@@ -374,7 +374,7 @@ where
     let body = body.as_ref().map(|e| map_expr_visitor_env(e, map, env, fe, fs, ft)).transpose()?;
     map.pop_scope();
     let functionx = FunctionX {
-        path,
+        name,
         visibility,
         mode,
         fuel,

--- a/source/vir/src/context.rs
+++ b/source/vir/src/context.rs
@@ -1,10 +1,10 @@
 use crate::ast::{
-    Datatype, Function, GenericBound, IntRange, Krate, Mode, Path, TypX, Variants, VirErr,
+    Datatype, Fun, Function, GenericBound, IntRange, Krate, Mode, Path, TypX, Variants, VirErr,
 };
 use crate::datatype_to_air::is_datatype_transparent;
 use crate::def::FUEL_ID;
 use crate::scc::Graph;
-use crate::sst_to_air::path_to_air_ident;
+use crate::sst_to_air::fun_to_air_ident;
 use crate::util::vec_map;
 use air::ast::{Command, CommandX, Commands, DeclX, MultiOp, Span};
 use air::ast_util::str_typ;
@@ -15,7 +15,7 @@ use std::sync::Arc;
 pub struct GlobalCtx {
     pub(crate) chosen_triggers: std::cell::RefCell<Vec<(Span, Vec<Vec<String>>)>>, // diagnostics
     pub(crate) datatypes: HashMap<Path, Variants>,
-    pub(crate) fun_bounds: HashMap<Path, Vec<GenericBound>>,
+    pub(crate) fun_bounds: HashMap<Fun, Vec<GenericBound>>,
     // Used for synthesized AST nodes that have no relation to any location in the original code:
     pub(crate) no_span: Span,
 }
@@ -25,9 +25,9 @@ pub struct Ctx {
     pub(crate) module: Path,
     pub(crate) datatypes_with_invariant: HashSet<Path>,
     pub(crate) functions: Vec<Function>,
-    pub(crate) func_map: HashMap<Path, Function>,
-    pub(crate) func_call_graph: Graph<Path>,
-    pub(crate) funcs_with_ensure_predicate: HashSet<Path>,
+    pub(crate) func_map: HashMap<Fun, Function>,
+    pub(crate) func_call_graph: Graph<Fun>,
+    pub(crate) funcs_with_ensure_predicate: HashSet<Fun>,
     pub(crate) debug: bool,
     pub(crate) global: GlobalCtx,
 }
@@ -87,10 +87,10 @@ impl GlobalCtx {
             std::cell::RefCell::new(Vec::new());
         let datatypes: HashMap<Path, Variants> =
             krate.datatypes.iter().map(|d| (d.x.path.clone(), d.x.variants.clone())).collect();
-        let mut fun_bounds: HashMap<Path, Vec<GenericBound>> = HashMap::new();
+        let mut fun_bounds: HashMap<Fun, Vec<GenericBound>> = HashMap::new();
         for f in &krate.functions {
             let bounds = vec_map(&f.x.typ_bounds, |(_, bound)| bound.clone());
-            fun_bounds.insert(f.x.path.clone(), bounds);
+            fun_bounds.insert(f.x.name.clone(), bounds);
         }
         GlobalCtx { chosen_triggers, datatypes, fun_bounds, no_span }
     }
@@ -110,11 +110,11 @@ impl Ctx {
     ) -> Result<Self, VirErr> {
         let datatypes_with_invariant = datatypes_invs(&module, &krate.datatypes);
         let mut functions: Vec<Function> = Vec::new();
-        let mut func_map: HashMap<Path, Function> = HashMap::new();
-        let mut func_call_graph: Graph<Path> = Graph::new();
-        let funcs_with_ensure_predicate: HashSet<Path> = HashSet::new();
+        let mut func_map: HashMap<Fun, Function> = HashMap::new();
+        let mut func_call_graph: Graph<Fun> = Graph::new();
+        let funcs_with_ensure_predicate: HashSet<Fun> = HashSet::new();
         for function in krate.functions.iter() {
-            func_map.insert(function.x.path.clone(), function.clone());
+            func_map.insert(function.x.name.clone(), function.clone());
             crate::recursion::expand_call_graph(&mut func_call_graph, function)?;
             functions.push(function.clone());
         }
@@ -150,7 +150,7 @@ impl Ctx {
         for function in &self.functions {
             match (function.x.mode, function.x.body.as_ref()) {
                 (Mode::Spec, Some(_)) => {
-                    let id = crate::def::prefix_fuel_id(&path_to_air_ident(&function.x.path));
+                    let id = crate::def::prefix_fuel_id(&fun_to_air_ident(&function.x.name));
                     ids.push(air::ast_util::ident_var(&id));
                     let typ_fuel_id = str_typ(&FUEL_ID);
                     let decl = Arc::new(DeclX::Const(id, typ_fuel_id));

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -1,4 +1,4 @@
-use crate::ast::{Path, PathX};
+use crate::ast::{Fun, FunX, Path, PathX};
 use crate::sst::UniqueIdent;
 use air::ast::{Ident, Span};
 use air::ast_util::str_ident;
@@ -58,6 +58,8 @@ const PREFIX_CLOSURE: &str = "closure%";
 const PATH_SEPARATOR: &str = ".";
 const VARIANT_SEPARATOR: &str = "/";
 const VARIANT_FIELD_SEPARATOR: &str = "/";
+const FUN_TRAIT_DEF_BEGIN: &str = "<";
+const FUN_TRAIT_DEF_END: &str = ">";
 
 pub const SUFFIX_SNAP_MUT: &str = "_mutation";
 pub const SUFFIX_SNAP_JOIN: &str = "_join";
@@ -115,12 +117,31 @@ pub fn path_to_string(path: &Path) -> String {
     strings.join(crate::def::PATH_SEPARATOR) + crate::def::SUFFIX_PATH
 }
 
-pub fn check_decrease_int() -> Path {
-    Arc::new(PathX { krate: None, segments: Arc::new(vec![str_ident(CHECK_DECREASE_INT)]) })
+pub fn fun_to_string(fun: &Fun) -> String {
+    let FunX { path, trait_path } = &(**fun);
+    let s = path_to_string(path);
+    if let Some(trait_path) = trait_path {
+        s + FUN_TRAIT_DEF_BEGIN + &path_to_string(trait_path) + FUN_TRAIT_DEF_END
+    } else {
+        s
+    }
 }
 
-pub fn height() -> Path {
-    Arc::new(PathX { krate: None, segments: Arc::new(vec![str_ident(HEIGHT)]) })
+pub fn check_decrease_int() -> Fun {
+    Arc::new(FunX {
+        path: Arc::new(PathX {
+            krate: None,
+            segments: Arc::new(vec![str_ident(CHECK_DECREASE_INT)]),
+        }),
+        trait_path: None,
+    })
+}
+
+pub fn height() -> Fun {
+    Arc::new(FunX {
+        path: Arc::new(PathX { krate: None, segments: Arc::new(vec![str_ident(HEIGHT)]) }),
+        trait_path: None,
+    })
 }
 
 pub fn suffix_global_id(ident: &Ident) -> Ident {
@@ -239,8 +260,14 @@ fn prefix_path(prefix: String, path: &Path) -> Path {
     Arc::new(pathx)
 }
 
-pub fn prefix_recursive(path: &Path) -> Path {
+fn prefix_recursive(path: &Path) -> Path {
     prefix_path(PREFIX_RECURSIVE.to_string(), path)
+}
+
+pub fn prefix_recursive_fun(fun: &Fun) -> Fun {
+    let FunX { path, trait_path } = &(**fun);
+    let path = prefix_recursive(path);
+    Arc::new(FunX { path, trait_path: trait_path.clone() })
 }
 
 pub fn prefix_temp_var(n: u64) -> Ident {

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -1,12 +1,12 @@
 use crate::ast::{Function, GenericBoundX, Ident, Idents, Mode, ParamX, Params, Typ, TypX, VirErr};
 use crate::context::Ctx;
 use crate::def::{
-    prefix_ensures, prefix_fuel_id, prefix_fuel_nat, prefix_recursive, prefix_requires,
+    prefix_ensures, prefix_fuel_id, prefix_fuel_nat, prefix_recursive_fun, prefix_requires,
     suffix_global_id, suffix_local_stmt_id, suffix_typ_param_id, SnapPos, Spanned, FUEL_BOOL,
     FUEL_BOOL_DEFAULT, FUEL_LOCAL, FUEL_TYPE, SUCC, ZERO,
 };
 use crate::sst::{BndX, ExpX};
-use crate::sst_to_air::{exp_to_expr, path_to_air_ident, typ_invariant, typ_to_air};
+use crate::sst_to_air::{exp_to_expr, fun_to_air_ident, typ_invariant, typ_to_air};
 use crate::util::{vec_map, vec_map_result};
 use air::ast::{
     BinaryOp, Bind, BindX, Binder, BinderX, Command, CommandX, Commands, DeclX, Expr, ExprX,
@@ -88,7 +88,7 @@ fn func_body_to_air(
     function: &Function,
     body: &crate::ast::Expr,
 ) -> Result<(), VirErr> {
-    let id_fuel = prefix_fuel_id(&path_to_air_ident(&function.x.path));
+    let id_fuel = prefix_fuel_id(&fun_to_air_ident(&function.x.name));
 
     // ast --> sst
     let (local_decls, closure_bodies, closure_axioms, body_exp) =
@@ -128,8 +128,8 @@ fn func_body_to_air(
     let def_body = if !is_recursive {
         body_expr
     } else {
-        let rec_f = suffix_global_id(&path_to_air_ident(&prefix_recursive(&function.x.path)));
-        let fuel_nat_f = prefix_fuel_nat(&path_to_air_ident(&function.x.path));
+        let rec_f = suffix_global_id(&fun_to_air_ident(&prefix_recursive_fun(&function.x.name)));
+        let fuel_nat_f = prefix_fuel_nat(&fun_to_air_ident(&function.x.name));
         let args = func_def_args(&function.x.typ_params(), &function.x.params);
         let mut args_zero = args.clone();
         let mut args_fuel = args.clone();
@@ -161,7 +161,7 @@ fn func_body_to_air(
     };
     let e_forall = func_def_quant(
         ctx,
-        &suffix_global_id(&path_to_air_ident(&function.x.path)),
+        &suffix_global_id(&fun_to_air_ident(&function.x.name)),
         &function.x.typ_params(),
         &function.x.params,
         def_body,
@@ -229,16 +229,16 @@ pub fn func_name_to_air(ctx: &Ctx, function: &Function) -> Result<Commands, VirE
     if function.x.mode == Mode::Spec {
         // Declare the function symbol itself
         let typ = typ_to_air(ctx, &function.x.ret.x.typ);
-        let name = suffix_global_id(&path_to_air_ident(&function.x.path));
+        let name = suffix_global_id(&fun_to_air_ident(&function.x.name));
         let decl = Arc::new(DeclX::Fun(name, Arc::new(all_typs), typ.clone()));
         commands.push(Arc::new(CommandX::Global(decl)));
 
         // Check whether we need to declare the recursive version too
         if let Some(body) = &function.x.body {
             let body_exp = crate::ast_to_sst::expr_to_exp(&ctx, &function.x.params, &body)?;
-            if crate::recursion::is_recursive_exp(ctx, &function.x.path, &body_exp) {
+            if crate::recursion::is_recursive_exp(ctx, &function.x.name, &body_exp) {
                 let rec_f =
-                    suffix_global_id(&path_to_air_ident(&prefix_recursive(&function.x.path)));
+                    suffix_global_id(&fun_to_air_ident(&prefix_recursive_fun(&function.x.name)));
                 let mut rec_typs =
                     vec_map(&*function.x.params, |param| typ_to_air(ctx, &param.x.typ));
                 for _ in function.x.typ_bounds.iter() {
@@ -267,7 +267,7 @@ pub fn func_decl_to_air(
     let mut check_commands: Vec<Command> = Vec::new();
     match function.x.mode {
         Mode::Spec => {
-            let name = suffix_global_id(&path_to_air_ident(&function.x.path));
+            let name = suffix_global_id(&fun_to_air_ident(&function.x.name));
 
             // Body
             if public_body {
@@ -315,7 +315,7 @@ pub fn func_decl_to_air(
                 &function.x.require,
                 &function.x.typ_params(),
                 &param_typs,
-                &prefix_requires(&path_to_air_ident(&function.x.path)),
+                &prefix_requires(&fun_to_air_ident(&function.x.name)),
                 &msg,
             )?;
             let mut ens_typs = (*param_typs).clone();
@@ -339,11 +339,11 @@ pub fn func_decl_to_air(
                 &function.x.ensure,
                 &function.x.typ_params(),
                 &Arc::new(ens_typs),
-                &prefix_ensures(&path_to_air_ident(&function.x.path)),
+                &prefix_ensures(&fun_to_air_ident(&function.x.name)),
                 &None,
             )?;
             if has_ens_pred {
-                ctx.funcs_with_ensure_predicate.insert(function.x.path.clone());
+                ctx.funcs_with_ensure_predicate.insert(function.x.name.clone());
             }
             if function.x.attrs.export_as_global_forall {
                 let span = &function.span;

--- a/source/vir/src/headers.rs
+++ b/source/vir/src/headers.rs
@@ -1,10 +1,10 @@
-use crate::ast::{Expr, ExprX, Exprs, HeaderExprX, Ident, Path, Stmt, StmtX, Typ, VirErr};
+use crate::ast::{Expr, ExprX, Exprs, Fun, HeaderExprX, Ident, Stmt, StmtX, Typ, VirErr};
 use crate::ast_util::err_str;
 use std::sync::Arc;
 
 #[derive(Clone, Debug)]
 pub struct Header {
-    pub hidden: Vec<Path>,
+    pub hidden: Vec<Fun>,
     pub require: Exprs,
     pub ensure_id_typ: Option<(Ident, Typ)>,
     pub ensure: Exprs,
@@ -13,7 +13,7 @@ pub struct Header {
 }
 
 fn read_header_block(block: &mut Vec<Stmt>) -> Result<Header, VirErr> {
-    let mut hidden: Vec<Path> = Vec::new();
+    let mut hidden: Vec<Fun> = Vec::new();
     let mut require: Option<Exprs> = None;
     let mut ensure: Option<(Option<(Ident, Typ)>, Exprs)> = None;
     let mut invariant: Option<Exprs> = None;

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -1,5 +1,5 @@
 use crate::ast::{
-    BinaryOp, CallTarget, Datatype, Expr, ExprX, Function, Ident, Krate, Mode, Path, Pattern,
+    BinaryOp, CallTarget, Datatype, Expr, ExprX, Fun, Function, Ident, Krate, Mode, Path, Pattern,
     PatternX, Stmt, StmtX, UnaryOpr, VirErr,
 };
 use crate::ast_util::{err_str, err_string, get_field};
@@ -38,7 +38,7 @@ pub struct ErasureModes {
 }
 
 struct Typing {
-    pub(crate) funs: HashMap<Path, Function>,
+    pub(crate) funs: HashMap<Fun, Function>,
     pub(crate) datatypes: HashMap<Path, Datatype>,
     pub(crate) vars: ScopeMap<Ident, Mode>,
     pub(crate) erasure_modes: ErasureModes,
@@ -113,10 +113,10 @@ fn check_expr(typing: &mut Typing, outer_mode: Mode, expr: &Expr) -> Result<Mode
             typing.erasure_modes.var_modes.push((expr.span.clone(), mode));
             Ok(mode)
         }
-        ExprX::Call(CallTarget::Path(x, _), es) => {
+        ExprX::Call(CallTarget::Static(x, _), es) => {
             let function = match typing.funs.get(x) {
                 None => {
-                    let name = crate::ast_util::path_as_rust_name(x);
+                    let name = crate::ast_util::path_as_rust_name(&x.path);
                     return err_string(&expr.span, format!("cannot find function {}", name));
                 }
                 Some(f) => f.clone(),
@@ -361,10 +361,10 @@ fn check_function(typing: &mut Typing, function: &Function) -> Result<(), VirErr
 }
 
 pub fn check_crate(krate: &Krate) -> Result<ErasureModes, VirErr> {
-    let mut funs: HashMap<Path, Function> = HashMap::new();
+    let mut funs: HashMap<Fun, Function> = HashMap::new();
     let mut datatypes: HashMap<Path, Datatype> = HashMap::new();
     for function in krate.functions.iter() {
-        funs.insert(function.x.path.clone(), function.clone());
+        funs.insert(function.x.name.clone(), function.clone());
     }
     for datatype in krate.datatypes.iter() {
         datatypes.insert(datatype.x.path.clone(), datatype.clone());

--- a/source/vir/src/prelude.rs
+++ b/source/vir/src/prelude.rs
@@ -1,6 +1,6 @@
 use crate::ast::Path;
 use crate::def::*;
-use crate::sst_to_air::path_to_air_ident;
+use crate::sst_to_air::{fun_to_air_ident, path_to_air_ident};
 use air::ast::Ident;
 use air::printer::{macro_push_node, str_to_node};
 use air::{node, nodes_vec};
@@ -26,8 +26,8 @@ pub(crate) fn prelude_nodes() -> Vec<Node> {
     let i_inv = str_to_node(I_INV);
     let arch_size = str_to_node(ARCH_SIZE);
     let check_decrease_int =
-        str_to_node(&suffix_global_id(&path_to_air_ident(&check_decrease_int())));
-    let height = str_to_node(&suffix_global_id(&path_to_air_ident(&height())));
+        str_to_node(&suffix_global_id(&fun_to_air_ident(&check_decrease_int())));
+    let height = str_to_node(&suffix_global_id(&fun_to_air_ident(&height())));
     #[allow(non_snake_case)]
     let Poly = str_to_node(POLY);
     let box_int = str_to_node(BOX_INT);
@@ -247,7 +247,7 @@ pub(crate) fn prelude_nodes() -> Vec<Node> {
 }
 
 pub(crate) fn datatype_height_axiom(typ_name1: &Path, typ_name2: &Path, field: &Ident) -> Node {
-    let height = str_to_node(&suffix_global_id(&path_to_air_ident(&height())));
+    let height = str_to_node(&suffix_global_id(&fun_to_air_ident(&height())));
     let field = str_to_node(field.as_str());
     let typ1 = str_to_node(path_to_air_ident(typ_name1).as_str());
     let box_t1 = str_to_node(prefix_box(typ_name1).as_str());

--- a/source/vir/src/prune.rs
+++ b/source/vir/src/prune.rs
@@ -3,8 +3,8 @@
 /// 2) Also remove any export_as_global_forall from any modules that are unreachable
 ///    from this module.  This could, in principle, result in incompleteness.
 use crate::ast::{
-    CallTarget, Datatype, Expr, ExprX, Function, Ident, Krate, KrateX, Mode, Path, Stmt, Typ, TypX,
-    Visibility,
+    CallTarget, Datatype, Expr, ExprX, Fun, Function, Ident, Krate, KrateX, Mode, Path, Stmt, Typ,
+    TypX, Visibility,
 };
 use crate::ast_util::is_visible_to;
 use crate::ast_visitor::map_expr_visitor;
@@ -15,32 +15,36 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 struct Ctxt {
-    function_map: HashMap<Path, Function>,
+    function_map: HashMap<Fun, Function>,
     datatype_map: HashMap<Path, Datatype>,
-    all_functions_in_each_module: HashMap<Path, Vec<Path>>,
+    all_functions_in_each_module: HashMap<Path, Vec<Fun>>,
 }
 
 #[derive(Default)]
 struct State {
-    reached_functions: HashSet<Path>,
+    reached_functions: HashSet<Fun>,
     reached_datatypes: HashSet<Path>,
     reached_modules: HashSet<Path>,
-    worklist_functions: Vec<Path>,
+    worklist_functions: Vec<Fun>,
     worklist_datatypes: Vec<Path>,
     worklist_modules: Vec<Path>,
 }
 
-fn reach(reached: &mut HashSet<Path>, worklist: &mut Vec<Path>, path: &Path) {
-    if !reached.contains(path) {
-        reached.insert(path.clone());
-        worklist.push(path.clone());
+fn reach<A: std::hash::Hash + std::cmp::Eq + Clone>(
+    reached: &mut HashSet<A>,
+    worklist: &mut Vec<A>,
+    id: &A,
+) {
+    if !reached.contains(id) {
+        reached.insert(id.clone());
+        worklist.push(id.clone());
     }
 }
 
-fn reach_function(ctxt: &Ctxt, state: &mut State, path: &Path) {
-    if ctxt.function_map.contains_key(path) {
-        reach(&mut state.reached_functions, &mut state.worklist_functions, path);
-        let module_path = path.pop_segment();
+fn reach_function(ctxt: &Ctxt, state: &mut State, name: &Fun) {
+    if ctxt.function_map.contains_key(name) {
+        reach(&mut state.reached_functions, &mut state.worklist_functions, name);
+        let module_path = name.path.pop_segment();
         reach(&mut state.reached_modules, &mut state.worklist_modules, &module_path);
     }
 }
@@ -66,7 +70,9 @@ fn traverse_reachable(ctxt: &Ctxt, state: &mut State) {
             let function = &ctxt.function_map[&f];
             let fe = |state: &mut State, _: &mut ScopeMap<Ident, Typ>, e: &Expr| {
                 match &e.x {
-                    ExprX::Call(CallTarget::Path(path, _), _) => reach_function(ctxt, state, path),
+                    ExprX::Call(CallTarget::Static(name, _), _) => {
+                        reach_function(ctxt, state, name)
+                    }
                     ExprX::Ctor(path, _, _, _) => reach_datatype(ctxt, state, path),
                     _ => {}
                 }
@@ -105,7 +111,7 @@ pub fn prune_krate_for_module(krate: &Krate, module: &Path) -> Krate {
     state.worklist_modules.push(module.clone());
 
     // Collect all functions that our module reveals:
-    let mut revealed_functions: HashSet<Path> = HashSet::new();
+    let mut revealed_functions: HashSet<Fun> = HashSet::new();
     for f in &krate.functions {
         match (&f.x.visibility.owning_module, &f.x.body) {
             (Some(path), Some(body)) if path == module => {
@@ -133,8 +139,8 @@ pub fn prune_krate_for_module(krate: &Krate, module: &Path) -> Krate {
             Some(path) if path == module => {
                 // our function
                 functions.push(f.clone());
-                state.reached_functions.insert(f.x.path.clone());
-                state.worklist_functions.push(f.x.path.clone());
+                state.reached_functions.insert(f.x.name.clone());
+                state.worklist_functions.push(f.x.name.clone());
                 continue;
             }
             _ => {}
@@ -147,7 +153,7 @@ pub fn prune_krate_for_module(krate: &Krate, module: &Path) -> Krate {
         let vis = f.x.visibility.clone();
         let vis = Visibility { is_private: vis.is_private || f.x.is_abstract, ..vis };
         let is_vis = is_visible_to(&vis, module);
-        let is_revealed = f.x.fuel > 0 || revealed_functions.contains(&f.x.path);
+        let is_revealed = f.x.fuel > 0 || revealed_functions.contains(&f.x.name);
         let is_spec = f.x.mode == Mode::Spec;
         if is_vis && is_revealed && is_spec {
             functions.push(f.clone());
@@ -181,16 +187,16 @@ pub fn prune_krate_for_module(krate: &Krate, module: &Path) -> Krate {
         }
     }
 
-    let mut function_map: HashMap<Path, Function> = HashMap::new();
+    let mut function_map: HashMap<Fun, Function> = HashMap::new();
     let mut datatype_map: HashMap<Path, Datatype> = HashMap::new();
-    let mut all_functions_in_each_module: HashMap<Path, Vec<Path>> = HashMap::new();
+    let mut all_functions_in_each_module: HashMap<Path, Vec<Fun>> = HashMap::new();
     for f in &functions {
-        function_map.insert(f.x.path.clone(), f.clone());
-        let module = f.x.path.pop_segment();
+        function_map.insert(f.x.name.clone(), f.clone());
+        let module = f.x.name.path.pop_segment();
         if !all_functions_in_each_module.contains_key(&module) {
             all_functions_in_each_module.insert(module.clone(), Vec::new());
         }
-        all_functions_in_each_module.get_mut(&module).unwrap().push(f.x.path.clone());
+        all_functions_in_each_module.get_mut(&module).unwrap().push(f.x.name.clone());
     }
     for d in &datatypes {
         datatype_map.insert(d.x.path.clone(), d.clone());
@@ -201,7 +207,7 @@ pub fn prune_krate_for_module(krate: &Krate, module: &Path) -> Krate {
     let kratex = KrateX {
         functions: functions
             .into_iter()
-            .filter(|f| state.reached_functions.contains(&f.x.path))
+            .filter(|f| state.reached_functions.contains(&f.x.name))
             .collect(),
         datatypes: datatypes
             .into_iter()

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -1,12 +1,12 @@
 use crate::ast::{
-    BinaryOp, CallTarget, Constant, Function, Ident, IntRange, Params, Path, Typ, TypX, UnaryOp,
+    BinaryOp, CallTarget, Constant, Fun, Function, Ident, IntRange, Params, Typ, TypX, UnaryOp,
     UnaryOpr, VirErr,
 };
 use crate::ast_util::err_str;
 use crate::ast_visitor::map_expr_visitor;
 use crate::context::Ctx;
 use crate::def::{
-    check_decrease_int, height, prefix_recursive, suffix_rename, Spanned, DECREASE_AT_ENTRY,
+    check_decrease_int, height, prefix_recursive_fun, suffix_rename, Spanned, DECREASE_AT_ENTRY,
     FUEL_PARAM,
 };
 use crate::scc::Graph;
@@ -21,12 +21,12 @@ use std::sync::Arc;
 
 #[derive(Clone)]
 struct Ctxt<'a> {
-    recursive_function_path: Path,
+    recursive_function_name: Fun,
     params: Params,
     decreases_at_entry: Ident,
     decreases_exp: Exp,
     decreases_typ: Typ,
-    scc_rep: Path,
+    scc_rep: Fun,
     ctx: &'a Ctx,
 }
 
@@ -74,7 +74,7 @@ fn check_decrease_rename(ctxt: &Ctxt, span: &Span, args: &Exps) -> Exp {
     check_decrease(ctxt, &e_dec)
 }
 
-fn update_decreases_exp<'a>(ctxt: &'a Ctxt, name: &Path) -> Result<Ctxt<'a>, VirErr> {
+fn update_decreases_exp<'a>(ctxt: &'a Ctxt, name: &Fun) -> Result<Ctxt<'a>, VirErr> {
     let function = ctxt.ctx.func_map.get(name).expect("func_map should hold all functions");
     let new_decreases_expr = function
         .x
@@ -94,7 +94,7 @@ fn terminates(ctxt: &Ctxt, exp: &Exp) -> Result<Exp, VirErr> {
             Ok(Spanned::new(exp.span.clone(), ExpX::Const(Constant::Bool(true))))
         }
         ExpX::Call(x, _, args) => {
-            let mut e = if *x == ctxt.recursive_function_path
+            let mut e = if *x == ctxt.recursive_function_name
                 || ctxt.ctx.func_call_graph.get_scc_rep(x) == ctxt.scc_rep
             {
                 let new_ctxt = update_decreases_exp(&ctxt, x)?;
@@ -179,7 +179,7 @@ fn terminates(ctxt: &Ctxt, exp: &Exp) -> Result<Exp, VirErr> {
     }
 }
 
-pub(crate) fn is_recursive_exp(ctx: &Ctx, name: &Path, body: &Exp) -> bool {
+pub(crate) fn is_recursive_exp(ctx: &Ctx, name: &Fun, body: &Exp) -> bool {
     if ctx.func_call_graph.get_scc_size(name) > 1 {
         // This function is part of a mutually recursive component
         true
@@ -197,7 +197,7 @@ pub(crate) fn is_recursive_exp(ctx: &Ctx, name: &Path, body: &Exp) -> bool {
     }
 }
 
-pub(crate) fn is_recursive_stm(ctx: &Ctx, name: &Path, body: &Stm) -> bool {
+pub(crate) fn is_recursive_stm(ctx: &Ctx, name: &Fun, body: &Stm) -> bool {
     if ctx.func_call_graph.get_scc_size(name) > 1 {
         // This function is part of a mutually recursive component
         true
@@ -240,11 +240,11 @@ pub(crate) fn disallow_recursion_exp(
     function: &Function,
     exp: &Exp,
 ) -> Result<(), VirErr> {
-    let scc_rep = ctx.func_call_graph.get_scc_rep(&function.x.path);
+    let scc_rep = ctx.func_call_graph.get_scc_rep(&function.x.name);
     let _ = map_exp_visitor_result(exp, &mut |exp| {
         match &exp.x {
             ExpX::Call(x, _, _) => {
-                if *x == function.x.path || ctx.func_call_graph.get_scc_rep(x) == scc_rep {
+                if *x == function.x.name || ctx.func_call_graph.get_scc_rep(x) == scc_rep {
                     return err_str(&exp.span, "recursion not allowed here");
                 }
             }
@@ -261,7 +261,7 @@ pub(crate) fn check_termination_exp(
     mut local_decls: Vec<LocalDecl>,
     body: &Exp,
 ) -> Result<(bool, Commands, Exp), VirErr> {
-    if !is_recursive_exp(ctx, &function.x.path, body) {
+    if !is_recursive_exp(ctx, &function.x.name, body) {
         return Ok((false, Arc::new(vec![]), body.clone()));
     }
 
@@ -274,10 +274,10 @@ pub(crate) fn check_termination_exp(
     let decreases_typ = decreases_expr.typ.clone();
     let decreases_exp = crate::ast_to_sst::expr_to_exp(ctx, &function.x.params, &decreases_expr)?;
     let decreases_at_entry = str_ident(DECREASE_AT_ENTRY);
-    let scc_rep = ctx.func_call_graph.get_scc_rep(&function.x.path);
+    let scc_rep = ctx.func_call_graph.get_scc_rep(&function.x.name);
     let scc_rep_clone = scc_rep.clone();
     let ctxt = Ctxt {
-        recursive_function_path: function.x.path.clone(),
+        recursive_function_name: function.x.name.clone(),
         params: function.x.params.clone(),
         decreases_at_entry,
         decreases_exp,
@@ -310,11 +310,11 @@ pub(crate) fn check_termination_exp(
     // New body: substitute rec%f(args, fuel) for f(args)
     let body = map_exp_visitor(&body, &mut |exp| match &exp.x {
         ExpX::Call(x, typs, args)
-            if *x == function.x.path || ctx.func_call_graph.get_scc_rep(x) == scc_rep_clone =>
+            if *x == function.x.name || ctx.func_call_graph.get_scc_rep(x) == scc_rep_clone =>
         {
             let mut args = (**args).clone();
             args.push(Spanned::new(exp.span.clone(), ExpX::Var((str_ident(FUEL_PARAM), Some(0)))));
-            let rec_name = prefix_recursive(&x);
+            let rec_name = prefix_recursive_fun(&x);
             Spanned::new(exp.span.clone(), ExpX::Call(rec_name, typs.clone(), Arc::new(args)))
         }
         _ => exp.clone(),
@@ -328,7 +328,7 @@ pub(crate) fn check_termination_stm(
     function: &Function,
     body: &Stm,
 ) -> Result<(Vec<LocalDecl>, Stm), VirErr> {
-    if !is_recursive_stm(ctx, &function.x.path, body) {
+    if !is_recursive_stm(ctx, &function.x.name, body) {
         return Ok((vec![], body.clone()));
     }
 
@@ -341,9 +341,9 @@ pub(crate) fn check_termination_stm(
     let decreases_typ = decreases_expr.typ.clone();
     let decreases_exp = crate::ast_to_sst::expr_to_exp(ctx, &function.x.params, &decreases_expr)?;
     let decreases_at_entry = str_ident(DECREASE_AT_ENTRY);
-    let scc_rep = ctx.func_call_graph.get_scc_rep(&function.x.path);
+    let scc_rep = ctx.func_call_graph.get_scc_rep(&function.x.name);
     let ctxt = Ctxt {
-        recursive_function_path: function.x.path.clone(),
+        recursive_function_name: function.x.name.clone(),
         params: function.x.params.clone(),
         decreases_at_entry,
         decreases_exp,
@@ -353,7 +353,7 @@ pub(crate) fn check_termination_stm(
     };
     let stm = map_stm_visitor(body, &mut |s| match &s.x {
         StmX::Call(x, _, args, _)
-            if *x == function.x.path || ctx.func_call_graph.get_scc_rep(x) == ctxt.scc_rep =>
+            if *x == function.x.name || ctx.func_call_graph.get_scc_rep(x) == ctxt.scc_rep =>
         {
             let new_ctxt = update_decreases_exp(&ctxt, x)?;
             let check = check_decrease_rename(&new_ctxt, &s.span, &args);
@@ -375,14 +375,14 @@ pub(crate) fn check_termination_stm(
 }
 
 fn add_call_graph_edges(
-    call_graph: &mut Graph<Path>,
-    src: &Path,
+    call_graph: &mut Graph<Fun>,
+    src: &Fun,
     expr: &crate::ast::Expr,
 ) -> Result<crate::ast::Expr, VirErr> {
     use crate::ast::ExprX;
 
     match &expr.x {
-        ExprX::Call(CallTarget::Path(x, _), _) | ExprX::Fuel(x, _) => {
+        ExprX::Call(CallTarget::Static(x, _), _) | ExprX::Fuel(x, _) => {
             call_graph.add_edge(src.clone(), x.clone())
         }
         _ => {}
@@ -391,13 +391,13 @@ fn add_call_graph_edges(
 }
 
 pub(crate) fn expand_call_graph(
-    call_graph: &mut Graph<Path>,
+    call_graph: &mut Graph<Fun>,
     function: &Function,
 ) -> Result<(), VirErr> {
     // We only traverse expressions (not statements), since calls only appear in the former (see ast.rs)
     if let Some(body) = &function.x.body {
         map_expr_visitor(body, &mut |expr| {
-            add_call_graph_edges(call_graph, &function.x.path, expr)
+            add_call_graph_edges(call_graph, &function.x.name, expr)
         })?;
     }
     Ok(())

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -6,7 +6,7 @@
 //! SST expressions cannot contain statments.
 //! SST is designed to make the translation to AIR as straightforward as possible.
 
-use crate::ast::{BinaryOp, Constant, Path, Typ, Typs, UnaryOp, UnaryOpr};
+use crate::ast::{BinaryOp, Constant, Fun, Path, Typ, Typs, UnaryOp, UnaryOpr};
 use crate::def::Spanned;
 use air::ast::{Binders, Ident, Quant};
 use std::sync::Arc;
@@ -33,7 +33,7 @@ pub enum ExpX {
     // used only during sst_to_air to generate AIR Old
     Old(Ident, Ident),
     // call to spec function
-    Call(Path, Typs, Exps),
+    Call(Fun, Typs, Exps),
     Ctor(Path, Ident, Binders<Exp>),
     Unary(UnaryOp, Exp),
     UnaryOpr(UnaryOpr, Exp),
@@ -52,7 +52,7 @@ pub type Stm = Arc<Spanned<StmX>>;
 pub type Stms = Arc<Vec<Stm>>;
 #[derive(Debug)]
 pub enum StmX {
-    Call(Path, Typs, Exps, Option<Dest>), // call to exec/proof function
+    Call(Fun, Typs, Exps, Option<Dest>), // call to exec/proof function
     Assert(Exp),
     Assume(Exp),
     Assign {
@@ -60,7 +60,7 @@ pub enum StmX {
         rhs: Exp,
         is_init: bool,
     },
-    Fuel(Path, u32),
+    Fuel(Fun, u32),
     DeadEnd(Stm),
     If(Exp, Stm, Option<Stm>),
     While {

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1,14 +1,14 @@
 use crate::ast::{
-    BinaryOp, Ident, Idents, IntRange, Mode, Params, Path, Typ, TypX, Typs, UnaryOp, UnaryOpr,
+    BinaryOp, Fun, Ident, Idents, IntRange, Mode, Params, Path, Typ, TypX, Typs, UnaryOp, UnaryOpr,
 };
 use crate::ast_util::{get_field, get_variant};
 use crate::context::Ctx;
 use crate::def::{
-    path_to_string, prefix_box, prefix_ensures, prefix_fuel_id, prefix_requires, suffix_global_id,
-    suffix_local_expr_id, suffix_local_stmt_id, suffix_local_unique_id, suffix_typ_param_id,
-    variant_field_ident, variant_ident, SnapPos, SpanKind, Spanned, FUEL_BOOL, FUEL_BOOL_DEFAULT,
-    FUEL_DEFAULTS, FUEL_ID, FUEL_PARAM, FUEL_TYPE, POLY, SNAPSHOT_CALL, SUCC, SUFFIX_SNAP_JOIN,
-    SUFFIX_SNAP_MUT, SUFFIX_SNAP_WHILE_BEGIN, SUFFIX_SNAP_WHILE_END,
+    fun_to_string, path_to_string, prefix_box, prefix_ensures, prefix_fuel_id, prefix_requires,
+    suffix_global_id, suffix_local_expr_id, suffix_local_stmt_id, suffix_local_unique_id,
+    suffix_typ_param_id, variant_field_ident, variant_ident, SnapPos, SpanKind, Spanned, FUEL_BOOL,
+    FUEL_BOOL_DEFAULT, FUEL_DEFAULTS, FUEL_ID, FUEL_PARAM, FUEL_TYPE, POLY, SNAPSHOT_CALL, SUCC,
+    SUFFIX_SNAP_JOIN, SUFFIX_SNAP_MUT, SUFFIX_SNAP_WHILE_BEGIN, SUFFIX_SNAP_WHILE_END,
 };
 use crate::sst::{BndX, Dest, Exp, ExpX, LocalDecl, Stm, StmX, UniqueIdent};
 use crate::sst_vars::AssignMap;
@@ -24,6 +24,11 @@ use air::ast_util::{
 };
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+
+#[inline(always)]
+pub(crate) fn fun_to_air_ident(fun: &Fun) -> Ident {
+    Arc::new(fun_to_string(fun))
+}
 
 #[inline(always)]
 pub(crate) fn path_to_air_ident(path: &Path) -> Ident {
@@ -151,7 +156,7 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp) -> Expr {
         ExpX::Var(x) => string_var(&suffix_local_unique_id(x)),
         ExpX::Old(span, x) => Arc::new(ExprX::Old(span.clone(), suffix_local_stmt_id(x))),
         ExpX::Call(x, typs, args) => {
-            let name = suffix_global_id(&path_to_air_ident(&x));
+            let name = suffix_global_id(&fun_to_air_ident(&x));
             let mut exprs: Vec<Expr> = vec_map(typs, typ_to_id);
             for arg in args.iter() {
                 exprs.push(exp_to_expr(ctx, arg));
@@ -397,7 +402,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
             let mut stmts: Vec<Stmt> = Vec::new();
             let func = &ctx.func_map[x];
             if func.x.require.len() > 0 {
-                let f_req = prefix_requires(&path_to_air_ident(&func.x.path));
+                let f_req = prefix_requires(&fun_to_air_ident(&func.x.name));
                 let mut req_args = vec_map(typs, typ_to_id);
                 for arg in args.iter() {
                     req_args.push(exp_to_expr(ctx, arg));
@@ -455,8 +460,8 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
                     }
                 }
             }
-            if ctx.funcs_with_ensure_predicate.contains(&func.x.path) {
-                let f_ens = prefix_ensures(&path_to_air_ident(&func.x.path));
+            if ctx.funcs_with_ensure_predicate.contains(&func.x.name) {
+                let f_ens = prefix_ensures(&fun_to_air_ident(&func.x.name));
                 let e_ens = Arc::new(ExprX::Apply(f_ens, Arc::new(ens_args)));
                 stmts.push(Arc::new(StmtX::Assume(e_ens)));
             }
@@ -629,7 +634,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
             let mut stmts: Vec<Stmt> = Vec::new();
             if *fuel >= 1 {
                 // (assume (fuel_bool fuel%f))
-                let id_fuel = prefix_fuel_id(&path_to_air_ident(&x));
+                let id_fuel = prefix_fuel_id(&fun_to_air_ident(&x));
                 let expr_fuel_bool = str_apply(&FUEL_BOOL, &vec![ident_var(&id_fuel)]);
                 stmts.push(Arc::new(StmtX::Assume(expr_fuel_bool)));
             }
@@ -640,7 +645,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
                     added_fuel = str_apply(SUCC, &vec![added_fuel]);
                 }
                 let eq = mk_eq(
-                    &ident_var(&crate::def::prefix_fuel_nat(&path_to_air_ident(&x))),
+                    &ident_var(&crate::def::prefix_fuel_nat(&fun_to_air_ident(&x))),
                     &added_fuel,
                 );
                 let binder = ident_binder(&str_ident(FUEL_PARAM), &str_typ(FUEL_TYPE));
@@ -665,7 +670,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
     }
 }
 
-fn set_fuel(local: &mut Vec<Decl>, hidden: &Vec<Path>) {
+fn set_fuel(local: &mut Vec<Decl>, hidden: &Vec<Fun>) {
     let fuel_expr = if hidden.len() == 0 {
         str_var(&FUEL_DEFAULTS)
     } else {
@@ -681,7 +686,7 @@ fn set_fuel(local: &mut Vec<Decl>, hidden: &Vec<Path>) {
 
         // ... || id == hidden1 || id == hidden2 || ...
         for hide in hidden {
-            let x_hide = ident_var(&prefix_fuel_id(&path_to_air_ident(hide)));
+            let x_hide = ident_var(&prefix_fuel_id(&fun_to_air_ident(hide)));
             disjuncts.push(Arc::new(ExprX::Binary(air::ast::BinaryOp::Eq, x_id.clone(), x_hide)));
         }
 
@@ -701,7 +706,7 @@ pub fn body_stm_to_air(
     typ_params: &Idents,
     params: &Params,
     local_decls: &Vec<LocalDecl>,
-    hidden: &Vec<Path>,
+    hidden: &Vec<Fun>,
     reqs: &Vec<Exp>,
     enss: &Vec<Exp>,
     stm: &Stm,

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -1,4 +1,4 @@
-use crate::ast::{BinaryOp, Constant, Ident, Path, Typ, TypX, UnaryOp, UnaryOpr, VirErr};
+use crate::ast::{BinaryOp, Constant, Fun, Ident, Path, Typ, TypX, UnaryOp, UnaryOpr, VirErr};
 use crate::ast_util::{err_str, path_as_rust_name};
 use crate::context::Ctx;
 use crate::sst::{Exp, ExpX, Trig, Trigs, UniqueIdent};
@@ -31,7 +31,7 @@ and programmers having to use manual triggers to eliminate the timeouts.
 enum App {
     Const(Constant),
     Field(Path, Ident, Ident),
-    Call(Path),
+    Call(Fun),
     Ctor(Path, Ident), // datatype constructor: (Path, Variant)
     Other(u64),        // u64 is an id, assigned via a simple counter
 }
@@ -52,7 +52,7 @@ impl std::fmt::Debug for TermX {
             TermX::App(App::Field(_, x, y), es) => write!(f, "{:?}.{}/{}", es[0], x, y),
             TermX::App(c @ (App::Call(_) | App::Ctor(_, _)), es) => {
                 match c {
-                    App::Call(x) => write!(f, "{}(", path_as_rust_name(x))?,
+                    App::Call(x) => write!(f, "{}(", path_as_rust_name(&x.path))?,
                     App::Ctor(path, variant) => {
                         write!(f, "{}::{}(", path_as_rust_name(path), variant)?
                     }

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -1,5 +1,5 @@
 use crate::ast::{
-    CallTarget, Datatype, Expr, ExprX, Function, Krate, Mode, Path, UnaryOpr, VirErr,
+    CallTarget, Datatype, Expr, ExprX, Fun, Function, Krate, Mode, Path, UnaryOpr, VirErr,
 };
 use crate::ast_util::{err_str, err_string};
 use crate::ast_visitor::map_expr_visitor;
@@ -7,7 +7,7 @@ use crate::datatype_to_air::is_datatype_transparent;
 use std::collections::HashMap;
 
 struct Ctxt {
-    pub(crate) funs: HashMap<Path, Function>,
+    pub(crate) funs: HashMap<Fun, Function>,
     pub(crate) dts: HashMap<Path, Datatype>,
 }
 
@@ -43,7 +43,7 @@ fn check_function(ctxt: &Ctxt, function: &Function) -> Result<(), VirErr> {
     if let Some(body) = &function.x.body {
         map_expr_visitor(body, &mut |expr: &Expr| {
             match &expr.x {
-                ExprX::Call(CallTarget::Path(x, _), _) => {
+                ExprX::Call(CallTarget::Static(x, _), _) => {
                     // Check that public, non-abstract spec function bodies don't refer to private items
                     if !function.x.is_abstract
                         && !function.x.visibility.is_private
@@ -101,7 +101,7 @@ pub fn check_crate(krate: &Krate) -> Result<(), VirErr> {
     let funs = krate
         .functions
         .iter()
-        .map(|function| (function.x.path.clone(), function.clone()))
+        .map(|function| (function.x.name.clone(), function.clone()))
         .collect();
     let dts = krate
         .datatypes


### PR DESCRIPTION
Rust:

```
        #[derive(PartialEq, Eq)] #[spec]
        struct V {
           ...
        }

        impl std::ops::Index<int> for V {
            type Output = nat;

            #[spec]
            fn index(&self, idx: int) -> &nat {
                ...
            }
        }

        fn test(v: V) {
            requires(v[0] == 3);

            assert(v[0] + 1 == 4);
        }
```

AIR:

`index` Decl:
```
 ;; Function-Decl crate::V::index<core::ops::index::Index>
 (declare-fun V.index.<core.ops.index.Index.>? (V. Int) Int)
```

`fn test`:
```
 ;; Function-Def crate::test
 (check-valid
  (declare-const v@ V.)
  (declare-const tmp%1@ Bool)
  (axiom fuel_defaults)
  (axiom (has_type (Poly%V. v@) TYPE%V.))
  (axiom (= (V.index.<core.ops.index.Index.>? v@ 0) 3))
  (block
   (assume
    (= tmp%1@ (= (nClip (+ (V.index.<core.ops.index.Index.>? v@ 0) 1)) 4))
   )
   (block
    (assert
     "test.rs:38:5: 38:26 (#0)"
     (req%pervasive.assert. tmp%1@)
    )
    (assume
     (ens%pervasive.assert. tmp%1@)
 ))))
```
