### PR TITLE
Add #[verifier(unforgeable)] attribute for #[proof] structs

### DIFF
--- a/source/rust_verify/example/cells.rs
+++ b/source/rust_verify/example/cells.rs
@@ -7,7 +7,6 @@ use crate::cell::new_empty;
 #[allow(unused_imports)]
 use crate::cell::*;
 
-
 struct X {
   pub i: u64,
 }
@@ -19,7 +18,7 @@ fn main() {
     PCellWithToken{pcell, token} => {
       #[proof] let t1 = pcell.put(x, token);
 
-      assert(equal(t1.view().value, option::Option::Some(X { i : 5 })));
+      assert(equal(t1.value, option::Option::Some(X { i : 5 })));
     }
   }
 }

--- a/source/rust_verify/src/rust_to_vir_adts.rs
+++ b/source/rust_verify/src/rust_to_vir_adts.rs
@@ -95,7 +95,9 @@ pub fn check_item_struct<'tcx>(
     };
     let variants = Arc::new(vec![variant]);
     let mode = get_mode(Mode::Exec, attrs);
-    let datatype = DatatypeX { path, visibility, transparency, typ_params, variants, mode };
+    let unforgeable = vattrs.unforgeable;
+    let datatype =
+        DatatypeX { path, visibility, transparency, typ_params, variants, mode, unforgeable };
     vir.datatypes.push(spanned_new(span, datatype));
     Ok(())
 }
@@ -130,6 +132,7 @@ pub fn check_item_enum<'tcx>(
         DatatypeTransparency::Always
     };
     let mode = get_mode(Mode::Exec, attrs);
+    let unforgeable = vattrs.unforgeable;
     vir.datatypes.push(spanned_new(
         span,
         DatatypeX {
@@ -139,6 +142,7 @@ pub fn check_item_enum<'tcx>(
             typ_params,
             variants: Arc::new(variants),
             mode,
+            unforgeable,
         },
     ));
     Ok(())

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -207,6 +207,8 @@ pub(crate) enum Attr {
     Trigger(Option<Vec<u64>>),
     // custom error string to report for precondition failures
     CustomReqErr(String),
+    // for unforgeable token types
+    Unforgeable,
 }
 
 fn get_trigger_arg(span: Span, attr_tree: &AttrTree) -> Result<u64, VirErr> {
@@ -260,6 +262,9 @@ pub(crate) fn parse_attrs(attrs: &[Attribute]) -> Result<Vec<Attr>, VirErr> {
                 }
                 Some(box [AttrTree::Fun(_, arg, None)]) if arg == "autoview" => {
                     v.push(Attr::Autoview)
+                }
+                Some(box [AttrTree::Fun(_, arg, None)]) if arg == "unforgeable" => {
+                    v.push(Attr::Unforgeable)
                 }
                 Some(box [AttrTree::Fun(_, arg, Some(box [AttrTree::Fun(_, msg, None)]))])
                     if arg == "custom_req_err" =>
@@ -355,6 +360,7 @@ pub(crate) struct VerifierAttrs {
     pub(crate) export_as_global_forall: bool,
     pub(crate) autoview: bool,
     pub(crate) custom_req_err: Option<String>,
+    pub(crate) unforgeable: bool,
 }
 
 pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, VirErr> {
@@ -365,6 +371,7 @@ pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, V
         export_as_global_forall: false,
         autoview: false,
         custom_req_err: None,
+        unforgeable: false,
     };
     for attr in parse_attrs(attrs)? {
         match attr {
@@ -374,6 +381,7 @@ pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, V
             Attr::ExportAsGlobalForall => vs.export_as_global_forall = true,
             Attr::Autoview => vs.autoview = true,
             Attr::CustomReqErr(s) => vs.custom_req_err = Some(s.clone()),
+            Attr::Unforgeable => vs.unforgeable = true,
             _ => {}
         }
     }

--- a/source/rust_verify/tests/harness.rs
+++ b/source/rust_verify/tests/harness.rs
@@ -22,7 +22,7 @@ fn harness_invalid_rust() {
         }
     };
     let err = verify_one_file(code).unwrap_err();
