### PR TITLE
tweaks to Error builder functions

### DIFF
--- a/source/air/src/errors.rs
+++ b/source/air/src/errors.rs
@@ -41,7 +41,7 @@ pub type Error = Arc<ErrorX>;
 // To build an error, use one of the constructors below:
 
 /// Basic error, with a message and a single span to be highlighted with ^^^^^^
-pub fn error_basic<S: Into<String>>(msg: S, span: &Span) -> Error {
+pub fn error<S: Into<String>>(msg: S, span: &Span) -> Error {
     return Arc::new(ErrorX { msg: msg.into(), spans: vec![span.clone()], labels: Vec::new() });
 }
 

--- a/source/air/src/errors.rs
+++ b/source/air/src/errors.rs
@@ -40,54 +40,49 @@ pub type Error = Arc<ErrorX>;
 
 // To build an error, use one of the constructors below:
 
-/// Basic error, with a message and a single span to be highlighted.
-pub fn error_str(span: &Span, msg: &str) -> Error {
-    return error_string(span, msg.to_string());
+/// Basic error, with a message and a single span to be highlighted with ^^^^^^
+pub fn error_basic<S: Into<String>>(msg: S, span: &Span) -> Error {
+    return Arc::new(ErrorX { msg: msg.into(), spans: vec![span.clone()], labels: Vec::new() });
 }
 
-/// Basic error, with a message and a single span to be highlighted.
-pub fn error_string(span: &Span, msg: String) -> Error {
-    return Arc::new(ErrorX { msg: msg, spans: vec![span.clone()], labels: Vec::new() });
-}
-
-/// Error with a message, a span to be highlighted, and a label for that span
-pub fn error_with_label(msg: String, span: &Span, label: String) -> Error {
+/// Error with a message, a span to be highlighted with ^^^^^^, and a label for that span
+pub fn error_with_label<S: Into<String>, T: Into<String>>(msg: S, span: &Span, label: T) -> Error {
     return Arc::new(ErrorX {
-        msg: msg,
+        msg: msg.into(),
         spans: vec![span.clone()],
-        labels: vec![ErrorLabel { span: span.clone(), msg: label }],
+        labels: vec![ErrorLabel { span: span.clone(), msg: label.into() }],
     });
 }
 
 // Add additional stuff with the "builders" below.
 
 impl ErrorX {
-    /// Add a new primary span
+    /// Add a new primary span (rendered with ^^^^^^)
     pub fn primary_span(&self, span: &Span) -> Error {
         let mut e = self.clone();
         e.spans.push(span.clone());
         Arc::new(e)
     }
 
-    /// Add a new primary span with a label
-    pub fn primary_label(&self, span: &Span, label: String) -> Error {
+    /// Add a new primary span with a label (rendered with ^^^^^^)
+    pub fn primary_label<S: Into<String>>(&self, span: &Span, label: S) -> Error {
         let mut e = self.clone();
         e.spans.push(span.clone());
-        e.labels.push(ErrorLabel { span: span.clone(), msg: label });
+        e.labels.push(ErrorLabel { span: span.clone(), msg: label.into() });
         Arc::new(e)
     }
 
-    /// Add a secondary_span to be highlighted, with no label
+    /// Add a secondary_span to be highlighted, with no label (rendered with ------)
     pub fn secondary_span(&self, span: &Span) -> Error {
         let mut e = self.clone();
         e.labels.push(ErrorLabel { span: span.clone(), msg: "".to_string() });
         Arc::new(e)
     }
 
-    /// Add a secondary_span to be highlighted, with a label
-    pub fn secondary_label(&self, span: &Span, label: String) -> Error {
+    /// Add a secondary_span to be highlighted, with a label (rendered with ------)
+    pub fn secondary_label<S: Into<String>>(&self, span: &Span, label: S) -> Error {
         let mut e = self.clone();
-        e.labels.push(ErrorLabel { span: span.clone(), msg: label });
+        e.labels.push(ErrorLabel { span: span.clone(), msg: label.into() });
         Arc::new(e)
     }
 

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -5,16 +5,19 @@ use crate::ast::{
 use crate::util::vec_map;
 use air::ast::{Binder, BinderX, Binders, Span};
 pub use air::ast_util::{ident_binder, str_ident};
-use air::errors::{error_str, error_string};
+use air::errors::error_basic;
 use std::fmt;
 use std::sync::Arc;
 
+/// Construct an Error and wrap it in Err.
+/// For more complex Error objects, use the builder functions in air::errors
+
 pub fn err_str<A>(span: &Span, msg: &str) -> Result<A, VirErr> {
-    Err(error_str(span, msg))
+    Err(error_basic(msg, span))
 }
 
 pub fn err_string<A>(span: &Span, msg: String) -> Result<A, VirErr> {
-    Err(error_string(span, msg))
+    Err(error_basic(msg, span))
 }
 
 impl PathX {

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -5,7 +5,7 @@ use crate::ast::{
 use crate::util::vec_map;
 use air::ast::{Binder, BinderX, Binders, Span};
 pub use air::ast_util::{ident_binder, str_ident};
-use air::errors::error_basic;
+use air::errors::error;
 use std::fmt;
 use std::sync::Arc;
 
@@ -13,11 +13,11 @@ use std::sync::Arc;
 /// For more complex Error objects, use the builder functions in air::errors
 
 pub fn err_str<A>(span: &Span, msg: &str) -> Result<A, VirErr> {
-    Err(error_basic(msg, span))
+    Err(error(msg, span))
 }
 
 pub fn err_string<A>(span: &Span, msg: String) -> Result<A, VirErr> {
-    Err(error_basic(msg, span))
+    Err(error(msg, span))
 }
 
 impl PathX {

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -18,7 +18,7 @@ use crate::sst_visitor::{
 use crate::util::vec_map_result;
 use air::ast::{Binder, Commands, Quant, Span};
 use air::ast_util::{ident_binder, str_ident, str_typ};
-use air::errors::error_str;
+use air::errors::error_basic;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -293,7 +293,7 @@ pub(crate) fn check_termination_exp(
         Ctxt { recursive_function_name: function.x.name.clone(), num_decreases, scc_rep, ctx };
     let check = terminates(&ctxt, &body)?;
     let (mut decls, mut stm_assigns) = mk_decreases_at_entry(&ctxt, &body.span, &decreases_exps);
-    let error = error_str(&body.span, "could not prove termination");
+    let error = error_basic("could not prove termination", &body.span);
     let stm_assert = Spanned::new(body.span.clone(), StmX::Assert(Some(error), check));
     stm_assigns.push(stm_assert);
     let stm_block = Spanned::new(body.span.clone(), StmX::Block(Arc::new(stm_assigns)));
@@ -354,7 +354,7 @@ pub(crate) fn check_termination_stm(
             if *x == function.x.name || ctx.func_call_graph.get_scc_rep(x) == ctxt.scc_rep =>
         {
             let check = check_decrease_call(&ctxt, &s.span, x, args)?;
-            let error = error_str(&s.span, "could not prove termination");
+            let error = error_basic("could not prove termination", &s.span);
             let stm_assert = Spanned::new(s.span.clone(), StmX::Assert(Some(error), check));
             let stm_block =
                 Spanned::new(s.span.clone(), StmX::Block(Arc::new(vec![stm_assert, s.clone()])));

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -18,7 +18,7 @@ use crate::sst_visitor::{
 use crate::util::vec_map_result;
 use air::ast::{Binder, Commands, Quant, Span};
 use air::ast_util::{ident_binder, str_ident, str_typ};
-use air::errors::error_basic;
+use air::errors::error;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -293,7 +293,7 @@ pub(crate) fn check_termination_exp(
         Ctxt { recursive_function_name: function.x.name.clone(), num_decreases, scc_rep, ctx };
     let check = terminates(&ctxt, &body)?;
     let (mut decls, mut stm_assigns) = mk_decreases_at_entry(&ctxt, &body.span, &decreases_exps);
-    let error = error_basic("could not prove termination", &body.span);
+    let error = error("could not prove termination", &body.span);
     let stm_assert = Spanned::new(body.span.clone(), StmX::Assert(Some(error), check));
     stm_assigns.push(stm_assert);
     let stm_block = Spanned::new(body.span.clone(), StmX::Block(Arc::new(stm_assigns)));
@@ -354,7 +354,7 @@ pub(crate) fn check_termination_stm(
             if *x == function.x.name || ctx.func_call_graph.get_scc_rep(x) == ctxt.scc_rep =>
         {
             let check = check_decrease_call(&ctxt, &s.span, x, args)?;
-            let error = error_basic("could not prove termination", &s.span);
+            let error = error("could not prove termination", &s.span);
             let stm_assert = Spanned::new(s.span.clone(), StmX::Assert(Some(error), check));
             let stm_block =
                 Spanned::new(s.span.clone(), StmX::Block(Arc::new(vec![stm_assert, s.clone()])));

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -23,7 +23,7 @@ use air::ast_util::{
     mk_eq, mk_exists, mk_implies, mk_ite, mk_not, mk_or, str_apply, str_ident, str_typ, str_var,
     string_var,
 };
-use air::errors::{error_basic, error_with_label};
+use air::errors::{error, error_with_label};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -483,7 +483,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
                     None => "precondition not satisfied".to_string(),
                     Some(s) => s.clone(),
                 };
-                let error = error_basic(description, &stm.span);
+                let error = error(description, &stm.span);
                 stmts.push(Arc::new(StmtX::Assert(error, e_req)));
             }
             let mut ens_args: Vec<Expr> = vec_map(typs, typ_to_id);
@@ -657,7 +657,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
                 local.push(Arc::new(DeclX::Axiom(inv.clone())));
             }
             for (span, inv) in invs.iter() {
-                let error = error_basic("invariant not satisfied at end of loop body", span);
+                let error = error("invariant not satisfied at end of loop body", span);
                 let inv_stmt = StmtX::Assert(error, inv.clone());
                 air_body.push(Arc::new(inv_stmt));
             }
@@ -680,7 +680,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
             // At original site of while loop, assert invariant, havoc, assume invariant + neg_cond
             let mut stmts: Vec<Stmt> = Vec::new();
             for (span, inv) in invs.iter() {
-                let error = error_basic("invariant not satisfied before loop", span);
+                let error = error("invariant not satisfied before loop", span);
                 let inv_stmt = StmtX::Assert(error, inv.clone());
                 stmts.push(Arc::new(inv_stmt));
             }
@@ -851,7 +851,7 @@ pub fn body_stm_to_air(
     let mut local = state.local_shared.clone();
 
     for ens in enss {
-        let error = error_basic("postcondition not satisfied", &ens.span);
+        let error = error("postcondition not satisfied", &ens.span);
         let ens_stmt = StmtX::Assert(error, exp_to_expr(ctx, ens));
         stmts.push(Arc::new(ens_stmt));
     }

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -23,7 +23,7 @@ use air::ast_util::{
     mk_eq, mk_exists, mk_implies, mk_ite, mk_not, mk_or, str_apply, str_ident, str_typ, str_var,
     string_var,
 };
-use air::errors::{error_str, error_string, error_with_label};
+use air::errors::{error_basic, error_with_label};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -483,7 +483,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
                     None => "precondition not satisfied".to_string(),
                     Some(s) => s.clone(),
                 };
-                let error = error_string(&stm.span, description);
+                let error = error_basic(description, &stm.span);
                 stmts.push(Arc::new(StmtX::Assert(error, e_req)));
             }
             let mut ens_args: Vec<Expr> = vec_map(typs, typ_to_id);
@@ -657,7 +657,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
                 local.push(Arc::new(DeclX::Axiom(inv.clone())));
             }
             for (span, inv) in invs.iter() {
-                let error = error_str(span, "invariant not satisfied at end of loop body");
+                let error = error_basic("invariant not satisfied at end of loop body", span);
                 let inv_stmt = StmtX::Assert(error, inv.clone());
                 air_body.push(Arc::new(inv_stmt));
             }
@@ -680,7 +680,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
             // At original site of while loop, assert invariant, havoc, assume invariant + neg_cond
             let mut stmts: Vec<Stmt> = Vec::new();
             for (span, inv) in invs.iter() {
-                let error = error_str(span, "invariant not satisfied before loop");
+                let error = error_basic("invariant not satisfied before loop", span);
                 let inv_stmt = StmtX::Assert(error, inv.clone());
                 stmts.push(Arc::new(inv_stmt));
             }
@@ -851,7 +851,7 @@ pub fn body_stm_to_air(
     let mut local = state.local_shared.clone();
 
     for ens in enss {
-        let error = error_str(&ens.span, "postcondition not satisfied");
+        let error = error_basic("postcondition not satisfied", &ens.span);
         let ens_stmt = StmtX::Assert(error, exp_to_expr(ctx, ens));
         stmts.push(Arc::new(ens_stmt));
     }


### PR DESCRIPTION
Just some small changes to the Error builder functions for consistency, and a bit more documentation. Also, use `Into<String>` (I was started to get annoyed having to type `to_string()` all the time or handle multiple method names.)