### PR TITLE
pcell

### DIFF
--- a/source/pervasive/cell.rs
+++ b/source/pervasive/cell.rs
@@ -1,0 +1,113 @@
+use std::cell::UnsafeCell;
+use std::mem::MaybeUninit;
+
+#[allow(unused_imports)] use builtin::*;
+#[allow(unused_imports)] use crate::pervasive::*;
+
+//type Identifier = int;
+
+#[verifier(external_body)]
+pub struct PCell<V> {
+  ucell: UnsafeCell<MaybeUninit<V>>,
+}
+
+// TODO find a way to consolidate Permission and PermissionToken
+
+#[spec]
+pub struct Permission<V> {
+  pub pcell: int,
+  pub value: option::Option<V>,
+}
+
+#[verifier(external_body)]
+#[proof]
+pub struct PermissionToken<V> {
+  dummy: std::marker::PhantomData<V>,
+}
+
+pub struct PCellWithToken<V> {
+  pub pcell: PCell<V>,
+  #[proof] pub token: PermissionToken<V>,
+}
+
+impl<V> PermissionToken<V> {
+  #[verifier(pub_abstract)]
+  #[spec]
+  pub fn view(&self) -> Permission<V> {
+    arbitrary()
+  }
+}
+
+// TODO put these in impl:
+
+//// new_empty
+#[inline(always)]
+#[verifier(external_body)]
+fn new_empty_external<V>() -> PCell<V> {
+  ensures(|p: PCell<V>| false);
+  return PCell { ucell: UnsafeCell::new(MaybeUninit::uninit()) };
+}
+
+#[inline(always)]
+pub fn new_empty<V>() -> PCellWithToken<V> {
+  ensures(|pt : PCellWithToken<V>|
+    equal(pt.token.view(), Permission{ pcell: pt.pcell.view(), value: option::Option::None })
+  );
+
+  let p = new_empty_external();
+  #[proof] let t = proof_from_false();
+  PCellWithToken {pcell: p, token: t}
+}
+
+impl<V> PCell<V> {
+  #[verifier(pub_abstract)]
+  #[spec]
+  pub fn view(&self) -> int {
+    arbitrary()
+  }
+
+  //// Put
+
+  #[inline(always)]
+  #[verifier(external_body)]
+  fn put_external(&self, v: V) {
+    ensures(false);
+    unsafe {
+      *(self.ucell.get()) = MaybeUninit::new(v);
+    }
+  }
+
+  #[inline(always)]
+  #[verifier(returns(proof))]
+  pub fn put(&self, v: V, #[proof] perm: PermissionToken<V>) -> PermissionToken<V> {
+    requires([
+        equal(self.view(), perm.view().pcell),
+        equal(perm.view().value, option::Option::None),
+    ]);
+    ensures(|p: PermissionToken<V>|
+        equal(p.view().value, option::Option::Some(v))
+    );
+
+    self.put_external(v);
+
+    perm
+  }
+
+  /*
+  #[inline(always)]
+  #[verifier(no_verify)]
+  pub fn borrow(&self, perm: &'a PermissionToken<V>) -> &'a V {
+    requires([
+        equal(self.view(), perm.view().pcell),
+        !equal(perm.view().value, None),
+    ]);
+    ensures(|p: PermissionToken<V>|
+        equal(p.view().value, Some(v))
+    );
+    
+    self.write_external(v);
+
+    return perm;
+  }
+  */
+}

--- a/source/pervasive/cell.rs
+++ b/source/pervasive/cell.rs
@@ -4,14 +4,20 @@ use std::mem::MaybeUninit;
 #[allow(unused_imports)] use builtin::*;
 #[allow(unused_imports)] use crate::pervasive::*;
 
+// TODO Identifier should be some opaque type, not necessarily an int
+
+// TODO find a way to consolidate Permission and PermissionToken; having 2 types is cumbersome
+
+// TODO implement: borrow, borrow_mut, take, swap, read_copy
+
+// TODO figure out how Drop should work
+
 //type Identifier = int;
 
 #[verifier(external_body)]
 pub struct PCell<V> {
   ucell: UnsafeCell<MaybeUninit<V>>,
 }
-
-// TODO find a way to consolidate Permission and PermissionToken
 
 #[spec]
 pub struct Permission<V> {
@@ -38,7 +44,7 @@ impl<V> PermissionToken<V> {
   }
 }
 
-// TODO put these in impl:
+// TODO put these in impl once methods without 'self' are supported
 
 //// new_empty
 #[inline(always)]

--- a/source/pervasive/mod.rs
+++ b/source/pervasive/mod.rs
@@ -5,6 +5,7 @@ pub mod seq;
 pub mod seq_lib;
 pub mod set;
 pub mod set_lib;
+pub mod cell;
 
 #[allow(unused_imports)]
 use builtin::*;

--- a/source/rust_verify/example/cells.rs
+++ b/source/rust_verify/example/cells.rs
@@ -1,0 +1,25 @@
+#[allow(unused_imports)]
+use builtin::*;
+mod pervasive;
+#[allow(unused_imports)]
+use crate::pervasive::{*, cell::*};
+use crate::cell::new_empty;
+#[allow(unused_imports)]
+use crate::cell::*;
+
+
+struct X {
+  pub i: u64,
+}
+
+fn main() {
+  let x = X { i: 5 };
+
+  match new_empty() {
+    PCellWithToken{pcell, token} => {
+      #[proof] let t1 = pcell.put(x, token);
+
+      assert(equal(t1.view().value, option::Option::Some(X { i : 5 })));
+    }
+  }
+}


### PR DESCRIPTION
This is my first attempt at porting [Seagull's `LinearCell`](https://github.com/vmware-labs/verified-betrfs/blob/concurrency-experiments/concurrency/framework/Cells.s.dfy).

First of all, Rust already has a thing called `Cell`, so I needed a new name. I decided on `PCell` (for "permissioned cell").

`PCell` is implemented externally. There are two more types, `PermissionToken` ("proof") and `Permission` ("spec"; serves as a `view()` of `PermissionToken`). This feels a little tedious, but I wasn't sure what would happen if I tried to combine them into a single `proof` type:

```rust
#[proof]
pub struct PermissionToken<V> {
  pub pcell: int,
  pub value: option::Option<V>,
}
```

Are users allowed to modify the fields of a #[proof] struct at will? For this design to be sane, that needs to not be the case, but I wasn't sure.

In this PR, I implemented the `write` method. I wanted to make a constructor as well, but ran into a couple of issues:

 * First of all, it seems Verus doesn't yet support `impl` methods that don't take a `self` argument. This is easy enough to work around, though, since I can just put the constructor outside of `impl`.
 * The constructor needs to return a pair `(PCell<V>, PermissionToken<V>)`, where the left argument is #[exec] and the right argument is #[proof]. This also seemed to be unsupported, and is much harder or impossible to work around.

Finally, one last issue I had was that the implementation of `PCell` requires the use of `MaybeUninit`. Rust apparently implements `MaybeUninit` via a `union`, which Verus complained about... I put a fix in `rust_to_vir_base.rs`, but I don't know if that change was sensible.