-    assert_eq!(err.len(), 0);
+    assert_eq!(err.errors.len(), 0);
 }
 
 #[test]
@@ -45,8 +45,8 @@ fn harness_false() {
         }
     })
     .unwrap_err();
-    assert_eq!(err.len(), 1);
-    assert!(err[0].first().expect("span").test_span_line.contains("FAILS"));
+    assert_eq!(err.errors.len(), 1);
+    assert!(err.errors[0].first().expect("span").test_span_line.contains("FAILS"));
 }
 
 test_verify_one_file! {

--- a/source/rust_verify/tests/modules.rs
+++ b/source/rust_verify/tests/modules.rs
@@ -40,5 +40,5 @@ test_verify_one_file! {
         fn mod_adt_no_verify() {
             assert(!Car { four_doors: false }.four_doors);
         }
-    } => Err(err) => assert_eq!(err.len(), 0)
+    } => Err(err) => assert_vir_error(err)
 }

--- a/source/rust_verify/tests/proof_adts.rs
+++ b/source/rust_verify/tests/proof_adts.rs
@@ -1,0 +1,71 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+// Error: #[verifier(unforgeable)] should be marked #[proof]
+
+test_verify_one_file! {
+    #[test] spec_unforgeable_err code! {
+        #[verifier(unforgeable)]
+        #[spec]
+        struct X { // FAILS
+          #[spec] pub u: int,
+        }
+    } => Err(err) => assert_vir_error(err)
+}
+
+test_verify_one_file! {
+    #[test] exec_unforgeable_err code! {
+        #[verifier(unforgeable)]
+        struct X { // FAILS
+          #[spec] pub u: int,
+        }
+    } => Err(err) => assert_vir_error(err)
+}
+
+// The fields of a unforgeable datatype must be 'spec'
+
+test_verify_one_file! {
+    #[test] unforgeable_fields_must_be_spec1 code! {
+        #[verifier(unforgeable)]
+        #[proof]
+        struct X { // FAILS
+          pub u: int,
+        }
+    } => Err(err) => assert_vir_error(err)
+}
+
+test_verify_one_file! {
+    #[test] unforgeable_fields_must_be_spec2 code! {
+        #[verifier(unforgeable)]
+        #[proof]
+        struct X { // FAILS
+          #[proof] pub u: int,
+        }
+    } => Err(err) => assert_vir_error(err)
+}
+
+test_verify_one_file! {
+    #[test] unforgeable_ok code! {
+        #[verifier(unforgeable)]
+        #[proof]
+        struct X { // FAILS
+          #[spec] pub u: u8,
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] unforgeable_cant_construct code! {
+        #[verifier(unforgeable)]
+        #[proof]
+        struct X { // FAILS
+          #[spec] pub u: u8,
+        }
+
+        pub fn X() {
+          #[proof] let x = X{u: 8};
+        }
+    } => Err(err) => assert_vir_error(err)
+}

--- a/source/rust_verify/tests/structural.rs
+++ b/source/rust_verify/tests/structural.rs
@@ -48,7 +48,7 @@ test_verify_one_file! {
             let v2 = Thing { v: true };
             assert(v1 == v2);
         }
-    } => Err(err) => assert_eq!(err.len(), 0)
+    } => Err(err) => assert_vir_error(err)
 }
 
 test_verify_one_file! {
@@ -70,7 +70,7 @@ test_verify_one_file! {
             let v2 = Thing { v: true };
             assert(v1 == v2);
         }
-    } => Err(err) => assert_eq!(err.len(), 0)
+    } => Err(err) => assert_vir_error(err)
 }
 
 test_verify_one_file! {
@@ -82,5 +82,5 @@ test_verify_one_file! {
         struct Thing {
             o: Other,
         }
-    } => Err(err) => assert_eq!(err.len(), 0)
+    } => Err(err) => assert_eq!(err.errors.len(), 0)
 }

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -420,6 +420,8 @@ pub struct DatatypeX {
     pub typ_params: Idents,
     pub variants: Variants,
     pub mode: Mode,
+    // For token types that need to be 'unforgeable'. Only makes sense for 'Proof' types.
+    pub unforgeable: bool,
 }
 pub type Datatype = Arc<Spanned<DatatypeX>>;
 pub type Datatypes = Vec<Datatype>;

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -480,8 +480,15 @@ pub fn simplify_krate(ctx: &mut GlobalCtx, krate: &Krate) -> Result<Krate, VirEr
         }
         let variant = ident_binder(&prefix_tuple_variant(arity), &Arc::new(fields));
         let variants = Arc::new(vec![variant]);
