### PR TITLE
initial work to support `assert_bit_vector` primitive

### DIFF
--- a/source/air/src/ast.rs
+++ b/source/air/src/ast.rs
@@ -52,6 +52,8 @@ pub enum BinaryOp {
     EuclideanDiv,
     EuclideanMod,
 
+    UintXor,
+
     BitXor,
     BitAnd,
     BitOr,

--- a/source/air/src/ast.rs
+++ b/source/air/src/ast.rs
@@ -33,7 +33,7 @@ pub enum TypX {
 pub enum Constant {
     Bool(bool),
     Nat(Arc<String>),
-    // BitVec(Arc<String>, u32),
+    BitVec(Arc<String>, u32),
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]

--- a/source/air/src/ast.rs
+++ b/source/air/src/ast.rs
@@ -53,12 +53,11 @@ pub enum BinaryOp {
     EuclideanMod,
 
     UintXor,
-
     BitXor,
+
     BitAnd,
     BitOr,
     BitAdd,
-
     Shr,
     Shl,
 }

--- a/source/air/src/ast.rs
+++ b/source/air/src/ast.rs
@@ -33,6 +33,7 @@ pub enum TypX {
 pub enum Constant {
     Bool(bool),
     Nat(Arc<String>),
+    // BitVec(Arc<String>, u32),
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
@@ -50,9 +51,12 @@ pub enum BinaryOp {
     Gt,
     EuclideanDiv,
     EuclideanMod,
+
     BitXor,
     BitAnd,
     BitOr,
+    BitAdd,
+
     Shr,
     Shl,
 }

--- a/source/air/src/ast.rs
+++ b/source/air/src/ast.rs
@@ -49,6 +49,11 @@ pub enum BinaryOp {
     Gt,
     EuclideanDiv,
     EuclideanMod,
+    BitXor,
+    BitAnd,
+    BitOr,
+    Shr,
+    Shl,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]

--- a/source/air/src/ast.rs
+++ b/source/air/src/ast.rs
@@ -26,6 +26,7 @@ pub enum TypX {
     // Lambda deliberately omits argument, return types to make box/unbox for generics easier
     Lambda,
     Named(Ident),
+    BitVec(u32),
 }
 
 #[derive(Clone, PartialEq, Eq, Hash)] // for Debug, see ast_util

--- a/source/air/src/ast.rs
+++ b/source/air/src/ast.rs
@@ -52,7 +52,6 @@ pub enum BinaryOp {
     EuclideanDiv,
     EuclideanMod,
 
-    UintXor,
     BitXor,
 
     BitAnd,

--- a/source/air/src/ast_util.rs
+++ b/source/air/src/ast_util.rs
@@ -110,6 +110,10 @@ pub fn str_typ(x: &str) -> Typ {
     Arc::new(TypX::Named(Arc::new(x.to_string())))
 }
 
+pub fn bv_typ(size: u32) -> Typ {
+    Arc::new(TypX::BitVec(size))
+}
+
 pub fn ident_binder<A: Clone>(x: &Ident, a: &A) -> Binder<A> {
     Arc::new(BinderX { name: x.clone(), a: a.clone() })
 }

--- a/source/air/src/ast_util.rs
+++ b/source/air/src/ast_util.rs
@@ -16,7 +16,7 @@ impl Debug for Constant {
         match self {
             Constant::Bool(b) => write!(f, "{}", b),
             Constant::Nat(n) => write!(f, "{}", n),
-            // Constant::BitVec(n) => write!(f, "{}", n),
+            Constant::BitVec(n, width) => write!(f, "{}(bv{})", n, width),
         }
     }
 }

--- a/source/air/src/ast_util.rs
+++ b/source/air/src/ast_util.rs
@@ -16,6 +16,7 @@ impl Debug for Constant {
         match self {
             Constant::Bool(b) => write!(f, "{}", b),
             Constant::Nat(n) => write!(f, "{}", n),
+            // Constant::BitVec(n) => write!(f, "{}", n),
         }
     }
 }
@@ -110,8 +111,8 @@ pub fn str_typ(x: &str) -> Typ {
     Arc::new(TypX::Named(Arc::new(x.to_string())))
 }
 
-pub fn bv_typ(size: u32) -> Typ {
-    Arc::new(TypX::BitVec(size))
+pub fn bv_typ(width: u32) -> Typ {
+    Arc::new(TypX::BitVec(width))
 }
 
 pub fn ident_binder<A: Clone>(x: &Ident, a: &A) -> Binder<A> {

--- a/source/air/src/closure.rs
+++ b/source/air/src/closure.rs
@@ -418,7 +418,8 @@ fn simplify_expr(ctxt: &mut Context, state: &mut State, expr: &Expr) -> (Typ, Ex
                 BinaryOp::Implies | BinaryOp::Eq => Arc::new(TypX::Bool),
                 BinaryOp::Le | BinaryOp::Ge | BinaryOp::Lt | BinaryOp::Gt => Arc::new(TypX::Bool),
                 BinaryOp::EuclideanDiv | BinaryOp::EuclideanMod => Arc::new(TypX::Int),
-                BinaryOp::BitXor | BinaryOp::BitAnd | BinaryOp::BitOr | BinaryOp::Shr | BinaryOp::Shl => Arc::new(TypX::Int),
+                // TODO: is this actually reasonable for bit vector operations?
+                BinaryOp::BitXor | BinaryOp::BitAnd | BinaryOp::BitOr | BinaryOp::BitAdd | BinaryOp::Shr | BinaryOp::Shl => Arc::new(TypX::Int),
             };
             let (es, ts) = simplify_exprs_ref(ctxt, state, &vec![e1, e2]);
             let (es, t) = enclose(state, App::Binary(*op), es, ts);

--- a/source/air/src/closure.rs
+++ b/source/air/src/closure.rs
@@ -420,7 +420,6 @@ fn simplify_expr(ctxt: &mut Context, state: &mut State, expr: &Expr) -> (Typ, Ex
                 BinaryOp::Le | BinaryOp::Ge | BinaryOp::Lt | BinaryOp::Gt => Arc::new(TypX::Bool),
                 BinaryOp::EuclideanDiv | BinaryOp::EuclideanMod => Arc::new(TypX::Int),
                 // TODO: is this actually reasonable for bit vector operations?
-                BinaryOp::UintXor
                 | BinaryOp::BitXor
                 | BinaryOp::BitAnd
                 | BinaryOp::BitOr

--- a/source/air/src/closure.rs
+++ b/source/air/src/closure.rs
@@ -420,7 +420,13 @@ fn simplify_expr(ctxt: &mut Context, state: &mut State, expr: &Expr) -> (Typ, Ex
                 BinaryOp::Le | BinaryOp::Ge | BinaryOp::Lt | BinaryOp::Gt => Arc::new(TypX::Bool),
                 BinaryOp::EuclideanDiv | BinaryOp::EuclideanMod => Arc::new(TypX::Int),
                 // TODO: is this actually reasonable for bit vector operations?
-                BinaryOp::UintXor | BinaryOp::BitXor | BinaryOp::BitAnd | BinaryOp::BitOr | BinaryOp::BitAdd | BinaryOp::Shr | BinaryOp::Shl => Arc::new(TypX::Int),
+                BinaryOp::UintXor
+                | BinaryOp::BitXor
+                | BinaryOp::BitAnd
+                | BinaryOp::BitOr
+                | BinaryOp::BitAdd
+                | BinaryOp::Shr
+                | BinaryOp::Shl => Arc::new(TypX::Int),
             };
             let (es, ts) = simplify_exprs_ref(ctxt, state, &vec![e1, e2]);
             let (es, t) = enclose(state, App::Binary(*op), es, ts);

--- a/source/air/src/closure.rs
+++ b/source/air/src/closure.rs
@@ -4,7 +4,7 @@ use crate::ast::{
 };
 use crate::ast_util::{ident_binder, mk_forall};
 use crate::context::Context;
-use crate::typecheck::DeclaredX;
+use crate::typecheck::{DeclaredX, typ_eq};
 use crate::util::vec_map;
 use std::sync::Arc;
 
@@ -415,19 +415,17 @@ fn simplify_expr(ctxt: &mut Context, state: &mut State, expr: &Expr) -> (Typ, Ex
             (typ, Arc::new(ExprX::Unary(*op, es[0].clone())), t)
         }
         ExprX::Binary(op, e1, e2) => {
+            let (es, ts) = simplify_exprs_ref(ctxt, state, &vec![e1, e2]);
             let typ = match op {
                 BinaryOp::Implies | BinaryOp::Eq => Arc::new(TypX::Bool),
                 BinaryOp::Le | BinaryOp::Ge | BinaryOp::Lt | BinaryOp::Gt => Arc::new(TypX::Bool),
                 BinaryOp::EuclideanDiv | BinaryOp::EuclideanMod => Arc::new(TypX::Int),
-                // TODO: is this actually reasonable for bit vector operations?
-                | BinaryOp::BitXor
-                | BinaryOp::BitAnd
-                | BinaryOp::BitOr
-                | BinaryOp::BitAdd
-                | BinaryOp::Shr
-                | BinaryOp::Shl => Arc::new(TypX::Int),
+                BinaryOp::BitXor | BinaryOp::BitAnd | BinaryOp::BitOr | BinaryOp::BitAdd | BinaryOp::Shr | BinaryOp::Shl => 
+                {
+                    assert!(typ_eq(&(ts[0].0), &(ts[1].0)));
+                    ts[0].0.clone()
+                }
             };
-            let (es, ts) = simplify_exprs_ref(ctxt, state, &vec![e1, e2]);
             let (es, t) = enclose(state, App::Binary(*op), es, ts);
             (typ, Arc::new(ExprX::Binary(*op, es[0].clone(), es[1].clone())), t)
         }

--- a/source/air/src/closure.rs
+++ b/source/air/src/closure.rs
@@ -420,7 +420,7 @@ fn simplify_expr(ctxt: &mut Context, state: &mut State, expr: &Expr) -> (Typ, Ex
                 BinaryOp::Le | BinaryOp::Ge | BinaryOp::Lt | BinaryOp::Gt => Arc::new(TypX::Bool),
                 BinaryOp::EuclideanDiv | BinaryOp::EuclideanMod => Arc::new(TypX::Int),
                 // TODO: is this actually reasonable for bit vector operations?
-                BinaryOp::BitXor | BinaryOp::BitAnd | BinaryOp::BitOr | BinaryOp::BitAdd | BinaryOp::Shr | BinaryOp::Shl => Arc::new(TypX::Int),
+                BinaryOp::UintXor | BinaryOp::BitXor | BinaryOp::BitAnd | BinaryOp::BitOr | BinaryOp::BitAdd | BinaryOp::Shr | BinaryOp::Shl => Arc::new(TypX::Int),
             };
             let (es, ts) = simplify_exprs_ref(ctxt, state, &vec![e1, e2]);
             let (es, t) = enclose(state, App::Binary(*op), es, ts);

--- a/source/air/src/closure.rs
+++ b/source/air/src/closure.rs
@@ -372,6 +372,7 @@ fn simplify_expr(ctxt: &mut Context, state: &mut State, expr: &Expr) -> (Typ, Ex
             let typ = match c {
                 Constant::Bool(_) => Arc::new(TypX::Bool),
                 Constant::Nat(_) => Arc::new(TypX::Int),
+                Constant::BitVec(_, width) => Arc::new(TypX::BitVec(*width)),
             };
             (typ, expr.clone(), None)
         }

--- a/source/air/src/closure.rs
+++ b/source/air/src/closure.rs
@@ -4,7 +4,7 @@ use crate::ast::{
 };
 use crate::ast_util::{ident_binder, mk_forall};
 use crate::context::Context;
-use crate::typecheck::{DeclaredX, typ_eq};
+use crate::typecheck::{typ_eq, DeclaredX};
 use crate::util::vec_map;
 use std::sync::Arc;
 
@@ -420,8 +420,12 @@ fn simplify_expr(ctxt: &mut Context, state: &mut State, expr: &Expr) -> (Typ, Ex
                 BinaryOp::Implies | BinaryOp::Eq => Arc::new(TypX::Bool),
                 BinaryOp::Le | BinaryOp::Ge | BinaryOp::Lt | BinaryOp::Gt => Arc::new(TypX::Bool),
                 BinaryOp::EuclideanDiv | BinaryOp::EuclideanMod => Arc::new(TypX::Int),
-                BinaryOp::BitXor | BinaryOp::BitAnd | BinaryOp::BitOr | BinaryOp::BitAdd | BinaryOp::Shr | BinaryOp::Shl => 
-                {
+                BinaryOp::BitXor
+                | BinaryOp::BitAnd
+                | BinaryOp::BitOr
+                | BinaryOp::BitAdd
+                | BinaryOp::Shr
+                | BinaryOp::Shl => {
                     assert!(typ_eq(&(ts[0].0), &(ts[1].0)));
                     ts[0].0.clone()
                 }

--- a/source/air/src/closure.rs
+++ b/source/air/src/closure.rs
@@ -418,6 +418,7 @@ fn simplify_expr(ctxt: &mut Context, state: &mut State, expr: &Expr) -> (Typ, Ex
                 BinaryOp::Implies | BinaryOp::Eq => Arc::new(TypX::Bool),
                 BinaryOp::Le | BinaryOp::Ge | BinaryOp::Lt | BinaryOp::Gt => Arc::new(TypX::Bool),
                 BinaryOp::EuclideanDiv | BinaryOp::EuclideanMod => Arc::new(TypX::Int),
+                BinaryOp::BitXor | BinaryOp::BitAnd | BinaryOp::BitOr | BinaryOp::Shr | BinaryOp::Shl => Arc::new(TypX::Int),
             };
             let (es, ts) = simplify_exprs_ref(ctxt, state, &vec![e1, e2]);
             let (es, t) = enclose(state, App::Binary(*op), es, ts);

--- a/source/air/src/printer.rs
+++ b/source/air/src/printer.rs
@@ -138,6 +138,11 @@ impl Printer {
                     BinaryOp::Gt => ">",
                     BinaryOp::EuclideanDiv => "div",
                     BinaryOp::EuclideanMod => "mod",
+                    BinaryOp::BitXor => "^",
+                    BinaryOp::BitAnd => "&",
+                    BinaryOp::BitOr => "|",
+                    BinaryOp::Shr => ">",
+                    BinaryOp::Shl => "<",
                 };
                 Node::List(vec![str_to_node(sop), self.expr_to_node(lhs), self.expr_to_node(rhs)])
             }

--- a/source/air/src/printer.rs
+++ b/source/air/src/printer.rs
@@ -138,11 +138,11 @@ impl Printer {
                     BinaryOp::Gt => ">",
                     BinaryOp::EuclideanDiv => "div",
                     BinaryOp::EuclideanMod => "mod",
-                    BinaryOp::BitXor => "^",
-                    BinaryOp::BitAnd => "&",
-                    BinaryOp::BitOr => "|",
-                    BinaryOp::Shr => ">>",
-                    BinaryOp::Shl => "<<",
+                    BinaryOp::BitXor => "bvxor",
+                    BinaryOp::BitAnd => "bvand",
+                    BinaryOp::BitOr => "bvor",
+                    BinaryOp::Shr => "bvshr",
+                    BinaryOp::Shl => "bvshl",
                 };
                 Node::List(vec![str_to_node(sop), self.expr_to_node(lhs), self.expr_to_node(rhs)])
             }

--- a/source/air/src/printer.rs
+++ b/source/air/src/printer.rs
@@ -89,12 +89,11 @@ impl Printer {
             TypX::Lambda if self.print_as_smt => str_to_node(crate::def::FUNCTION),
             TypX::Lambda => str_to_node("Fun"),
             TypX::Named(name) => str_to_node(&name.clone()),
-            TypX::BitVec(size) if self.print_as_smt => Node::List(vec![
+            TypX::BitVec(size) => Node::List(vec![
                 str_to_node("_"),
                 str_to_node("BitVec"),
                 str_to_node(&size.to_string()),
             ]),
-            TypX::BitVec(size) => str_to_node(format!("BitVec{}", size).as_str()),
         }
     }
 

--- a/source/air/src/printer.rs
+++ b/source/air/src/printer.rs
@@ -99,10 +99,20 @@ impl Printer {
         Node::List(vec_map(typs, |t| self.typ_to_node(t)))
     }
 
+    pub(crate) fn bv_const_expr_to_node(&self, n: &Arc<String>, width: &u32) -> Node {
+        let value = n.parse::<u32>().unwrap();
+        if *width == 32 {
+            Node::Atom(format!("#x{:08x}", value))
+        } else {
+            panic!("unhandled bitwidth")
+        }
+    }
+
     pub(crate) fn expr_to_node(&self, expr: &Expr) -> Node {
         match &**expr {
             ExprX::Const(Constant::Bool(b)) => Node::Atom(b.to_string()),
             ExprX::Const(Constant::Nat(n)) => Node::Atom((**n).clone()),
+            ExprX::Const(Constant::BitVec(n, width)) => self.bv_const_expr_to_node(n, width),
             ExprX::Var(x) => Node::Atom(x.to_string()),
             ExprX::Old(snap, x) => {
                 nodes!(old {str_to_node(&snap.to_string())} {str_to_node(&x.to_string())})

--- a/source/air/src/printer.rs
+++ b/source/air/src/printer.rs
@@ -154,7 +154,6 @@ impl Printer {
                     BinaryOp::EuclideanDiv => "div",
                     BinaryOp::EuclideanMod => "mod",
 
-                    BinaryOp::UintXor => "uintxor",
                     BinaryOp::BitXor => "bvxor",
 
                     BinaryOp::BitAnd => "bvand",

--- a/source/air/src/printer.rs
+++ b/source/air/src/printer.rs
@@ -153,12 +153,11 @@ impl Printer {
                     BinaryOp::EuclideanMod => "mod",
 
                     BinaryOp::UintXor => "uintxor",
-
                     BinaryOp::BitXor => "bvxor",
+            
                     BinaryOp::BitAnd => "bvand",
                     BinaryOp::BitOr => "bvor",
                     BinaryOp::BitAdd => "bvadd",
-
                     BinaryOp::Shr => "bvshr",
                     BinaryOp::Shl => "bvshl",
                 };

--- a/source/air/src/printer.rs
+++ b/source/air/src/printer.rs
@@ -152,6 +152,8 @@ impl Printer {
                     BinaryOp::EuclideanDiv => "div",
                     BinaryOp::EuclideanMod => "mod",
 
+                    BinaryOp::UintXor => "uintxor",
+
                     BinaryOp::BitXor => "bvxor",
                     BinaryOp::BitAnd => "bvand",
                     BinaryOp::BitOr => "bvor",

--- a/source/air/src/printer.rs
+++ b/source/air/src/printer.rs
@@ -89,7 +89,8 @@ impl Printer {
             TypX::Lambda if self.print_as_smt => str_to_node(crate::def::FUNCTION),
             TypX::Lambda => str_to_node("Fun"),
             TypX::Named(name) => str_to_node(&name.clone()),
-            TypX::BitVec(size) if self.print_as_smt => str_to_node(format!("(_ BitVec {})", size).as_str()),
+            TypX::BitVec(size) if self.print_as_smt => Node::List(
+                vec![str_to_node("_"), str_to_node("BitVec"), str_to_node(&size.to_string())]),
             TypX::BitVec(size) => str_to_node(format!("BitVec{}", size).as_str()),
         }
     }
@@ -140,9 +141,12 @@ impl Printer {
                     BinaryOp::Gt => ">",
                     BinaryOp::EuclideanDiv => "div",
                     BinaryOp::EuclideanMod => "mod",
+
                     BinaryOp::BitXor => "bvxor",
                     BinaryOp::BitAnd => "bvand",
                     BinaryOp::BitOr => "bvor",
+                    BinaryOp::BitAdd => "bvadd",
+
                     BinaryOp::Shr => "bvshr",
                     BinaryOp::Shl => "bvshl",
                 };

--- a/source/air/src/printer.rs
+++ b/source/air/src/printer.rs
@@ -89,6 +89,8 @@ impl Printer {
             TypX::Lambda if self.print_as_smt => str_to_node(crate::def::FUNCTION),
             TypX::Lambda => str_to_node("Fun"),
             TypX::Named(name) => str_to_node(&name.clone()),
+            TypX::BitVec(size) if self.print_as_smt => str_to_node(format!("(_ BitVec {})", size).as_str()),
+            TypX::BitVec(size) => str_to_node(format!("BitVec{}", size).as_str()),
         }
     }
 

--- a/source/air/src/printer.rs
+++ b/source/air/src/printer.rs
@@ -89,8 +89,11 @@ impl Printer {
             TypX::Lambda if self.print_as_smt => str_to_node(crate::def::FUNCTION),
             TypX::Lambda => str_to_node("Fun"),
             TypX::Named(name) => str_to_node(&name.clone()),
-            TypX::BitVec(size) if self.print_as_smt => Node::List(
-                vec![str_to_node("_"), str_to_node("BitVec"), str_to_node(&size.to_string())]),
+            TypX::BitVec(size) if self.print_as_smt => Node::List(vec![
+                str_to_node("_"),
+                str_to_node("BitVec"),
+                str_to_node(&size.to_string()),
+            ]),
             TypX::BitVec(size) => str_to_node(format!("BitVec{}", size).as_str()),
         }
     }
@@ -154,7 +157,7 @@ impl Printer {
 
                     BinaryOp::UintXor => "uintxor",
                     BinaryOp::BitXor => "bvxor",
-            
+
                     BinaryOp::BitAnd => "bvand",
                     BinaryOp::BitOr => "bvor",
                     BinaryOp::BitAdd => "bvadd",

--- a/source/air/src/printer.rs
+++ b/source/air/src/printer.rs
@@ -141,8 +141,8 @@ impl Printer {
                     BinaryOp::BitXor => "^",
                     BinaryOp::BitAnd => "&",
                     BinaryOp::BitOr => "|",
-                    BinaryOp::Shr => ">",
-                    BinaryOp::Shl => "<",
+                    BinaryOp::Shr => ">>",
+                    BinaryOp::Shl => "<<",
                 };
                 Node::List(vec![str_to_node(sop), self.expr_to_node(lhs), self.expr_to_node(rhs)])
             }

--- a/source/air/src/typecheck.rs
+++ b/source/air/src/typecheck.rs
@@ -53,6 +53,7 @@ fn typ_name(typ: &Typ) -> String {
         TypX::Int => "Int".to_string(),
         TypX::Lambda => "Fun".to_string(),
         TypX::Named(x) => x.to_string(),
+        TypX::BitVec(n) => format!("BitVec{}", n),
     }
 }
 
@@ -73,6 +74,7 @@ fn check_typ(typing: &Typing, typ: &Typ) -> Result<(), TypeError> {
             Some(DeclaredX::Type) => Ok(()),
             _ => Err(format!("use of undeclared type {}", x)),
         },
+        TypX::BitVec(_) => Ok(()),
     }
 }
 

--- a/source/air/src/typecheck.rs
+++ b/source/air/src/typecheck.rs
@@ -57,7 +57,7 @@ fn typ_name(typ: &Typ) -> String {
     }
 }
 
-fn typ_eq(typ1: &Typ, typ2: &Typ) -> bool {
+pub fn typ_eq(typ1: &Typ, typ2: &Typ) -> bool {
     typ1 == typ2
 }
 

--- a/source/air/src/typecheck.rs
+++ b/source/air/src/typecheck.rs
@@ -204,9 +204,6 @@ fn check_expr(typing: &mut Typing, expr: &Expr) -> Result<Typ, TypeError> {
         ExprX::Binary(BinaryOp::EuclideanMod, e1, e2) => {
             check_exprs(typing, "mod", &[it(), it()], &it(), &[e1.clone(), e2.clone()])
         }
-        ExprX::Binary(BinaryOp::UintXor, e1, e2) => {
-            check_exprs(typing, "^", &[it(), it()], &it(), &[e1.clone(), e2.clone()])
-        }
         ExprX::Binary(BinaryOp::BitXor, e1, e2) => {
             check_bv_exprs(typing, "bvxor", &[e1.clone(), e2.clone()])
         }

--- a/source/air/src/typecheck.rs
+++ b/source/air/src/typecheck.rs
@@ -179,9 +179,11 @@ fn check_expr(typing: &mut Typing, expr: &Expr) -> Result<Typ, TypeError> {
             if typ_eq(&t1, &t2) {
                 Ok(bt())
             } else {
-                println!("{:?}, {:?}", t1, t2);
-                let _ = check_bv_exprs(typing, "=", &[e1.clone(), e2.clone()])?;
-                Ok(bt())
+                Err(format!(
+                        "in equality, left expression has type {} and right expression has different type {}",
+                        typ_name(&t1),
+                        typ_name(&t2)
+                    ))
             }
         }
         ExprX::Binary(BinaryOp::Le, e1, e2) => {

--- a/source/air/src/typecheck.rs
+++ b/source/air/src/typecheck.rs
@@ -122,6 +122,7 @@ fn get_bv_width(et: &Typ) -> Result<u32, TypeError> {
     if let TypX::BitVec(size) = &**et {
         return Ok(*size);
     }
+    panic!("???{:?}", et);
     return Err("not a bit vector type".to_string());
 }
 
@@ -186,6 +187,7 @@ fn check_expr(typing: &mut Typing, expr: &Expr) -> Result<Typ, TypeError> {
             if typ_eq(&t1, &t2) {
                 Ok(bt())
             } else {
+                println!("{:?}, {:?}", t1, t2);
                 let _ = check_bv_exprs(typing, "=", &[e1.clone(), e2.clone()])?;
                 Ok(bt())
             }
@@ -208,8 +210,11 @@ fn check_expr(typing: &mut Typing, expr: &Expr) -> Result<Typ, TypeError> {
         ExprX::Binary(BinaryOp::EuclideanMod, e1, e2) => {
             check_exprs(typing, "mod", &[it(), it()], &it(), &[e1.clone(), e2.clone()])
         }
+        ExprX::Binary(BinaryOp::UintXor, e1, e2) => {
+            check_exprs(typing, "^", &[it(), it()], &it(), &[e1.clone(), e2.clone()])
+        }
         ExprX::Binary(BinaryOp::BitXor, e1, e2) => {
-            check_bv_exprs(typing, "^", &[e1.clone(), e2.clone()])
+            check_bv_exprs(typing, "bvxor", &[e1.clone(), e2.clone()])
         }
         ExprX::Binary(BinaryOp::BitAnd, e1, e2) => {
             check_bv_exprs(typing, "&", &[e1.clone(), e2.clone()])
@@ -226,6 +231,7 @@ fn check_expr(typing: &mut Typing, expr: &Expr) -> Result<Typ, TypeError> {
         ExprX::Binary(BinaryOp::Shl, e1, e2) => {
             check_bv_exprs(typing, "<<", &[e1.clone(), e2.clone()])
         }
+
         ExprX::Multi(op, exprs) => {
             let (x, t) = match op {
                 MultiOp::And => ("and", bt()),

--- a/source/air/src/typecheck.rs
+++ b/source/air/src/typecheck.rs
@@ -180,6 +180,21 @@ fn check_expr(typing: &mut Typing, expr: &Expr) -> Result<Typ, TypeError> {
         ExprX::Binary(BinaryOp::EuclideanMod, e1, e2) => {
             check_exprs(typing, "mod", &[it(), it()], &it(), &[e1.clone(), e2.clone()])
         }
+        ExprX::Binary(BinaryOp::BitXor, e1, e2) => {
+            check_exprs(typing, "div", &[it(), it()], &it(), &[e1.clone(), e2.clone()])
+        }
+        ExprX::Binary(BinaryOp::BitAnd, e1, e2) => {
+            check_exprs(typing, "mod", &[it(), it()], &it(), &[e1.clone(), e2.clone()])
+        }
+        ExprX::Binary(BinaryOp::BitOr, e1, e2) => {
+            check_exprs(typing, "div", &[it(), it()], &it(), &[e1.clone(), e2.clone()])
+        }
+        ExprX::Binary(BinaryOp::Shr, e1, e2) => {
+            check_exprs(typing, "mod", &[it(), it()], &it(), &[e1.clone(), e2.clone()])
+        }
+        ExprX::Binary(BinaryOp::Shl, e1, e2) => {
+            check_exprs(typing, "mod", &[it(), it()], &it(), &[e1.clone(), e2.clone()])
+        }
         ExprX::Multi(op, exprs) => {
             let (x, t) = match op {
                 MultiOp::And => ("and", bt()),

--- a/source/air/src/typecheck.rs
+++ b/source/air/src/typecheck.rs
@@ -122,7 +122,6 @@ fn get_bv_width(et: &Typ) -> Result<u32, TypeError> {
     if let TypX::BitVec(size) = &**et {
         return Ok(*size);
     }
-    panic!("???{:?}", et);
     return Err("not a bit vector type".to_string());
 }
 
@@ -138,7 +137,7 @@ fn check_bv_exprs(
     let w0 = get_bv_width(&t0)?;
     let w1 = get_bv_width(&t1)?;
 
-    if w0 != w1 && w0 != 0 && w1 != 0 {
+    if w0 != w1 {
         return Err(format!(
                 "in call to {}, argument should have the same width", 
                 f_name));

--- a/source/air/src/typecheck.rs
+++ b/source/air/src/typecheck.rs
@@ -181,19 +181,19 @@ fn check_expr(typing: &mut Typing, expr: &Expr) -> Result<Typ, TypeError> {
             check_exprs(typing, "mod", &[it(), it()], &it(), &[e1.clone(), e2.clone()])
         }
         ExprX::Binary(BinaryOp::BitXor, e1, e2) => {
-            check_exprs(typing, "div", &[it(), it()], &it(), &[e1.clone(), e2.clone()])
+            check_exprs(typing, "^", &[it(), it()], &it(), &[e1.clone(), e2.clone()])
         }
         ExprX::Binary(BinaryOp::BitAnd, e1, e2) => {
-            check_exprs(typing, "mod", &[it(), it()], &it(), &[e1.clone(), e2.clone()])
+            check_exprs(typing, "&", &[it(), it()], &it(), &[e1.clone(), e2.clone()])
         }
         ExprX::Binary(BinaryOp::BitOr, e1, e2) => {
-            check_exprs(typing, "div", &[it(), it()], &it(), &[e1.clone(), e2.clone()])
+            check_exprs(typing, "|", &[it(), it()], &it(), &[e1.clone(), e2.clone()])
         }
         ExprX::Binary(BinaryOp::Shr, e1, e2) => {
-            check_exprs(typing, "mod", &[it(), it()], &it(), &[e1.clone(), e2.clone()])
+            check_exprs(typing, ">>", &[it(), it()], &it(), &[e1.clone(), e2.clone()])
         }
         ExprX::Binary(BinaryOp::Shl, e1, e2) => {
-            check_exprs(typing, "mod", &[it(), it()], &it(), &[e1.clone(), e2.clone()])
+            check_exprs(typing, "<<", &[it(), it()], &it(), &[e1.clone(), e2.clone()])
         }
         ExprX::Multi(op, exprs) => {
             let (x, t) = match op {

--- a/source/air/src/typecheck.rs
+++ b/source/air/src/typecheck.rs
@@ -125,12 +125,7 @@ fn get_bv_width(et: &Typ) -> Result<u32, TypeError> {
     return Err("not a bit vector type".to_string());
 }
 
-fn check_bv_exprs(
-    typing: &mut Typing,
-    f_name: &str,
-    exprs: &[Expr],
-    ) -> Result<Typ, TypeError> {
-
+fn check_bv_exprs(typing: &mut Typing, f_name: &str, exprs: &[Expr]) -> Result<Typ, TypeError> {
     let t0 = check_expr(typing, &exprs[0])?;
     let t1 = check_expr(typing, &exprs[1])?;
 
@@ -138,9 +133,7 @@ fn check_bv_exprs(
     let w1 = get_bv_width(&t1)?;
 
     if w0 != w1 {
-        return Err(format!(
-                "in call to {}, argument should have the same width", 
-                f_name));
+        return Err(format!("in call to {}, argument should have the same width", f_name));
     }
 
     return Ok(t0.clone());
@@ -225,7 +218,7 @@ fn check_expr(typing: &mut Typing, expr: &Expr) -> Result<Typ, TypeError> {
             check_bv_exprs(typing, "bvadd", &[e1.clone(), e2.clone()])
         }
         ExprX::Binary(BinaryOp::Shr, e1, e2) => {
-            check_bv_exprs(typing, ">>",&[e1.clone(), e2.clone()])
+            check_bv_exprs(typing, ">>", &[e1.clone(), e2.clone()])
         }
         ExprX::Binary(BinaryOp::Shl, e1, e2) => {
             check_bv_exprs(typing, "<<", &[e1.clone(), e2.clone()])

--- a/source/air/src/typecheck.rs
+++ b/source/air/src/typecheck.rs
@@ -180,10 +180,10 @@ fn check_expr(typing: &mut Typing, expr: &Expr) -> Result<Typ, TypeError> {
                 Ok(bt())
             } else {
                 Err(format!(
-                        "in equality, left expression has type {} and right expression has different type {}",
-                        typ_name(&t1),
-                        typ_name(&t2)
-                    ))
+                    "in equality, left expression has type {} and right expression has different type {}",
+                    typ_name(&t1),
+                    typ_name(&t2)
+                ))
             }
         }
         ExprX::Binary(BinaryOp::Le, e1, e2) => {

--- a/source/air/src/typecheck.rs
+++ b/source/air/src/typecheck.rs
@@ -150,8 +150,7 @@ fn check_expr(typing: &mut Typing, expr: &Expr) -> Result<Typ, TypeError> {
     let result = match &**expr {
         ExprX::Const(Constant::Bool(_)) => Ok(Arc::new(TypX::Bool)),
         ExprX::Const(Constant::Nat(_)) => Ok(Arc::new(TypX::Int)),
-        // we don't know the bit width just yet
-        // ExprX::Const(Constant::BitVec(_)) => Ok(Arc::new(TypX::BitVec(0))),
+        ExprX::Const(Constant::BitVec(_, width)) => Ok(Arc::new(TypX::BitVec(*width))),
         ExprX::Var(x) => match typing.get(x) {
             Some(DeclaredX::Var { typ, .. }) => Ok(typ.clone()),
             _ => Err(format!("use of undeclared variable {}", x)),

--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -75,6 +75,11 @@ pub fn assert_by(_: bool, _: ()) {
     unimplemented!();
 }
 
+#[proof]
+pub fn assert_bit_vector(_: bool) {
+    unimplemented!();
+}
+
 // Used internally by erase.rs
 #[spec]
 pub fn internal_arbitrary<A>(_: u64) -> A {

--- a/source/docs/bv_expriments/bv.py
+++ b/source/docs/bv_expriments/bv.py
@@ -49,6 +49,15 @@ def logical_right_shift_is_division():
     return LShR(x, shift) == (UDiv(x, (2 ** shift)));
 
 
+def and7_is_mod8():
+    x = BitVec("x", 32)
+    return (x & 7) == x % 8
+
+
+def left_shift_2_is_mul_4():
+    x = BitVec("x", 32)
+    return x << 2 == (x * 4)
+
 # def index_highest_one(x):
 #     y = extract(31, 30, x);
     
@@ -63,9 +72,11 @@ def logical_right_shift_is_division():
 # query = and_preserves_bound()
 # query = or_preserves_bound()
 # query = mask_with_ffff()
-query = left_shift_is_muliplication()
+# query = left_shift_is_muliplication()
 # query = left_shift_is_mul_if_no_overflow()
 # query = logical_right_shift_is_division()
+# query = and7_is_mod8()
+query = left_shift_2_is_mul_4()
 
 s = Solver()
 s.push()

--- a/source/docs/bv_expriments/bv.py
+++ b/source/docs/bv_expriments/bv.py
@@ -3,21 +3,28 @@ from z3 import *
 full_bits = 256
 base = (2 ** full_bits)
 
-# def bvadd():
-#     x = BitVec("x", full_bits)
-#     y = BitVec("y", full_bits)
-#     z = Concat(y, x) 
-#     # print(z.sort())
-#     x_ext = ZeroExt(full_bits, x)
-#     y_ext = ZeroExt(full_bits, y)
-#     return z == x_ext + y_ext * (2 ** full_bits)
+def bvadd():
+    x = BitVec("x", full_bits)
+    y = BitVec("y", full_bits)
+    z = Concat(y, x) 
+    # print(z.sort())
+    x_ext = ZeroExt(full_bits, x)
+    y_ext = ZeroExt(full_bits, y)
+    return z == x_ext + y_ext * (2 ** full_bits)
 
-def xor_bytes():
+def and_preserves_bound():
     x = BitVec("x", full_bits)
     y = BitVec("y", full_bits)
     return Implies(
             And(x < 256, y < 256),
             x & y < 256);
+
+def or_preserves_bound():
+    x = BitVec("x", full_bits)
+    y = BitVec("y", full_bits)
+    return Implies(
+            And(x < 256, y < 256),
+            x | y < 256);
 
 def mask_with_ffff():
     x = BitVec("x", full_bits)
@@ -26,20 +33,43 @@ def mask_with_ffff():
 def left_shift_is_muliplication():
     x = BitVec("x", full_bits)
     shift = 128
-    return x << shift == (x * (2 ** shift)) % base;
+    return x << shift == (x * (2 ** shift));# % base;
+
+def left_shift_is_mul_if_no_overflow():
+    x = BitVec("x", full_bits)
+    shift = BitVec("shift", full_bits)
+    return Implies(
+             BVMulNoOverflow(x, 2 ** shift, False),
+             x << shift == x * (2 ** shift));
 
 def logical_right_shift_is_division():
     x = BitVec("x", full_bits)
     shift = 128
     # logical right shift
-    return LShR(x, shift) == (UDiv(x, (2 ** shift))) % base;
+    return LShR(x, shift) == (UDiv(x, (2 ** shift)));
 
 
-query = logical_right_shift_is_division()
-prove(query)
+# def index_highest_one(x):
+#     y = extract(31, 30, x);
+    
+
+# def make_bound_with_highest_one():
+#     x = BitVec("x", full_bits)
+
+
+
+
+# query = bvadd()
+# query = and_preserves_bound()
+# query = or_preserves_bound()
+# query = mask_with_ffff()
+query = left_shift_is_muliplication()
+# query = left_shift_is_mul_if_no_overflow()
+# query = logical_right_shift_is_division()
 
 s = Solver()
 s.push()
 s.add(Not(query))
 print(s.sexpr(), end="")
 print("(check-sat)")
+print(s.check())

--- a/source/docs/bv_expriments/bv.py
+++ b/source/docs/bv_expriments/bv.py
@@ -1,0 +1,45 @@
+from z3 import *
+
+full_bits = 256
+base = (2 ** full_bits)
+
+# def bvadd():
+#     x = BitVec("x", full_bits)
+#     y = BitVec("y", full_bits)
+#     z = Concat(y, x) 
+#     # print(z.sort())
+#     x_ext = ZeroExt(full_bits, x)
+#     y_ext = ZeroExt(full_bits, y)
+#     return z == x_ext + y_ext * (2 ** full_bits)
+
+def xor_bytes():
+    x = BitVec("x", full_bits)
+    y = BitVec("y", full_bits)
+    return Implies(
+            And(x < 256, y < 256),
+            x & y < 256);
+
+def mask_with_ffff():
+    x = BitVec("x", full_bits)
+    return x & 0xFFFF < 0x10000;
+
+def left_shift_is_muliplication():
+    x = BitVec("x", full_bits)
+    shift = 128
+    return x << shift == (x * (2 ** shift)) % base;
+
+def logical_right_shift_is_division():
+    x = BitVec("x", full_bits)
+    shift = 128
+    # logical right shift
+    return LShR(x, shift) == (UDiv(x, (2 ** shift))) % base;
+
+
+query = logical_right_shift_is_division()
+prove(query)
+
+s = Solver()
+s.push()
+s.add(Not(query))
+print(s.sexpr(), end="")
+print("(check-sat)")

--- a/source/docs/bv_expriments/bv.py
+++ b/source/docs/bv_expriments/bv.py
@@ -50,7 +50,7 @@ def logical_right_shift_is_division():
 
 
 def and7_is_mod8():
-    x = BitVec("x", 32)
+    x = BitVec("x", 5)
     return (x & 7) == x % 8
 
 
@@ -77,9 +77,9 @@ def xor_clear():
 # query = left_shift_is_muliplication()
 # query = left_shift_is_mul_if_no_overflow()
 # query = logical_right_shift_is_division()
-# query = and7_is_mod8()
+query = and7_is_mod8()
 # query = left_shift_2_is_mul_4()
-query = xor_clear()
+# query = xor_clear()
 
 s = Solver()
 s.push()

--- a/source/docs/bv_expriments/bv.py
+++ b/source/docs/bv_expriments/bv.py
@@ -58,14 +58,16 @@ def left_shift_2_is_mul_4():
     x = BitVec("x", 32)
     return x << 2 == (x * 4)
 
+def xor_clear():
+    x = BitVec("x", 32)
+    return x ^ x == 0
+
 # def index_highest_one(x):
 #     y = extract(31, 30, x);
     
 
 # def make_bound_with_highest_one():
 #     x = BitVec("x", full_bits)
-
-
 
 
 # query = bvadd()
@@ -76,7 +78,8 @@ def left_shift_2_is_mul_4():
 # query = left_shift_is_mul_if_no_overflow()
 # query = logical_right_shift_is_division()
 # query = and7_is_mod8()
-query = left_shift_2_is_mul_4()
+# query = left_shift_2_is_mul_4()
+query = xor_clear()
 
 s = Solver()
 s.push()

--- a/source/docs/bv_expriments/bv_examples.dfy
+++ b/source/docs/bv_expriments/bv_examples.dfy
@@ -1,0 +1,360 @@
+module bv {
+
+  newtype uint8 = n: int | 0 <= n < 256
+
+  newtype uint16 = n: int | 0 <= n < 65536
+
+  newtype uint32 = n: int | 0 <= n < 4294967296
+
+  newtype uint64 = n: int | 0 <= n < 18446744073709551616
+
+  newtype int8 = n: int | -128 <= n < 128
+
+  newtype int16 = n: int | -32768 <= n < 32768
+
+  newtype int32 = n: int | -2147483648 <= n < 2147483648
+
+  newtype int64 = n: int | -9223372036854775808 <= n < 9223372036854775808
+
+  function {:opaque} U32(b:bv32) : uint32 { b as uint32 }
+  function {:opaque} B32(u:uint32) : bv32 { u as bv32 }
+  function {:opaque} U64(b:bv64) : uint64 { b as uint64 }
+  function {:opaque} B64(u:uint64) : bv64 { u as bv64 }
+
+  // 32 bits
+  function {:opaque} bit_and32(b0:bv32, b1:bv32) : bv32 
+    { b0 & b1 }
+
+  function {:opaque} bit_or32(b0:bv32, b1:bv32) : bv32 
+    { b0 | b1 }
+
+  function {:opaque} bit_mod32(b0:bv32, b1:bv32) : bv32 
+    requires b1 != 0;
+    { b0 % b1 }
+
+  function {:opaque} bit_xor32(b0:bv32, b1:bv32) : bv32 
+    { b0 ^ b1 }
+
+  function {:opaque} bit_lshift32(b0:bv32, b1:bv32) : bv32 
+    requires b1 <= 32;
+    { b0 << b1 }
+
+  function {:opaque} bit_rshift32(b0:bv32, b1:bv32) : bv32 
+    requires b1 <= 32;
+    { b0 >> b1 }
+
+  function {:opaque} bit_and_uint32(u0:uint32, u1:uint32) : uint32 
+  {
+    U32(bit_and32(B32(u0), B32(u1)))
+  }
+
+  function {:opaque} bit_or_uint32(u0:uint32, u1:uint32) : uint32 
+  {
+    U32(bit_or32(B32(u0), B32(u1)))
+  }
+
+  function {:opaque} bit_mod_uint32(u0:uint32, u1:uint32) : uint32 
+    requires u1 != 0;
+  {
+    reveal B32();
+    U32(bit_mod32(B32(u0), B32(u1)))
+  }
+
+  function {:opaque} bit_xor_uint32(u0:uint32, u1:uint32) : uint32 
+  {
+    U32(bit_xor32(B32(u0), B32(u1)))
+  }
+
+  function {:opaque} bit_lshift_uint32(u0:uint32, u1:uint32) : uint32 
+    requires u1 <= 32;
+  {
+    bv32_inequality(u1);
+    U32(bit_lshift32(B32(u0), B32(u1)))
+  }
+
+  function {:opaque} bit_rshift_uint32(u0:uint32, u1:uint32) : uint32 
+    requires u1 <= 32;
+  {
+    bv32_inequality(u1);
+    U32(bit_rshift32(B32(u0), B32(u1)))
+  }
+
+  // 64 bits
+  function {:opaque} bit_and64(b0:bv64, b1:bv64) : bv64 
+    { b0 & b1 }
+
+  function {:opaque} bit_or64(b0:bv64, b1:bv64) : bv64 
+    { b0 | b1 }
+
+  function {:opaque} bit_mod64(b0:bv64, b1:bv64) : bv64 
+    requires b1 != 0;
+    { b0 % b1 }
+
+  function {:opaque} bit_xor64(b0:bv64, b1:bv64) : bv64 
+    { b0 ^ b1 }
+
+  function {:opaque} bit_lshift64(b0:bv64, b1:bv64) : bv64 
+    requires b1 <= 64;
+    { b0 << b1 }
+
+  function {:opaque} bit_rshift64(b0:bv64, b1:bv64) : bv64 
+    requires b1 <= 64;
+    { b0 >> b1 }
+
+  function {:opaque} bit_and_uint64(u0:uint64, u1:uint64) : uint64 
+  {
+    U64(bit_and64(B64(u0), B64(u1)))
+  }
+
+  function {:opaque} bit_or_uint64(u0:uint64, u1:uint64) : uint64 
+  {
+    U64(bit_or64(B64(u0), B64(u1)))
+  }
+
+  function {:opaque} bit_mod_uint64(u0:uint64, u1:uint64) : uint64 
+    requires u1 != 0;
+  {
+    reveal B64();
+    U64(bit_mod64(B64(u0), B64(u1)))
+  }
+
+  function {:opaque} bit_xor_uint64(u0:uint64, u1:uint64) : uint64 
+  {
+    U64(bit_xor64(B64(u0), B64(u1)))
+  }
+
+  function {:opaque} bit_lshift_uint64(u0:uint64, u1:uint64) : uint64 
+    requires u1 <= 64;
+  {
+    bv64_inequality(u1);
+    U64(bit_lshift64(B64(u0), B64(u1)))
+  }
+
+  function {:opaque} bit_rshift_uint64(u0:uint64, u1:uint64) : uint64 
+    requires u1 <= 64;
+  {
+    bv64_inequality(u1);
+    U64(bit_rshift64(B64(u0), B64(u1)))
+  }
+
+  lemma {:axiom} bv_core_properties()
+    ensures forall u:uint32 :: U32(B32(u)) == u;
+    ensures forall b:bv32 :: B32(U32(b)) == b;
+    ensures forall x:uint32, m:uint32 :: 
+                   m != 0 && B32(m) != 0 ==> (x % m) == U32(bit_mod32(B32(x), B32(m)));
+    ensures forall u:uint64 :: U64(B64(u)) == u;
+    ensures forall b:bv64 :: B64(U64(b)) == b;
+    ensures forall x:uint64, m:uint64 :: 
+                   m != 0 && B64(m) != 0 ==> (x % m) == U64(bit_mod64(B64(x), B64(m)));
+  
+  // 32 bits
+  lemma B32_injective(u0:uint32, u1:uint32)
+    ensures u0 == u1 <==> B32(u0) == B32(u1);
+  {
+    bv_core_properties();
+    assert u0 == u1 ==> B32(u0) == B32(u1);
+    var b0 := B32(u0);
+    var b1 := B32(u1);
+    assert b0 == b1 ==> U32(b0) == U32(b1);
+  }
+  
+  lemma U32_injective(b0:bv32, b1:bv32)
+    ensures b0 == b1 <==> U32(b0) == U32(b1);
+  {
+    bv_core_properties();
+    assert b0 == b1 ==> U32(b0) == U32(b1);
+    var u0 := U32(b0);
+    var u1 := U32(b1);
+    assert u0 == u1 ==> B32(u0) == B32(u1);
+  }
+
+  lemma bv32_injectivity()
+    ensures forall u0:uint32, u1:uint32 :: u0 == u1 <==> B32(u0) == B32(u1)
+    ensures forall b0, b1 :: b0 == b1 <==> U32(b0) == U32(b1)
+  {
+    reveal B32(); // Without this, Dafny can't seem to translate the forall statement to the forall expression
+    reveal U32(); // Without this, Dafny can't seem to translate the forall statement to the forall expression
+    forall u0:uint32, u1:uint32 ensures u0 == u1 <==> B32(u0) == B32(u1) { B32_injective(u0, u1); }
+    forall b0, b1 ensures b0 == b1 <==> U32(b0) == U32(b1) { U32_injective(b0, b1); }
+  }
+
+  lemma bv32_inequality(u:uint32)
+    requires u <= 32;
+    ensures  B32(u) <= 32;
+  {
+    reveal B32();
+    reveal U32();
+    bv_core_properties();
+    bv32_injectivity();
+  }
+
+  // 64 bits
+  lemma B64_injective(u0:uint64, u1:uint64)
+    ensures u0 == u1 <==> B64(u0) == B64(u1);
+  {
+    bv_core_properties();
+    assert u0 == u1 ==> B64(u0) == B64(u1);
+    var b0 := B64(u0);
+    var b1 := B64(u1);
+    assert b0 == b1 ==> U64(b0) == U64(b1);
+  }
+  
+  lemma U64_injective(b0:bv64, b1:bv64)
+    ensures b0 == b1 <==> U64(b0) == U64(b1);
+  {
+    bv_core_properties();
+    assert b0 == b1 ==> U64(b0) == U64(b1);
+    var u0 := U64(b0);
+    var u1 := U64(b1);
+    assert u0 == u1 ==> B64(u0) == B64(u1);
+  }
+
+  lemma bv64_injectivity()
+    ensures forall u0:uint64, u1:uint64 :: u0 == u1 <==> B64(u0) == B64(u1)
+    ensures forall b0, b1 :: b0 == b1 <==> U64(b0) == U64(b1)
+  {
+    reveal B64(); // Without this, Dafny can't seem to translate the forall statement to the forall expression
+    reveal U64(); // Without this, Dafny can't seem to translate the forall statement to the forall expression
+    forall u0:uint64, u1:uint64 ensures u0 == u1 <==> B64(u0) == B64(u1) { B64_injective(u0, u1); }
+    forall b0, b1 ensures b0 == b1 <==> U64(b0) == U64(b1) { U64_injective(b0, b1); }
+  }
+
+  lemma bv64_inequality(u:uint64)
+    requires u <= 64;
+    ensures  B64(u) <= 64;
+  {
+    reveal B64();
+    reveal U64();
+    bv_core_properties();
+    bv64_injectivity();
+  }
+
+
+  // Example uses
+  lemma bv_test(b:bv64)
+    //ensures bit_and64(b, 0) == 0;
+    //ensures bit_and64(b, 0xFFFFFFFFFFFFFFFF) == b
+    ensures bit_xor64(b, 0) == b;
+  {
+    //reveal bit_and64();
+    var all_ones:bv64 := 0xFFFFFFFFFFFFFFFF; 
+    //assert bit_and64(b, all_ones) == b;
+    reveal_bit_xor64();
+  }
+  
+  lemma bv64_properties()
+    ensures forall u0:uint64 :: bit_and_uint64(u0, 0) == 0
+  {
+    reveal bit_and_uint64();  // Without this, Dafny can't seem to translate the forall statement to the forall expression
+    forall u0 ensures bit_and_uint64(u0, 0) == 0 { bv64_properties_specific(u0, 0); }
+  }
+
+  lemma bv64_properties_specific(u0:uint64, u1:uint64)
+    ensures bit_and_uint64(u0, 0) == 0
+    ensures bit_and_uint64(u0, u1) == bit_and_uint64(u1, u0)
+    ensures bit_xor_uint64(u0, u0) == 0 
+    ensures bit_xor_uint64(u0, u1) == bit_xor_uint64(u1, u0)
+  {
+    bv_core_properties(); reveal U64(); reveal B64();
+
+    var all_ones:uint64 := 0xFFFFFFFFFFFFFFFF; 
+    assert B64(0) == 0; // Help Z3 with constant conversion
+    assert B64(all_ones) == 0xFFFFFFFFFFFFFFFF; // Help Z3 with constant conversion
+
+    // AND
+    assert bit_and_uint64(u0, 0)  == 0 by { reveal bit_and_uint64(); reveal bit_and64(); }
+    assert bit_and_uint64(u0, all_ones)  == u0 by { reveal bit_and_uint64(); reveal bit_and64(); }
+    assert bit_and_uint64(u0, u1) == bit_and_uint64(u1, u0) by { reveal bit_and_uint64(); reveal bit_and64(); }
+
+    // OR
+    assert bit_or_uint64(u0, 0)  == u0 by { reveal bit_or_uint64(); reveal bit_or64(); }
+    assert bit_or_uint64(u0, all_ones)  == all_ones by { reveal bit_or_uint64(); reveal bit_or64(); }
+    assert bit_or_uint64(u0, u1) == bit_or_uint64(u1, u0) by { reveal bit_or_uint64(); reveal bit_or64(); }
+
+    // XOR
+    assert bit_xor_uint64(u0, u0) == 0 by { reveal bit_xor_uint64(); reveal bit_xor64(); }
+    assert bit_xor_uint64(u0, u1) == bit_xor_uint64(u1, u0) by { reveal bit_xor_uint64(); reveal bit_xor64(); }
+    assert bit_xor_uint64(u0, 0)  == u0 by { reveal bit_xor_uint64(); reveal bit_xor64(); }
+  }
+
+  lemma mask_equiv_bv_wrapped(y:bv32)
+    ensures bit_mod32(y, 512) == bit_and32(y, 511);
+  {
+    reveal bit_mod32();
+    reveal bit_and32();
+  }
+
+  lemma mask_equiv_wrapped(x:uint32)
+    ensures bit_mod_uint32(x, 512) == bit_and_uint32(x, 511);
+  {
+    assert B32(512) == 512 by { reveal B32(); }
+    assert B32(511) == 511 by { reveal B32(); }
+    calc {
+      bit_mod_uint32(x, 512);
+        { reveal bit_mod_uint32(); reveal B32(); }
+      U32(bit_mod32(B32(x), B32(512)));
+        { mask_equiv_bv_wrapped(B32(x)); assert bit_mod32(B32(x), 512) == bit_and32(B32(x), 511); }
+      U32(bit_and32(B32(x), B32(511)));
+        { reveal bit_and_uint32(); }
+      bit_and_uint32(x, 511);
+    }
+  }
+
+  lemma bit_mod_equiv(u0:uint32, u1:uint32)
+    requires u1 != 0;
+    ensures bit_mod_uint32(u0, u1) == u0 % u1;
+  {
+    reveal bit_mod_uint32();
+    bv_core_properties();
+    assert B32(u1) != 0 by { reveal B32(); }
+    assert bit_mod32(B32(u0), B32(u1)) >= 0;
+  }
+
+  lemma mask_equiv_specific(x:uint32)
+    ensures x % 512 == bit_and_uint32(x, 511);
+  {
+    calc {
+      x % 512;
+        { bit_mod_equiv(x, 512); }
+      bit_mod_uint32(x, 512);
+        { mask_equiv_wrapped(x); }
+      bit_and_uint32(x, 511);
+    }
+  }
+
+  lemma lemma_xor_bytes(x:uint32, y:uint32)
+    requires 0 <= x < 256;
+    requires 0 <= y < 256;
+    ensures bit_and_uint32(x, y) < 256;
+  {
+    assume false;
+  }
+
+  // (declare-fun y () (_ BitVec 32))
+  // (declare-fun x () (_ BitVec 32))
+  // (assert (not (=> (and (bvslt x #x00000100) (bvslt y #x00000100))
+  //          (bvslt (bvand x y) #x00000100))))
+
+  lemma mask_with_ffff(x:uint32)
+    ensures bit_and_uint32(x, 0xFFFF) < 0x10000;
+  {
+    assume false;
+  }
+
+// (declare-fun x () (_ BitVec 32))
+// (assert (not (bvslt (bvand x #x0000ffff) #x00010000)))
+// (check-sat)
+
+
+  lemma lemma_and_with_32_64_specific_premium(x:uint32)
+    // ensures bit_and_uint32(x, 32) > 0 ==> BEWordToBitSeq(x)[26] == 1;
+    // ensures bit_and_uint32(x, 64) > 0 ==> BEWordToBitSeq(x)[25] == 1;
+  {
+    assume false;
+  }
+
+  lemma left_shift_is_muliplication(x:uint32)
+    ensures bit_lshift_uint32(x, 8) == (x * 256) % 4294967296
+
+
+}

--- a/source/docs/bv_expriments/bv_examples.rs
+++ b/source/docs/bv_expriments/bv_examples.rs
@@ -2,48 +2,52 @@ use builtin::*;
 mod pervasive;
 use pervasive::*;
 
-pub fn concat64() ->  {
-    unimplemented!();
-}
+// pub fn concat64() ->  {
+//     unimplemented!();
+// }
 
-#[spec]
-fn modulo_8(i: int) -> int {
-	i % 8
-}
+// #[spec]
+// fn modulo_8(i: int) -> int {
+// 	i % 8
+// }
 
 #[exec]
+// #[verifier(bit_vector)]
 fn and_7(b: u32) -> u32 {
-	ensures(|ret: u32| ret == modulo_8(b));
-	b & 7
-}
-
-#[exec]
-fn bv128_to_u64(b: bv128) -> (u64, u64){
-   let lower_mask:bv128 = 0x00000000000000001111111111111111;
-   let u1:u64 = ((b >> 64) & lower_mask) as u64 ;
-   let u2:u64 = (b & lower_mask) as u64;
-   (u1, u2)
-}
- 
-// gets two u64 and returns one bv128  "concat"
-#[exec]
-fn u64_to_bv128(u1:u64, u2:u64) -> bv128{
-   let b:bv128 = 0;
-   let b1 = u1 as bv128;
-   let b2 = u2 as bv128;
-   b = b | b1 | (b2 << 64);
+	// ensures(|ret: u32| ret == b + 1);
+   assert_bit_vector(true);
+	// let mut c: u32 = b + 1;
+   // c = c * 1;
    b
 }
+
+// #[exec]
+// fn bv128_to_u64(b: bv128) -> (u64, u64){
+//    let lower_mask:bv128 = 0x00000000000000001111111111111111;
+//    let u1:u64 = ((b >> 64) & lower_mask) as u64 ;
+//    let u2:u64 = (b & lower_mask) as u64;
+//    (u1, u2)
+// }
  
-#[proof]
-fn concat_and_split(u1:u64, u2:u64){
-   ensures(bv128_to_u64(u64_to_bv128(u1,u2)) == (u1,u2));
-}
+// // gets two u64 and returns one bv128  "concat"
+// #[exec]
+// fn u64_to_bv128(u1:u64, u2:u64) -> bv128{
+//    let b:bv128 = 0;
+//    let b1 = u1 as bv128;
+//    let b2 = u2 as bv128;
+//    b = b | b1 | (b2 << 64);
+//    b
+// }
  
-#[proof]
-fn split_property(u1:u64, u2:u64){
-   ensures(bv2int(u64_to_bv128(u1,u2)) == (u1 as int) * 0x10000000000000000 + (u2 as int));
-}
+// #[proof]
+// fn concat_and_split(u1:u64, u2:u64){
+//    ensures(bv128_to_u64(u64_to_bv128(u1,u2)) == (u1,u2));
+// }
+ 
+// #[proof]
+// fn split_property(u1:u64, u2:u64){
+//    ensures(bv2int(u64_to_bv128(u1,u2)) == (u1 as int) * 0x10000000000000000 + (u2 as int));
+// }
 
 
 

--- a/source/docs/bv_expriments/bv_examples.rs
+++ b/source/docs/bv_expriments/bv_examples.rs
@@ -1,0 +1,50 @@
+use builtin::*;
+mod pervasive;
+use pervasive::*;
+
+pub fn concat64() ->  {
+    unimplemented!();
+}
+
+#[spec]
+fn modulo_8(i: int) -> int {
+	i % 8
+}
+
+#[exec]
+fn and_7(b: u32) -> u32 {
+	ensures(|ret: u32| ret == modulo_8(b));
+	b & 7
+}
+
+#[exec]
+fn bv128_to_u64(b: bv128) -> (u64, u64){
+   let lower_mask:bv128 = 0x00000000000000001111111111111111;
+   let u1:u64 = ((b >> 64) & lower_mask) as u64 ;
+   let u2:u64 = (b & lower_mask) as u64;
+   (u1, u2)
+}
+ 
+// gets two u64 and returns one bv128  "concat"
+#[exec]
+fn u64_to_bv128(u1:u64, u2:u64) -> bv128{
+   let b:bv128 = 0;
+   let b1 = u1 as bv128;
+   let b2 = u2 as bv128;
+   b = b | b1 | (b2 << 64);
+   b
+}
+ 
+#[proof]
+fn concat_and_split(u1:u64, u2:u64){
+   ensures(bv128_to_u64(u64_to_bv128(u1,u2)) == (u1,u2));
+}
+ 
+#[proof]
+fn split_property(u1:u64, u2:u64){
+   ensures(bv2int(u64_to_bv128(u1,u2)) == (u1 as int) * 0x10000000000000000 + (u2 as int));
+}
+
+
+
+fn main() { }

--- a/source/docs/bv_expriments/bv_examples.rs
+++ b/source/docs/bv_expriments/bv_examples.rs
@@ -13,10 +13,12 @@ use pervasive::*;
 
 #[exec]
 // #[verifier(bit_vector)]
-fn and_7(b: u32) -> u32 {
+fn and_7(b: u32, c: u32) -> u32 {
    requires(b > 0);
 	// ensures(|ret: u32| ret == b + 1);
-   assert_bit_vector(b == b);
+   // assert_bit_vector(b & 7 == b % 8);
+   assert_bit_vector(b + c == c + b);
+   // assert(b + 1 == 1 + b);
 	// let mut c: u32 = b + 1;
    // c = c * 1;
    b + 1

--- a/source/docs/bv_expriments/bv_examples.rs
+++ b/source/docs/bv_expriments/bv_examples.rs
@@ -14,11 +14,12 @@ use pervasive::*;
 #[exec]
 // #[verifier(bit_vector)]
 fn and_7(b: u32) -> u32 {
+   requires(b > 0);
 	// ensures(|ret: u32| ret == b + 1);
-   assert_bit_vector(true);
+   assert_bit_vector(b == b);
 	// let mut c: u32 = b + 1;
    // c = c * 1;
-   b
+   b + 1
 }
 
 // #[exec]

--- a/source/docs/bv_expriments/bv_examples.rs
+++ b/source/docs/bv_expriments/bv_examples.rs
@@ -17,7 +17,8 @@ fn and_7(b: u32, c: u32) -> u32 {
    requires(b > 0);
 	// ensures(|ret: u32| ret == b + 1);
    // assert_bit_vector(b & 7 == b % 8);
-   assert_bit_vector(b + c == c + b);
+   // assert_bit_vector(b + c == c + b);
+   assert_bit_vector(b ^ b == 0);
    // assert(b + 1 == 1 + b);
 	// let mut c: u32 = b + 1;
    // c = c * 1;

--- a/source/docs/bv_expriments/bv_examples.rs
+++ b/source/docs/bv_expriments/bv_examples.rs
@@ -19,6 +19,7 @@ fn and_7(b: u32, c: u32) -> u32 {
    // assert_bit_vector(b & 7 == b % 8);
    // assert_bit_vector(b + c == c + b);
    assert_bit_vector(b ^ b == 0);
+   assert(b ^ b == 0);
    // assert(b + 1 == 1 + b);
 	// let mut c: u32 = b + 1;
    // c = c * 1;

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -372,7 +372,6 @@ pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, V
         autoview: false,
         custom_req_err: None,
         bit_vector: false,
-
     };
     for attr in parse_attrs(attrs)? {
         match attr {

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -207,7 +207,7 @@ pub(crate) enum Attr {
     Trigger(Option<Vec<u64>>),
     // custom error string to report for precondition failures
     CustomReqErr(String),
-    // verify using bitvector theory, not converting back and forth with integer
+    // verify using bitvector theory
     BitVector,
 }
 

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -176,6 +176,8 @@ pub(crate) enum Attr {
     Trigger(Option<Vec<u64>>),
     // custom error string to report for precondition failures
     CustomReqErr(String),
+    // verify using bitvector theory, not converting back and forth with integer
+    BitVector,
 }
 
 fn get_trigger_arg(span: Span, attr_tree: &AttrTree) -> Result<u64, VirErr> {
@@ -231,6 +233,9 @@ pub(crate) fn parse_attrs(attrs: &[Attribute]) -> Result<Vec<Attr>, VirErr> {
                     if arg == "custom_req_err" =>
                 {
                     v.push(Attr::CustomReqErr(msg.clone()))
+                }
+                Some(box [AttrTree::Fun(_, arg, None)]) if arg == "bit_vector" => {
+                    v.push(Attr::BitVector)
                 }
                 _ => return err_span_str(span, "unrecognized verifier attribute"),
             },
@@ -294,6 +299,7 @@ pub(crate) struct VerifierAttrs {
     pub(crate) is_abstract: bool,
     pub(crate) export_as_global_forall: bool,
     pub(crate) custom_req_err: Option<String>,
+    pub(crate) bit_vector: bool,
 }
 
 pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, VirErr> {
@@ -303,6 +309,8 @@ pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, V
         is_abstract: false,
         export_as_global_forall: false,
         custom_req_err: None,
+        bit_vector: false,
+
     };
     for attr in parse_attrs(attrs)? {
         match attr {
@@ -311,6 +319,7 @@ pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, V
             Attr::Abstract => vs.is_abstract = true,
             Attr::ExportAsGlobalForall => vs.export_as_global_forall = true,
             Attr::CustomReqErr(s) => vs.custom_req_err = Some(s.clone()),
+            Attr::BitVector => vs.bit_vector = true,
             _ => {}
         }
     }

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -336,7 +336,7 @@ fn fn_call_to_vir<'tcx>(
         &bctx.ctxt,
         fn_span,
         &name,
-        is_spec || is_quant || is_directive || is_assert_by || is_choose,
+        is_spec || is_quant || is_directive || is_assert_by || is_choose || is_assert_bit_vector,
         is_implies,
     );
 

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -305,6 +305,7 @@ fn fn_call_to_vir<'tcx>(
     let is_reveal_fuel = f_name == "builtin::reveal_with_fuel";
     let is_implies = f_name == "builtin::imply";
     let is_assert_by = f_name == "builtin::assert_by";
+    let is_assert_bit_vector = f_name == "builtin::assert_bit_vector";
     let is_eq = f_name == "core::cmp::PartialEq::eq";
     let is_ne = f_name == "core::cmp::PartialEq::ne";
     let is_le = f_name == "core::cmp::PartialOrd::le";
@@ -408,6 +409,11 @@ fn fn_call_to_vir<'tcx>(
         let ensure = expr_to_vir(bctx, &args[0])?;
         let proof = expr_to_vir(bctx, &args[1])?;
         return Ok(mk_expr(ExprX::Forall { vars, require, ensure, proof }));
+    }
+
+    if is_assert_bit_vector {
+        let expr = expr_to_vir(bctx, &args[0])?;
+        return Ok(mk_expr(ExprX::AssertBV(expr)));
     }
 
     let mut vir_args = vec_map_result(&args, |arg| expr_to_vir(bctx, arg))?;

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -888,6 +888,11 @@ pub(crate) fn expr_to_vir_inner<'tcx>(
                 BinOpKind::Mul => BinaryOp::Mul,
                 BinOpKind::Div => BinaryOp::EuclideanDiv,
                 BinOpKind::Rem => BinaryOp::EuclideanMod,
+                BinOpKind::BitXor => BinaryOp::BitXor,
+                BinOpKind::BitAnd => BinaryOp::BitAnd,
+                BinOpKind::BitOr => BinaryOp::BitOr,
+                BinOpKind::Shr => BinaryOp::Shr,
+                BinOpKind::Shl => BinaryOp::Shl,
                 _ => unsupported_err!(expr.span, format!("binary operator {:?}", op)),
             };
             let e = mk_expr(ExprX::Binary(vop, vlhs, vrhs));

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -256,6 +256,7 @@ pub(crate) fn check_item_fn<'tcx>(
         custom_req_err: vattrs.custom_req_err,
         no_auto_trigger: false,
         export_as_global_forall: vattrs.export_as_global_forall,
+        bit_vector: vattrs.bit_vector,
     };
     let func = FunctionX {
         name,

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -162,6 +162,12 @@ pub enum BinaryOp {
     EuclideanDiv,
     /// IntRange::Int % defined as Euclidean (returns non-negative result even for negative divisor)
     EuclideanMod,
+    // bit vector Ops
+    BitXor,
+    BitAnd,
+    BitOr,
+    Shr,
+    Shl,
 }
 
 /// Ghost annotations on functions and while loops; must appear at the beginning of function body

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -162,7 +162,7 @@ pub enum BinaryOp {
     EuclideanDiv,
     /// IntRange::Int % defined as Euclidean (returns non-negative result even for negative divisor)
     EuclideanMod,
-    // bit vector Ops
+    /// Bit Vector Operators
     BitXor,
     BitAnd,
     BitOr,
@@ -342,6 +342,8 @@ pub struct FunctionAttrsX {
     pub no_auto_trigger: bool,
     /// Custom error message to display when a pre-condition fails
     pub custom_req_err: Option<String>,
+    /// Verify using bit vector theory, not converting back and forth with integer
+    pub bit_vector: bool,
 }
 
 /// Static function identifier

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -348,7 +348,7 @@ pub struct FunctionAttrsX {
     pub custom_req_err: Option<String>,
     /// coerce f(e, ...) to f(e.view(), ...)
     pub autoview: bool,
-    /// Verify using bit vector theory, not converting back and forth with integer
+    /// Verify using bitvector theory
     pub bit_vector: bool,
 }
 

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -287,6 +287,8 @@ pub enum ExprX {
     Admit,
     /// Forall or assert-by statement; proves "forall vars. ensure" via proof.
     Forall { vars: Binders<Typ>, require: Expr, ensure: Expr, proof: Expr },
+    /// bit vector assertions
+    AssertBV(Expr),
     /// If-else
     If(Expr, Expr, Option<Expr>),
     /// Match (Note: ast_simplify replaces Match with other expressions)

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -593,7 +593,9 @@ pub(crate) fn expr_to_stm_opt(
             Ok((stms, None))
         }
         ExprX::AssertBV(e) => {
-            panic!("NYI")
+            let expr = expr_to_exp_state(ctx, state, &e)?;
+            let assert = Spanned::new(e.span.clone(), StmX::BVAssert(expr));
+            Ok((vec![assert], None))
         }
         ExprX::If(e0, e1, None) => {
             let (mut stms0, e0) = expr_to_stm(ctx, state, e0)?;

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -594,7 +594,7 @@ pub(crate) fn expr_to_stm_opt(
         }
         ExprX::AssertBV(e) => {
             let expr = expr_to_exp_state(ctx, state, &e)?;
-            let assert = Spanned::new(e.span.clone(), StmX::BVAssert(expr));
+            let assert = Spanned::new(e.span.clone(), StmX::AssertBV(expr));
             Ok((vec![assert], None))
         }
         ExprX::If(e0, e1, None) => {

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -592,6 +592,9 @@ pub(crate) fn expr_to_stm_opt(
             stms.push(assume);
             Ok((stms, None))
         }
+        ExprX::AssertBV(e) => {
+            panic!("NYI")
+        }
         ExprX::If(e0, e1, None) => {
             let (mut stms0, e0) = expr_to_stm(ctx, state, e0)?;
             let stms1 = expr_to_one_stm(ctx, state, e1)?;

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -1,6 +1,7 @@
 use crate::ast::{
     BinaryOp, Constant, DatatypeX, Expr, ExprX, Fun, FunX, FunctionX, Ident, Idents, Mode, Param,
     Params, Path, PathX, SpannedTyped, Typ, TypX, Variant, Variants, VirErr, VirErrX, Visibility,
+    IntRange,
 };
 use crate::def::Spanned;
 use crate::util::vec_map;
@@ -52,6 +53,13 @@ pub fn types_equal(typ1: &Typ, typ2: &Typ) -> bool {
         (TypX::TypParam(x1), TypX::TypParam(x2)) => x1 == x2,
         _ => false,
     }
+}
+
+pub fn bitwidth_from_type(et: &Typ) -> Option<u32> {
+    if let TypX::Int(IntRange::U(size)) = &**et {
+        return Some(*size);
+    }
+    return None;
 }
 
 pub fn path_as_rust_name(path: &Path) -> String {

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -1,7 +1,7 @@
 use crate::ast::{
-    BinaryOp, Constant, DatatypeX, Expr, ExprX, Fun, FunX, FunctionX, Ident, Idents, Mode, Param,
-    Params, Path, PathX, SpannedTyped, Typ, TypX, Variant, Variants, VirErr, VirErrX, Visibility,
-    IntRange,
+    BinaryOp, Constant, DatatypeX, Expr, ExprX, Fun, FunX, FunctionX, Ident, Idents, IntRange,
+    Mode, Param, Params, Path, PathX, SpannedTyped, Typ, TypX, Variant, Variants, VirErr, VirErrX,
+    Visibility,
 };
 use crate::def::Spanned;
 use crate::util::vec_map;

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -201,6 +201,10 @@ where
             map.pop_scope();
             ExprX::Forall { vars: Arc::new(vars), require, ensure, proof }
         }
+        ExprX::AssertBV(e) => {
+            let expr1 = map_expr_visitor_env(e, map, env, fe, fs, ft)?;
+            ExprX::AssertBV(expr1)
+        }
         ExprX::If(e1, e2, e3) => {
             let expr1 = map_expr_visitor_env(e1, map, env, fe, fs, ft)?;
             let expr2 = map_expr_visitor_env(e2, map, env, fe, fs, ft)?;

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -102,6 +102,8 @@ pub const AS_TYPE: &str = "as_type";
 const CHECK_DECREASE_INT: &str = "check_decrease_int";
 const HEIGHT: &str = "height";
 
+pub const UINT_XOR: &str = "uintxor";
+
 // We assume that usize is at least ARCH_SIZE_MIN_BITS wide
 pub const ARCH_SIZE_MIN_BITS: u32 = 32;
 

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -370,7 +370,7 @@ pub fn func_decl_to_air(
                 decl_commands.push(Arc::new(CommandX::Global(axiom)));
             }
             if function.x.attrs.bit_vector {
-                // TODO: function level bitvector mode 
+                // TODO: function level bitvector mode
             }
         }
     }

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -367,6 +367,9 @@ pub fn func_decl_to_air(
                 let axiom = Arc::new(DeclX::Axiom(expr));
                 decl_commands.push(Arc::new(CommandX::Global(axiom)));
             }
+            if function.x.attrs.bit_vector {
+                //print!("hello bit vector attribute\n");
+            }
         }
     }
     Ok((Arc::new(decl_commands), Arc::new(check_commands)))

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -371,6 +371,7 @@ pub fn func_decl_to_air(
             }
             if function.x.attrs.bit_vector {
                 // TODO: function level bitvector mode
+                unimplemented!("function level bitvector mode");
             }
         }
     }

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -370,7 +370,7 @@ pub fn func_decl_to_air(
                 decl_commands.push(Arc::new(CommandX::Global(axiom)));
             }
             if function.x.attrs.bit_vector {
-                //print!("hello bit vector attribute\n");
+                // TODO: function level bitvector mode 
             }
         }
     }

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -254,7 +254,7 @@ fn check_expr(typing: &mut Typing, outer_mode: Mode, expr: &Expr) -> Result<Mode
             Ok(Mode::Proof)
         }
         ExprX::AssertBV(e) => {
-            check_expr_has_mode(typing, Mode::Proof, e, Mode::Proof)?;
+            check_expr_has_mode(typing, Mode::Spec, e, Mode::Spec)?;
             Ok(Mode::Proof)
         }
         ExprX::If(e1, e2, e3) => {

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -253,6 +253,10 @@ fn check_expr(typing: &mut Typing, outer_mode: Mode, expr: &Expr) -> Result<Mode
             typing.in_forall_stmt = in_forall_stmt;
             Ok(Mode::Proof)
         }
+        ExprX::AssertBV(e) => {
+            check_expr_has_mode(typing, Mode::Proof, e, Mode::Proof)?;
+            Ok(Mode::Proof)
+        }
         ExprX::If(e1, e2, e3) => {
             let mode1 = check_expr(typing, outer_mode, e1)?;
             typing.erasure_modes.condition_modes.push((expr.span.clone(), mode1));

--- a/source/vir/src/prelude.rs
+++ b/source/vir/src/prelude.rs
@@ -278,7 +278,8 @@ pub(crate) fn prelude_nodes() -> Vec<Node> {
             :pattern (([height] x))
         )))
 
-        // Bit Vector
+        // BitVector
+        // these are the uninterpreted integer versions
         (declare-fun [uint_xor] (Int Int) Int)
     )
 }

--- a/source/vir/src/prelude.rs
+++ b/source/vir/src/prelude.rs
@@ -46,6 +46,8 @@ pub(crate) fn prelude_nodes() -> Vec<Node> {
     let has_type = str_to_node(HAS_TYPE);
     let as_type = str_to_node(AS_TYPE);
 
+    let uint_xor = str_to_node(UINT_XOR);
+
     nodes_vec!(
         // Fuel
         (declare-sort [FuelId])
@@ -275,6 +277,9 @@ pub(crate) fn prelude_nodes() -> Vec<Node> {
             (<= 0 ([height] x))
             :pattern (([height] x))
         )))
+
+        // Bit Vector
+        (declare-fun [uint_xor] (Int Int) Int)
     )
 }
 

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -59,6 +59,7 @@ pub enum StmX {
     Call(Fun, Typs, Exps, Option<Dest>),
     // note: failed assertion reports Stm's span, plus an optional additional span
     Assert(Option<Span>, Exp),
+    BVAssert(Exp),
     Assume(Exp),
     Assign {
         lhs: UniqueIdent,

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -59,7 +59,7 @@ pub enum StmX {
     Call(Fun, Typs, Exps, Option<Dest>),
     // note: failed assertion reports Stm's span, plus an optional additional span
     Assert(Option<Span>, Exp),
-    BVAssert(Exp),
+    AssertBV(Exp),
     Assume(Exp),
     Assign {
         lhs: UniqueIdent,

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -580,7 +580,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
             }
             vec![Arc::new(StmtX::Assert(Arc::new(spans), air_expr))]
         }
-        StmX::BVAssert(expr) => {
+        StmX::AssertBV(expr) => {
             let spans: Vec<Span> = vec![stm.span.clone()];
             let local = state.local_bv_shared.clone();
             let (air_expr, _) = exp_to_bv_expr(&state, &expr, 0);

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -272,6 +272,11 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp) -> Expr {
                         BinaryOp::Mul => panic!("internal error"),
                         BinaryOp::EuclideanDiv => air::ast::BinaryOp::EuclideanDiv,
                         BinaryOp::EuclideanMod => air::ast::BinaryOp::EuclideanMod,
+                        BinaryOp::BitXor => air::ast::BinaryOp::BitXor,
+                        BinaryOp::BitAnd => air::ast::BinaryOp::BitAnd,
+                        BinaryOp::BitOr => air::ast::BinaryOp::BitOr,
+                        BinaryOp::Shr => air::ast::BinaryOp::Shr,
+                        BinaryOp::Shl => air::ast::BinaryOp::Shl,
                     };
                     ExprX::Binary(aop, lh, rh)
                 }

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -19,9 +19,9 @@ use air::ast::{
     MultiOp, Quant, QueryX, Span, Stmt, StmtX, Trigger, Triggers,
 };
 use air::ast_util::{
-    bool_typ, ident_apply, ident_binder, ident_typ, ident_var, int_typ, bv_typ, mk_and, mk_bind_expr,
-    mk_eq, mk_exists, mk_implies, mk_ite, mk_not, mk_or, str_apply, str_ident, str_typ, str_var,
-    string_var,
+    bool_typ, bv_typ, ident_apply, ident_binder, ident_typ, ident_var, int_typ, mk_and,
+    mk_bind_expr, mk_eq, mk_exists, mk_implies, mk_ite, mk_not, mk_or, str_apply, str_ident,
+    str_typ, str_var, string_var,
 };
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -71,8 +71,8 @@ pub fn bitwidth_from_type(typ: &Typ) -> Option<u32> {
             IntRange::U(width) => Some(*width),
             _ => None,
             // panic!("unhandled IntRange in bv type conversion"),
-       }
-       _ => None,
+        },
+        _ => None,
     }
 }
 
@@ -463,7 +463,10 @@ fn exp_to_bv_expr(state: &State, exp: &Exp, parent_width: u32) -> (Expr, u32) {
             assert!(parent_width != 0);
             // Nat constant will get an inferred bitwidth from the parent
             // the width is needed when printing bv constants
-            return (Arc::new(ExprX::Const(Constant::BitVec(s.clone(), parent_width))), parent_width);
+            return (
+                Arc::new(ExprX::Const(Constant::BitVec(s.clone(), parent_width))),
+                parent_width,
+            );
         }
         ExpX::Var(x) => {
             // look up the bitwidth of a variable
@@ -483,7 +486,7 @@ fn exp_to_bv_expr(state: &State, exp: &Exp, parent_width: u32) -> (Expr, u32) {
                 BinaryOp::BitXor => air::ast::BinaryOp::BitXor,
                 _ => panic!("unhandled bv binary operation {:?}", op),
             };
-            
+
             let (lh, lwidth) = exp_to_bv_expr(state, lhs, parent_width);
             if parent_width == 0 {
                 parent_width = lwidth;
@@ -860,8 +863,7 @@ pub fn body_stm_to_air(
 
         if let Some(width) = bitwidth_from_type(&decl.typ) {
             let typ = bv_typ(width);
-            local_bv_shared.
-            push(Arc::new(DeclX::Var(suffix_local_unique_id(&decl.ident), typ)));
+            local_bv_shared.push(Arc::new(DeclX::Var(suffix_local_unique_id(&decl.ident), typ)));
             local_bv_width.insert(suffix_local_unique_id(&decl.ident), width);
         }
     }

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -2,7 +2,7 @@ use crate::ast::{
     BinaryOp, Fun, Ident, Idents, IntRange, Mode, Params, Path, SpannedTyped, Typ, TypX, Typs,
     UnaryOp, UnaryOpr,
 };
-use crate::ast_util::{get_field, get_variant, bitwidth_from_type};
+use crate::ast_util::{bitwidth_from_type, get_field, get_variant};
 use crate::context::Ctx;
 use crate::def::{
     fun_to_string, path_to_string, prefix_box, prefix_ensures, prefix_fuel_id, prefix_requires,
@@ -270,7 +270,9 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp) -> Expr {
                     ExprX::Unary(air::ast::UnaryOp::Not, Arc::new(eq))
                 }
                 // here the bv operation is translated to the integer versions
-                BinaryOp::BitXor => ExprX::Apply(Arc::new(crate::def::UINT_XOR.to_string()), Arc::new(vec![lh, rh])),
+                BinaryOp::BitXor => {
+                    ExprX::Apply(Arc::new(crate::def::UINT_XOR.to_string()), Arc::new(vec![lh, rh]))
+                }
                 _ => {
                     let aop = match op {
                         BinaryOp::And => panic!("internal error"),

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -295,7 +295,7 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp) -> Expr {
                         BinaryOp::Mul => panic!("internal error"),
                         BinaryOp::EuclideanDiv => air::ast::BinaryOp::EuclideanDiv,
                         BinaryOp::EuclideanMod => air::ast::BinaryOp::EuclideanMod,
-                        BinaryOp::BitXor => air::ast::BinaryOp::BitXor,
+                        BinaryOp::BitXor => air::ast::BinaryOp::UintXor,
                         BinaryOp::BitAnd => air::ast::BinaryOp::BitAnd,
                         BinaryOp::BitOr => air::ast::BinaryOp::BitOr,
                         BinaryOp::Shr => air::ast::BinaryOp::Shr,
@@ -609,8 +609,8 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
             // this creates a separate query for the bv assertion
             let query = Arc::new(QueryX { local: Arc::new(local), assertion });
             state.commands.push(Arc::new(CommandX::CheckValid(query)));
-            // TODO: put in an assume in the original assert location?
-            vec![]
+
+            vec![Arc::new(StmtX::Assume(exp_to_expr(ctx, &expr)))]
         }
         StmX::Assume(expr) => {
             if ctx.debug {
@@ -878,7 +878,6 @@ pub fn body_stm_to_air(
             local_bv_width.insert(suffix_local_unique_id(&decl.ident), width);
         }
     }
-    println!("{:?}", local_bv_width);
 
     set_fuel(&mut local_shared, hidden);
 

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -280,6 +280,8 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp) -> Expr {
                     let eq = ExprX::Binary(air::ast::BinaryOp::Eq, lh, rh);
                     ExprX::Unary(air::ast::UnaryOp::Not, Arc::new(eq))
                 }
+                // here the bv operation is translated to the integer versions
+                BinaryOp::BitXor => ExprX::Apply(Arc::new(crate::def::UINT_XOR.to_string()), Arc::new(vec![lh, rh])),
                 _ => {
                     let aop = match op {
                         BinaryOp::And => panic!("internal error"),
@@ -296,8 +298,7 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp) -> Expr {
                         BinaryOp::Mul => panic!("internal error"),
                         BinaryOp::EuclideanDiv => air::ast::BinaryOp::EuclideanDiv,
                         BinaryOp::EuclideanMod => air::ast::BinaryOp::EuclideanMod,
-                        // here the bv operation is translated to the integer versions
-                        BinaryOp::BitXor => air::ast::BinaryOp::UintXor,
+                        BinaryOp::BitXor => panic!("internal error"),
                         _ => panic!("unhandled bv operation translation {:?}", op),
                     };
                     ExprX::Binary(aop, lh, rh)

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -446,51 +446,35 @@ fn one_stmt(stmts: Vec<Stmt>) -> Stmt {
 }
 
 // convert the sst expression into bv air expression
-fn exp_to_bv_expr(state: &State, exp: &Exp, parent_width: u32) -> (Expr, u32) {
-    let mut parent_width = parent_width;
-
+fn exp_to_bv_expr(state: &State, exp: &Exp) -> Expr {
     match &exp.x {
         ExpX::Const(crate::ast::Constant::Nat(s)) => {
-            assert!(parent_width != 0);
-            // Nat constant will get an inferred bitwidth from the parent.
-            // The width is needed when printing bv constants.
-            return (
-                Arc::new(ExprX::Const(Constant::BitVec(s.clone(), parent_width))),
-                parent_width,
-            );
+            if let Some(width) = bitwidth_from_type(&exp.typ) {
+                // The width is needed when printing bv constants.
+                return Arc::new(ExprX::Const(Constant::BitVec(s.clone(), width)));
+            }
+            panic!("internal error: unable to get width from constant of type {:?}", exp.typ);
         }
         ExpX::Var(x) => {
-            if let Some(width) = bitwidth_from_type(&exp.typ) {
-                return (string_var(&suffix_local_unique_id(x)), width);
-            } else {
-                panic!("internal error: unhandled var type in bv translation {:?}", exp.typ);
-            }
+            return string_var(&suffix_local_unique_id(x));
         }
         ExpX::Binary(op, lhs, rhs) => {
             let bop = match op {
-                BinaryOp::Eq(_) => {
-                    parent_width = 0;
-                    air::ast::BinaryOp::Eq
-                }
+                BinaryOp::Eq(_) => air::ast::BinaryOp::Eq,
                 BinaryOp::Add => air::ast::BinaryOp::BitAdd,
                 // here the bv operation is translated as it is
                 BinaryOp::BitXor => air::ast::BinaryOp::BitXor,
                 _ => panic!("unhandled bv binary operation {:?}", op),
             };
 
-            let (lh, lwidth) = exp_to_bv_expr(state, lhs, parent_width);
-            if parent_width == 0 {
-                parent_width = lwidth;
-            }
-            let (rh, rwidth) = exp_to_bv_expr(state, rhs, parent_width);
-            assert!(lwidth == rwidth);
-
-            return (Arc::new(ExprX::Binary(bop, lh, rh)), lwidth);
+            let lh = exp_to_bv_expr(state, lhs);
+            let rh = exp_to_bv_expr(state, rhs);
+            return Arc::new(ExprX::Binary(bop, lh, rh));
         }
         ExpX::Unary(op, exp) => {
             // remove Clip and use the underlying bv operation
-            if let UnaryOp::Clip(IntRange::U(width)) = op {
-                return exp_to_bv_expr(state, exp, *width);
+            if let UnaryOp::Clip(_) = op {
+                return exp_to_bv_expr(state, exp);
             } else {
                 panic!("unhandled bv unary operation {:?}", op);
             }
@@ -585,7 +569,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
         StmX::AssertBV(expr) => {
             let spans: Vec<Span> = vec![stm.span.clone()];
             let local = state.local_bv_shared.clone();
-            let (air_expr, _) = exp_to_bv_expr(&state, &expr, 0);
+            let air_expr = exp_to_bv_expr(&state, &expr);
             let assertion = Arc::new(StmtX::Assert(Arc::new(spans), air_expr));
             // this creates a separate query for the bv assertion
             let query = Arc::new(QueryX { local: Arc::new(local), assertion });

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -452,8 +452,8 @@ fn exp_to_bv_expr(state: &State, exp: &Exp, parent_width: u32) -> (Expr, u32) {
     match &exp.x {
         ExpX::Const(crate::ast::Constant::Nat(s)) => {
             assert!(parent_width != 0);
-            // Nat constant will get an inferred bitwidth from the parent
-            // the width is needed when printing bv constants
+            // Nat constant will get an inferred bitwidth from the parent.
+            // The width is needed when printing bv constants.
             return (
                 Arc::new(ExprX::Const(Constant::BitVec(s.clone(), parent_width))),
                 parent_width,

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -430,20 +430,6 @@ impl State {
         println!("{:?} {:?}", stm.span, aset);
         self.snap_map.push((stm.span.clone(), spos));
     }
-
-    // fn map_full_span(&mut self, stm: &Stm) {
-    //     let spos = SnapPos::Full(self.get_current_sid());
-    //     let aset = self.get_assigned_set(stm);
-    //     println!("{:?} {:?}", stm.span, aset);
-    //     self.snap_map.push((stm.span.clone(), spos));
-    // }
-
-    // fn map_end_span(&mut self, stm: &Stm) {
-    //     let spos = SnapPos::End(self.get_current_sid());
-    //     let aset = self.get_assigned_set(stm);
-    //     println!("{:?} {:?}", stm.span, aset);
-    //     self.snap_map.push((stm.span.clone(), spos));
-    // }
 }
 
 fn assume_var(span: &Span, x: &UniqueIdent, exp: &Exp) -> Stm {
@@ -539,6 +525,16 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
                 state.map_span(&stm, SpanKind::Full);
             }
             vec![Arc::new(StmtX::Assert(Arc::new(spans), air_expr))]
+        }
+        StmX::BVAssert(expr) => {
+            let spans: Vec<Span> = vec![stm.span.clone()];
+            let local = state.local_shared.clone();
+            let air_expr = exp_to_expr(ctx, &expr);
+            let assertion = Arc::new(StmtX::Assert(Arc::new(spans), air_expr));
+            let query = Arc::new(QueryX { local: Arc::new(local), assertion });
+            state.commands.push(Arc::new(CommandX::CheckValid(query)));
+            // vec![Arc::new(StmtX::Assert(Arc::new(spans), air_expr))]
+            vec![]
         }
         StmX::Assume(expr) => {
             if ctx.debug {

--- a/source/vir/src/sst_vars.rs
+++ b/source/vir/src/sst_vars.rs
@@ -32,7 +32,7 @@ pub(crate) fn stm_assign(
             }
             stm.clone()
         }
-        StmX::Call(..) | StmX::Assert(..) | StmX::Assume(_) | StmX::Fuel(..) => stm.clone(),
+        StmX::Call(..) | StmX::Assert(..) | StmX::BVAssert(..) | StmX::Assume(_) | StmX::Fuel(..) => stm.clone(),
         StmX::Assign { lhs, rhs: _, is_init } => {
             assigned.insert(lhs.clone());
             if !is_init {

--- a/source/vir/src/sst_vars.rs
+++ b/source/vir/src/sst_vars.rs
@@ -32,7 +32,11 @@ pub(crate) fn stm_assign(
             }
             stm.clone()
         }
-        StmX::Call(..) | StmX::Assert(..) | StmX::BVAssert(..) | StmX::Assume(_) | StmX::Fuel(..) => stm.clone(),
+        StmX::Call(..)
+        | StmX::Assert(..)
+        | StmX::BVAssert(..)
+        | StmX::Assume(_)
+        | StmX::Fuel(..) => stm.clone(),
         StmX::Assign { lhs, rhs: _, is_init } => {
             assigned.insert(lhs.clone());
             if !is_init {

--- a/source/vir/src/sst_vars.rs
+++ b/source/vir/src/sst_vars.rs
@@ -34,7 +34,7 @@ pub(crate) fn stm_assign(
         }
         StmX::Call(..)
         | StmX::Assert(..)
-        | StmX::BVAssert(..)
+        | StmX::AssertBV(..)
         | StmX::Assume(_)
         | StmX::Fuel(..) => stm.clone(),
         StmX::Assign { lhs, rhs: _, is_init } => {

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -156,7 +156,7 @@ where
         StmX::Assert(_, _) => f(stm),
         StmX::Assume(_) => f(stm),
         StmX::Assign { .. } => f(stm),
-        StmX::BVAssert { .. } => f(stm),
+        StmX::AssertBV { .. } => f(stm),
         StmX::Fuel(..) => f(stm),
         StmX::DeadEnd(s) => {
             let s = map_stm_visitor(s, f)?;
@@ -211,7 +211,7 @@ where
                 Spanned::new(span, StmX::Call(path.clone(), typs.clone(), exps, (*dest).clone()))
             }
             StmX::Assert(span2, exp) => Spanned::new(span, StmX::Assert(span2.clone(), f(exp))),
-            StmX::BVAssert(exp) => Spanned::new(span, StmX::BVAssert(f(exp))),
+            StmX::AssertBV(exp) => Spanned::new(span, StmX::AssertBV(f(exp))),
             StmX::Assume(exp) => Spanned::new(span, StmX::Assume(f(exp))),
             StmX::Assign { lhs, rhs, is_init } => {
                 let rhs = f(rhs);

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -156,6 +156,7 @@ where
         StmX::Assert(_, _) => f(stm),
         StmX::Assume(_) => f(stm),
         StmX::Assign { .. } => f(stm),
+        StmX::BVAssert { .. } => f(stm),
         StmX::Fuel(..) => f(stm),
         StmX::DeadEnd(s) => {
             let s = map_stm_visitor(s, f)?;
@@ -210,6 +211,7 @@ where
                 Spanned::new(span, StmX::Call(path.clone(), typs.clone(), exps, (*dest).clone()))
             }
             StmX::Assert(span2, exp) => Spanned::new(span, StmX::Assert(span2.clone(), f(exp))),
+            StmX::BVAssert(exp) => Spanned::new(span, StmX::BVAssert(f(exp))),
             StmX::Assume(exp) => Spanned::new(span, StmX::Assume(f(exp))),
             StmX::Assign { lhs, rhs, is_init } => {
                 let rhs = f(rhs);

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -73,6 +73,7 @@ fn check_trigger_expr(exp: &Exp, free_vars: &mut HashSet<Ident>) -> Result<(), V
                 }
                 Le | Ge | Lt | Gt => Ok(exp.clone()),
                 Add | Sub | Mul | EuclideanDiv | EuclideanMod => Ok(exp.clone()),
+                BitXor | BitAnd | BitOr | Shr | Shl => Ok(exp.clone()),
             }
         }
         ExpX::If(_, _, _) => err_str(&exp.span, "triggers cannot contain if/else"),

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -268,6 +268,7 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
             let depth = match op {
                 And | Or | Implies | Eq(_) => 0,
                 Ne | Le | Ge | Lt | Gt | Add | Sub | Mul | EuclideanDiv | EuclideanMod => 1,
+                BitXor | BitAnd | BitOr | Shr | Shl => 1,
             };
             let (_, term1) = gather_terms(ctxt, ctx, e1, depth);
             let (_, term2) = gather_terms(ctxt, ctx, e2, depth);

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -40,6 +40,9 @@ fn check_function(ctxt: &Ctxt, function: &Function) -> Result<(), VirErr> {
             );
         }
     }
+    if function.x.attrs.bit_vector {
+        // return error if function has a non-integer type, or function call (for our simple version)
+    }
     if let Some(body) = &function.x.body {
         map_expr_visitor(body, &mut |expr: &Expr| {
             match &expr.x {

--- a/tools/update-rust.sh
+++ b/tools/update-rust.sh
@@ -14,7 +14,7 @@ fi
 
 (
     cd rust
-    current_branch=`git name-rev --name-only HEAD`
+    current_branch=`git branch --show-current`
     if [ "$current_branch" != "verification" ]; then
         echo "ERROR: The verification branch is not checked out in the rust repository."
         echo "To continue, commit you changes and switch back to the verification branch in the rust repository."

--- a/tools/update-rust.sh
+++ b/tools/update-rust.sh
@@ -14,7 +14,7 @@ fi
 
 (
     cd rust
-    current_branch=`git branch --show-current`
+    current_branch=`git name-rev --name-only HEAD`
     if [ "$current_branch" != "verification" ]; then
         echo "ERROR: The verification branch is not checked out in the rust repository."
         echo "To continue, commit you changes and switch back to the verification branch in the rust repository."


### PR DESCRIPTION
`assert_bit_vector` is added as a primitive: a separate SMT query is made using bitvector theory, and a assume with integer theory is put in place of the original assertion. Currently only supports very limited bitvector operations, but can and will be expanded to a larger set.