### PR TITLE
Support named lifetimes in function declarations

### DIFF
--- a/source/rust_verify/src/rust_to_vir_adts.rs
+++ b/source/rust_verify/src/rust_to_vir_adts.rs
@@ -76,7 +76,7 @@ pub fn check_item_struct<'tcx>(
     variant_data: &'tcx VariantData<'tcx>,
     generics: &'tcx Generics<'tcx>,
 ) -> Result<(), VirErr> {
-    let typ_params = check_generics(ctxt.tcx, generics)?;
+    let typ_params = check_generics(ctxt.tcx, generics, false)?;
     let name = hack_get_def_name(ctxt.tcx, id.def_id.to_def_id());
     let path = def_id_to_vir_path(ctxt.tcx, id.def_id.to_def_id());
     let variant_name = Arc::new(name.clone());
@@ -110,7 +110,7 @@ pub fn check_item_enum<'tcx>(
     enum_def: &'tcx EnumDef<'tcx>,
     generics: &'tcx Generics<'tcx>,
 ) -> Result<(), VirErr> {
-    let typ_params = check_generics(ctxt.tcx, generics)?;
+    let typ_params = check_generics(ctxt.tcx, generics, false)?;
     let path = def_id_to_vir_path(ctxt.tcx, id.def_id.to_def_id());
     let (variants, one_field_private): (Vec<_>, Vec<_>) = enum_def
         .variants

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -123,8 +123,11 @@ pub(crate) fn check_item_fn<'tcx>(
     } else {
         None
     };
-    let self_typ_params =
-        if let Some(cg) = self_generics { Some(check_generics(ctxt.tcx, cg)?) } else { None };
+    let self_typ_params = if let Some(cg) = self_generics {
+        Some(check_generics(ctxt.tcx, cg, false)?)
+    } else {
+        None
+    };
     let ret_typ_mode = match sig {
         FnSig {
             header: FnHeader { unsafety, constness: _, asyncness: _, abi: _ },
@@ -143,7 +146,7 @@ pub(crate) fn check_item_fn<'tcx>(
             )?
         }
     };
-    let sig_typ_bounds = check_generics_bounds(ctxt.tcx, generics)?;
+    let sig_typ_bounds = check_generics_bounds(ctxt.tcx, generics, true)?;
     let fuel = get_fuel(attrs);
     let vattrs = get_verifier_attrs(attrs)?;
     if vattrs.external {
@@ -294,7 +297,7 @@ pub(crate) fn check_foreign_item_fn<'tcx>(
 ) -> Result<(), VirErr> {
     let mode = get_mode(Mode::Exec, attrs);
     let ret_typ_mode = check_fn_decl(ctxt.tcx, &span, decl, None, None, attrs, mode)?;
-    let typ_bounds = check_generics_bounds(ctxt.tcx, generics)?;
+    let typ_bounds = check_generics_bounds(ctxt.tcx, generics, true)?;
     let fuel = get_fuel(attrs);
     let mut vir_params: Vec<vir::ast::Param> = Vec::new();
     for (param, input) in idents.iter().zip(decl.inputs.iter()) {

--- a/source/rust_verify/tests/refs.rs
+++ b/source/rust_verify/tests/refs.rs
@@ -39,8 +39,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    // TODO(utaal) support named lifetimes for immutable references
-    #[ignore] #[test] test_return_ref_named_lifetime code! {
+    #[test] test_return_ref_named_lifetime code! {
         fn return_ref<'a>(p: &'a u64) -> &'a u64 {
             ensures(|r: &u64| r == p);
             p


### PR DESCRIPTION
The borrow-checker is in charge of guaranteeing that the reference's lifetime is tied to an immutable borrow of the referenced object. Thus we can treat the reference as an immutable copy of the current value. I believe this is safe. @Chris-Hawblitzel can you think of anything that this would allow and that's unsound?

cc @tjhance