-        let datatypex =
-            DatatypeX { path, visibility, transparency, typ_params, variants, mode: Mode::Exec };
+        let datatypex = DatatypeX {
+            path,
+            visibility,
+            transparency,
+            typ_params,
+            variants,
+            mode: Mode::Exec,
+            unforgeable: false,
+        };
         datatypes.push(Spanned::new(ctx.no_span.clone(), datatypex));
     }
 

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -165,6 +165,11 @@ fn check_expr(typing: &mut Typing, outer_mode: Mode, expr: &Expr) -> Result<Mode
                     mode = mode_join(mode, mode_arg);
                 }
             }
+
+            if datatype.x.unforgeable && mode == Mode::Proof {
+                return err_str(&expr.span, "cannot construct an unforgeable proof object");
+            }
+
             Ok(mode)
         }
         ExprX::Unary(_, e1) => check_expr(typing, outer_mode, e1),
@@ -220,6 +225,8 @@ fn check_expr(typing: &mut Typing, outer_mode: Mode, expr: &Expr) -> Result<Mode
             Ok(Mode::Spec)
         }
         ExprX::Assign(lhs, rhs) => match &lhs.x {
+            // TODO when we support field updates, make sure we handle 'unforgeable' types
+            // correctly.
             ExprX::Var(x) => {
                 let (x_mut, x_mode) = typing.get(x);
                 if !x_mut {

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -140,6 +140,33 @@ fn check_function(ctxt: &Ctxt, function: &Function) -> Result<(), VirErr> {
     Ok(())
 }
 
+fn check_datatype(dt: &Datatype) -> Result<(), VirErr> {
+    let unforgeable = dt.x.unforgeable;
+    let dt_mode = dt.x.mode;
+
+    if unforgeable && dt_mode != Mode::Proof {
+        return err_string(&dt.span, format!("An unforgeable datatype must be in #[proof] mode."));
+    }
+
+    // For an 'unforgeable' datatype, all fields must be #[spec]
+
+    if unforgeable {
+        for variant in dt.x.variants.iter() {
+            for binder in variant.a.iter() {
+                let (_typ, field_mode) = &binder.a;
+                if *field_mode != Mode::Spec {
+                    return err_string(
+                        &dt.span,
+                        format!("All fields of a unforgeable datatype must be marked #[spec]"),
+                    );
+                }
+            }
+        }
+    }
+
+    return Ok(());
+}
+
 pub fn check_crate(krate: &Krate) -> Result<(), VirErr> {
     let funs = krate
         .functions
@@ -154,6 +181,9 @@ pub fn check_crate(krate: &Krate) -> Result<(), VirErr> {
     let ctxt = Ctxt { funs, dts };
     for function in krate.functions.iter() {
         check_function(&ctxt, function)?;
+    }
+    for dt in krate.datatypes.iter() {
+        check_datatype(dt)?;
     }
     crate::recursive_types::check_recursive_types(krate)?;
     Ok(())


### PR DESCRIPTION
There are - fundamentally - two different kinds of "proof" objects. One kind is basically like a normal struct, except that it gets erased. With such types, you build up a "struct" of smaller proof objects.

The other kind is the "base" objects that represent permissions or some other fancy thing, e.g., `Permission`. To make it easier to handle this second type, I added an attribute `#[verifier(unforgeable)]` to declare such types.

The rules:

- An `unforgeable` datatype must be `proof`.
- An `unforgeable` datatype can only have `spec` fields.
- You cannot call a constructor of an `unforgeable` datatype (in `proof` mode)
- You cannot modify a field of an `unforgeable` datatype.

Here, I add the attribute, implement these rules, and add tests. Although, it doesn't look like there is any support at all for field updates yet, so there was nothing to do for the last step.