### PR TITLE
introduce atomic operations

### DIFF
--- a/source/pervasive/atomics.rs
+++ b/source/pervasive/atomics.rs
@@ -20,18 +20,12 @@ pub struct PermissionU32 {
 
 #[inline(always)]
 #[verifier(external_body)]
-fn new_atomic_u32_external(i: u32) -> PAtomicU32 {
-    ensures(|p: PAtomicU32| false);
-    return PAtomicU32 { ato: AtomicU32::new(i) };
-}
-
-#[inline(always)]
 pub fn new_atomic_u32(i: u32) -> (PAtomicU32, Proof<PermissionU32>) {
     ensures(|res : (PAtomicU32, Proof<PermissionU32>)|
         equal(res.1, proof(PermissionU32{ patomic: res.0.view(), value: i }))
     );
 
-    let p = new_atomic_u32_external(i);
+    let p = PAtomicU32 { ato: AtomicU32::new(i) };
     #[proof] let t = proof_from_false();
     (p, proof(t))
 }

--- a/source/pervasive/atomics.rs
+++ b/source/pervasive/atomics.rs
@@ -1,0 +1,95 @@
+use std::sync::atomic::{AtomicU32, Ordering};
+
+#[allow(unused_imports)] use builtin::*;
+#[allow(unused_imports)] use crate::pervasive::*;
+#[allow(unused_imports)] use crate::pervasive::modes::*;
+
+// TODO support all the different integer types
+
+#[verifier(external_body)]
+pub struct PAtomicU32 {
+    ato: AtomicU32,
+}
+
+#[proof]
+#[verifier(unforgeable)]
+pub struct PermissionU32 {
+    #[spec] pub patomic: int,
+    #[spec] pub value: u32,
+}
+
+#[inline(always)]
+#[verifier(external_body)]
+fn new_atomic_u32_external(i: u32) -> PAtomicU32 {
+    ensures(|p: PAtomicU32| false);
+    return PAtomicU32 { ato: AtomicU32::new(i) };
+}
+
+#[inline(always)]
+pub fn new_atomic_u32(i: u32) -> (PAtomicU32, Proof<PermissionU32>) {
+    ensures(|res : (PAtomicU32, Proof<PermissionU32>)|
+        equal(res.1, proof(PermissionU32{ patomic: res.0.view(), value: i }))
+    );
+
+    let p = new_atomic_u32_external(i);
+    #[proof] let t = proof_from_false();
+    (p, proof(t))
+}
+
+#[spec]
+pub fn wrapping_add_u32(a: int, b: int) -> int {
+    if a + b >= 0x100000000 {
+        a + b - 0x100000000
+    } else {
+        a + b
+    }
+}
+
+impl PermissionU32 {
+    #[spec]
+    fn is_for(&self, patomic: PAtomicU32) -> bool {
+        self.patomic == patomic.view()
+    }
+
+    #[spec]
+    fn points_to(&self, v: u32) -> bool {
+        self.value == v
+    }
+}
+
+impl PAtomicU32 {
+  #[verifier(pub_abstract)]
+  #[spec]
+  pub fn view(&self) -> int {
+    arbitrary()
+  }
+
+  #[inline(always)]
+  #[verifier(external_body)]
+  #[verifier(atomic)]
+  pub fn load(&self, #[proof] perm: &PermissionU32) -> u32 {
+    requires([
+        equal(self.view(), perm.patomic),
+    ]);
+    ensures(|ret: u32| equal(perm.value, ret));
+    opens_invariants_none();
+
+    return self.ato.load(Ordering::SeqCst);
+  }
+
+  #[inline(always)]
+  #[verifier(external_body)]
+  #[verifier(atomic)]
+  pub fn fetch_add(&self, #[proof] perm: &mut PermissionU32, n: u32) -> u32 {
+    requires([
+        equal(self.view(), old(perm).patomic),
+    ]);
+    ensures(|ret: u32| equal(old(perm).value, ret)
+        && perm.patomic == old(perm).patomic
+        && perm.value == wrapping_add_u32(old(perm).value, n)
+    );
+    opens_invariants_none();
+
+    return self.ato.fetch_add(n, Ordering::SeqCst);
+  }
+}

--- a/source/pervasive/mod.rs
+++ b/source/pervasive/mod.rs
@@ -7,6 +7,8 @@ pub mod set;
 pub mod set_lib;
 pub mod cell;
 pub mod invariants;
+pub mod atomics;
+pub mod modes;
 
 #[allow(unused_imports)]
 use builtin::*;

--- a/source/pervasive/modes.rs
+++ b/source/pervasive/modes.rs
@@ -1,0 +1,17 @@
+#[allow(unused_imports)] use builtin::*;
+#[allow(unused_imports)] use crate::pervasive::*;
+
+#[allow(non_camel_case_types)]
+
+pub enum Proof<V> {
+    proof(#[proof] V)
+}
+
+pub use Proof::proof;
+
+#[allow(non_camel_case_types)]
+
+pub enum Spec<V> {
+    spec(#[spec] V)
+}
+pub use Spec::spec;

--- a/source/rust_verify/example/atomics.rs
+++ b/source/rust_verify/example/atomics.rs
@@ -1,0 +1,26 @@
+#[allow(unused_imports)]
+use builtin::*;
+mod pervasive;
+use pervasive::*;
+use crate::pervasive::{invariants::*};
+use crate::pervasive::{atomics::*};
+
+#[verifier(atomic)]
+#[verifier(external_body)]
+fn atomic_op() {
+  opens_invariants_none();
+}
+
+#[verifier(external_body)]
+fn non_atomic_op() {
+  opens_invariants_none();
+}
+
+pub fn do_nothing(#[proof] i: Invariant<u8>) {
+  open_invariant!(&i => inner => {
+    atomic_op();
+    //atomic_op();
+  });
+}
+
+pub fn main() { }

--- a/source/rust_verify/example/og_counter.rs
+++ b/source/rust_verify/example/og_counter.rs
@@ -1,0 +1,182 @@
+#![allow(unused_mut)] // TODO remove this once Verus allows removing 'mut'
+
+#[allow(unused_imports)]
+use builtin::*;
+mod pervasive;
+use pervasive::*;
+use crate::pervasive::{invariants::*};
+use crate::pervasive::{atomics::*};
+use crate::pervasive::{modes::*};
+
+// LTS tokens (currently trusted)
+// TODO, once we have state machine infrastructure, we can auto-generate these
+
+#[proof]
+#[verifier(unforgeable)]
+pub struct Counter {
+  #[spec] counter: int,
+}
+
+#[proof]
+#[verifier(unforgeable)]
+pub struct IncA {
+  #[spec] done: bool,
+}
+
+#[proof]
+#[verifier(unforgeable)]
+pub struct IncB {
+  #[spec] done: bool,
+}
+
+#[proof]
+pub struct Init {
+  #[proof] pub counter: Counter,
+  #[proof] pub incA: IncA,
+  #[proof] pub incB: IncB,
+}
+
+impl Init {
+  #[spec]
+  pub fn valid(self) -> bool {
+      equal(self.counter.counter, 0)
+      && !self.incA.done
+      && !self.incB.done
+  }
+}
+
+#[proof]
+#[verifier(external_body)]
+#[verifier(returns(proof))]
+pub fn init_protocol() -> Init {
+  ensures(|init: Init| init.valid());
+
+  unimplemented!();
+}
+
+#[proof]
+#[verifier(external_body)]
+#[verifier(returns(proof))]
+pub fn do_inc_a(#[proof] counter: &mut Counter, #[proof] inc_a: &mut IncA) {
+  requires([
+    !old(inc_a).done,
+  ]);
+  ensures([
+    inc_a.done,
+    equal(counter.counter, old(counter).counter + 1),
+    counter.counter <= 2,
+  ]);
+
+  unimplemented!();
+}
+
+#[proof]
+#[verifier(external_body)]
+#[verifier(returns(proof))]
+pub fn do_inc_b(#[proof] counter: &mut Counter, #[proof] inc_b: &mut IncB) {
+  requires([
+    !old(inc_b).done,
+  ]);
+  ensures([
+    inc_b.done,
+    equal(counter.counter, old(counter).counter + 1),
+  ]);
+
+  unimplemented!();
+}
+
+#[proof]
+#[verifier(external_body)]
+#[verifier(returns(proof))]
+pub fn finish(#[proof] counter: &Counter, #[proof] inc_a: &IncA, #[proof] inc_b: &IncB) {
+  requires([
+    inc_a.done,
+    inc_b.done,
+  ]);
+  ensures([
+    equal(counter.counter, 2)
+  ]);
+
+  unimplemented!();
+}
+
+// Untrusted stuff starts here
+
+#[proof]
+pub struct G {
+  #[proof] pub counter: Counter,
+  #[proof] pub perm: PermissionU32,
+}
+
+impl G {
+  #[spec]
+  pub fn wf(self, patomic: PAtomicU32) -> bool {
+    equal(self.perm.patomic, patomic.view()) && equal(self.perm.value as int, self.counter.counter)
+  }
+}
+
+fn main() {
+  // Initialize protocol 
+
+  #[proof] let Init{
+       counter: mut counter_token,
+       incA: mut inc_a_token,
+       incB: mut inc_b_token} = init_protocol();
+
+  // Initialize the counter
+
+  let mut at;
+  #[proof] let mut perm_token;
+  match new_atomic_u32(0) {
+    (patomic, proof(token)) => {
+      at = patomic;
+      perm_token = token;
+    }
+  }
+
+  #[proof] let at_inv: Invariant<G> = invariant_new(
+      G { counter: counter_token, perm: perm_token },
+      |g: G| g.wf(at),
+      0);
+
+  // TODO actually run these on separate threads
+
+  // Thread 1 (gets access to inc_a_token)
+
+  open_invariant!(&at_inv => g => {
+    #[proof] let G { counter: mut c, perm: mut p } = g;
+
+    at.fetch_add(&mut p, 1);
+    do_inc_a(&mut c, &mut inc_a_token); // atomic increment
+
+    g = G { counter: c, perm: p };
+  });
+
+  // Thread 2 (gets access to inc_b_token)
+
+  open_invariant!(&at_inv => g => {
+    #[proof] let G { counter: mut c, perm: mut p } = g;
+
+    at.fetch_add(&mut p, 1);
+    do_inc_b(&mut c, &mut inc_b_token); // atomic increment
+
+    g = G { counter: c, perm: p };
+  });
+
+  // Join threads, load the atomic again
+
+  // Since we recovered exclusive control of the invariant, we could destruct it
+  // if we want to. Or we can just open the invariant block like normal.
+
+  let mut x;
+  open_invariant!(&at_inv => g => {
+    #[proof] let G { counter: mut c, perm: mut p } = g;
+
+    x = at.load(&p);
+    finish(&c, &inc_a_token, &inc_b_token);
+
+    g = G { counter: c, perm: p };
+  });
+
+  assert(equal(x, 2));
+}

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -211,6 +211,8 @@ pub(crate) enum Attr {
     BitVector,
     // for unforgeable token types
     Unforgeable,
+    // for 'atomic' operations (e.g., CAS)
+    Atomic,
     // specifies an invariant block
     InvariantBlock,
 }
@@ -270,6 +272,7 @@ pub(crate) fn parse_attrs(attrs: &[Attribute]) -> Result<Vec<Attr>, VirErr> {
                 Some(box [AttrTree::Fun(_, arg, None)]) if arg == "unforgeable" => {
                     v.push(Attr::Unforgeable)
                 }
+                Some(box [AttrTree::Fun(_, arg, None)]) if arg == "atomic" => v.push(Attr::Atomic),
                 Some(box [AttrTree::Fun(_, arg, None)]) if arg == "invariant_block" => {
                     v.push(Attr::InvariantBlock)
                 }
@@ -372,6 +375,7 @@ pub(crate) struct VerifierAttrs {
     pub(crate) custom_req_err: Option<String>,
     pub(crate) bit_vector: bool,
     pub(crate) unforgeable: bool,
+    pub(crate) atomic: bool,
 }
 
 pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, VirErr> {
@@ -384,6 +388,7 @@ pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, V
         custom_req_err: None,
         bit_vector: false,
         unforgeable: false,
+        atomic: false,
     };
     for attr in parse_attrs(attrs)? {
         match attr {
@@ -395,6 +400,7 @@ pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, V
             Attr::CustomReqErr(s) => vs.custom_req_err = Some(s.clone()),
             Attr::BitVector => vs.bit_vector = true,
             Attr::Unforgeable => vs.unforgeable = true,
+            Attr::Atomic => vs.atomic = true,
             _ => {}
         }
     }

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -279,6 +279,7 @@ pub(crate) fn check_item_fn<'tcx>(
         export_as_global_forall: vattrs.export_as_global_forall,
         bit_vector: vattrs.bit_vector,
         autoview: vattrs.autoview,
+        atomic: vattrs.atomic,
     };
     let func = FunctionX {
         name,

--- a/source/rust_verify/tests/atomics.rs
+++ b/source/rust_verify/tests/atomics.rs
@@ -1,0 +1,119 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+const COMMON: &str = code_str! {
+    use crate::pervasive::invariants::*;
+
+    #[verifier(atomic)]
+    #[verifier(external_body)]
+    fn atomic_op() {
+        opens_invariants_none();
+    }
+
+    #[verifier(external_body)]
+    fn non_atomic_op() {
+        opens_invariants_none();
+    }
+
+    #[verifier(external_body)]
+    #[proof]
+    fn proof_op() { }
+};
+
+test_verify_one_file! {
+    #[test] one_atomic_ok
+    COMMON.to_string() + code_str! {
+        pub fn do_nothing(#[proof] i: Invariant<u8>) {
+            open_invariant!(&i => inner => {
+                atomic_op();
+            });
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] two_atomic_fail
+    COMMON.to_string() + code_str! {
+        pub fn do_nothing(#[proof] i: Invariant<u8>) {
+            open_invariant!(&i => inner => {
+                atomic_op();
+                atomic_op();
+            });
+        }
+    } => Err(err) => assert_vir_error(err)
+}
+
+test_verify_one_file! {
+    #[test] non_atomic_fail
+    COMMON.to_string() + code_str! {
+        pub fn do_nothing(#[proof] i: Invariant<u8>) {
+            open_invariant!(&i => inner => {
+                non_atomic_op();
+            });
+        }
+    } => Err(err) => assert_vir_error(err)
+}
+
+test_verify_one_file! {
+    #[test] if_ok
+    COMMON.to_string() + code_str! {
+        pub fn do_nothing(#[proof] i: Invariant<u8>, j: u64) {
+            open_invariant!(&i => inner => {
+                if j == 1 {
+                    atomic_op();
+                }
+            });
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] proof_call_ok
+    COMMON.to_string() + code_str! {
+        pub fn do_nothing(#[proof] i: Invariant<u8>, j: u64) {
+            open_invariant!(&i => inner => {
+                proof_op();
+                atomic_op();
+            });
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] assign_ok
+    COMMON.to_string() + code_str! {
+        pub fn do_nothing(#[proof] i: Invariant<u8>) -> u32 {
+            let mut x: u32 = 5;
+            open_invariant!(&i => inner => {
+                atomic_op();
+                x = 7;
+            });
+            x
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] loop_fail
+    COMMON.to_string() + code_str! {
+        pub fn do_nothing(#[proof] i: Invariant<u8>) -> u32 {
+            let mut x: u32 = 5;
+            open_invariant!(&i => inner => {
+                while x < 10 {
+                    x = x + 1;
+                }
+            });
+            x
+        }
+    } => Err(err) => assert_vir_error(err)
+}
+
+test_verify_one_file! {
+    #[test] untrusted_atomic_fail
+    COMMON.to_string() + code_str! {
+        #[verifier(atomic)]
+        fn untrusted_atomic_op() { }
+    } => Err(err) => assert_vir_error(err)
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -364,6 +364,8 @@ pub struct FunctionAttrsX {
     pub autoview: bool,
     /// Verify using bitvector theory
     pub bit_vector: bool,
+    /// Is atomic (i.e., can be inside an invariant block)
+    pub atomic: bool,
 }
 
 /// Static function identifier

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -5,7 +5,9 @@ use crate::ast::{
 use crate::ast_util::{err_str, err_string, get_field};
 use crate::util::vec_map_result;
 use air::ast::Span;
+use air::errors::{error, error_with_label};
 use air::scope_map::ScopeMap;
+use std::cmp::min;
 use std::collections::HashMap;
 
 // Exec <= Proof <= Spec
@@ -57,13 +59,90 @@ impl Typing {
     }
 }
 
+// One tricky thing in mode-checking is that an invariant blocks needs to have
+// *at most one* atomic instruction in it.
+// Thus, we can't just declare everything inside it to be 'proof' code,
+// but we can't allow it all to be 'exec' code either.
+// Instead, we need to measure *how much* exec code there is.
+//
+// Our plan is to pass around this AtomicInstCollector object. We instantiate a fresh
+// one when we begin an atomic block; as we traverse the atomic block, we collect
+// relevant information; when we're done with the block,
+// we look at what we picked up and error if necessary.
+// For simplicity, we just wait until the end of the block for the validation,
+// rather than erroring as soon as we find something bad.
+//
+// Note that we aren't interested in local manipulations like field accesses,
+// even if it's exec code. (We just need to make sure any exec code is terminating.)
+// What we're really interested in is *calls*. Any call can either be "atomic"
+// (if it is marked as such as its definition) or "non-atomic" (anything else).
+// Any non-atomic call at all is an error. It's also an error to have >= 2 atomic calls.
+//
+// We disallow loops entirely. (It would be OK to allow proof-only loops, but those
+// currently aren't supported at all.) We don't do anything fancy for branching statements.
+// In principle, we could do something fancy and allow 1 atomic instruction in each branch,
+// but for now we just error if there is more than 1 atomic call in the AST.
+
+#[derive(Default)]
+struct AtomicInstCollector {
+    atomics: Vec<Span>,
+    non_atomics: Vec<Span>,
+    loops: Vec<Span>,
+}
+
+impl AtomicInstCollector {
+    fn new() -> AtomicInstCollector {
+        Default::default()
+    }
+
+    fn add_atomic(&mut self, span: &Span) {
+        self.atomics.push(span.clone());
+    }
+
+    fn add_non_atomic(&mut self, span: &Span) {
+        self.non_atomics.push(span.clone());
+    }
+
+    fn add_loop(&mut self, span: &Span) {
+        self.loops.push(span.clone());
+    }
+
+    /// Check that the collected operations are well-formed; error if not
+    pub fn validate(&self, inv_block_span: &Span) -> Result<(), VirErr> {
+        if self.loops.len() > 0 {
+            return Err(error_with_label(
+                "open_invariant cannot contain an 'exec' loop",
+                inv_block_span,
+                "this invariant block contains a loop",
+            )
+            .secondary_span(&self.loops[0]));
+        } else if self.non_atomics.len() > 0 {
+            let mut e =
+                error("open_invariant cannot contain non-atomic operations", inv_block_span);
+            for i in 0..min(self.non_atomics.len(), 3) {
+                e = e.secondary_label(&self.non_atomics[i], "non-atomic here");
+            }
+            return Err(e);
+        } else if self.atomics.len() > 1 {
+            let mut e =
+                error("open_invariant cannot contain more than 1 atomic operation", inv_block_span);
+            for i in 0..min(self.atomics.len(), 3) {
+                e = e.secondary_label(&self.atomics[i], "atomic here");
+            }
+            return Err(e);
+        }
+        return Ok(());
+    }
+}
+
 fn check_expr_has_mode(
     typing: &mut Typing,
+    atomic_insts: &mut Option<AtomicInstCollector>,
     outer_mode: Mode,
     expr: &Expr,
     expected: Mode,
 ) -> Result<(), VirErr> {
-    let mode = check_expr(typing, outer_mode, expr)?;
+    let mode = check_expr(typing, atomic_insts, outer_mode, expr)?;
     if !mode_le(mode, expected) {
         err_string(&expr.span, format!("expression has mode {}, expected mode {}", mode, expected))
     } else {
@@ -98,7 +177,12 @@ fn add_pattern(typing: &mut Typing, mode: Mode, pattern: &Pattern) -> Result<(),
     }
 }
 
-fn check_expr(typing: &mut Typing, outer_mode: Mode, expr: &Expr) -> Result<Mode, VirErr> {
+fn check_expr(
+    typing: &mut Typing,
+    atomic_insts: &mut Option<AtomicInstCollector>,
+    outer_mode: Mode,
+    expr: &Expr,
+) -> Result<Mode, VirErr> {
     match &expr.x {
         ExprX::Const(_) => Ok(outer_mode),
         ExprX::Var(x) | ExprX::VarAt(x, _) => {
@@ -123,6 +207,18 @@ fn check_expr(typing: &mut Typing, outer_mode: Mode, expr: &Expr) -> Result<Mode
                 }
                 Some(f) => f.clone(),
             };
+            if function.x.mode == Mode::Exec {
+                match atomic_insts {
+                    None => {}
+                    Some(ai) => {
+                        if function.x.attrs.atomic {
+                            ai.add_atomic(&expr.span);
+                        } else {
+                            ai.add_non_atomic(&expr.span);
+                        }
+                    }
+                }
+            }
             if !mode_le(outer_mode, function.x.mode) {
                 return err_string(
                     &expr.span,
@@ -138,7 +234,7 @@ fn check_expr(typing: &mut Typing, outer_mode: Mode, expr: &Expr) -> Result<Mode
                             "cannot call function with &mut parameter inside forall/assert_by statements",
                         );
                     }
-                    let arg_mode = check_expr(typing, outer_mode, arg)?;
+                    let arg_mode = check_expr(typing, atomic_insts, outer_mode, arg)?;
                     if arg_mode != param_mode {
                         return err_string(
                             &param.span,
@@ -149,19 +245,20 @@ fn check_expr(typing: &mut Typing, outer_mode: Mode, expr: &Expr) -> Result<Mode
                         );
                     }
                 }
-                check_expr_has_mode(typing, param_mode, arg, param.x.mode)?;
+                check_expr_has_mode(typing, atomic_insts, param_mode, arg, param.x.mode)?;
             }
             Ok(function.x.ret.x.mode)
         }
         ExprX::Call(CallTarget::FnSpec(e0), es) => {
-            check_expr_has_mode(typing, Mode::Spec, e0, Mode::Spec)?;
+            // TODO call `add_non_atomic` if this is ever supported for exec-mode functions
+            check_expr_has_mode(typing, atomic_insts, Mode::Spec, e0, Mode::Spec)?;
             for arg in es.iter() {
-                check_expr_has_mode(typing, Mode::Spec, arg, Mode::Spec)?;
+                check_expr_has_mode(typing, atomic_insts, Mode::Spec, arg, Mode::Spec)?;
             }
             Ok(Mode::Spec)
         }
         ExprX::Tuple(es) => {
-            let modes = vec_map_result(es, |e| check_expr(typing, outer_mode, e))?;
+            let modes = vec_map_result(es, |e| check_expr(typing, atomic_insts, outer_mode, e))?;
             Ok(modes.into_iter().fold(outer_mode, mode_join))
         }
         ExprX::Ctor(path, variant, binders, update) => {
@@ -169,11 +266,12 @@ fn check_expr(typing: &mut Typing, outer_mode: Mode, expr: &Expr) -> Result<Mode
             let variant = datatype.x.get_variant(variant);
             let mut mode = mode_join(outer_mode, datatype.x.mode);
             if let Some(update) = update {
-                mode = mode_join(mode, check_expr(typing, outer_mode, update)?);
+                mode = mode_join(mode, check_expr(typing, atomic_insts, outer_mode, update)?);
             }
             for arg in binders.iter() {
                 let (_, field_mode) = get_field(&variant.a, &arg.name).a;
-                let mode_arg = check_expr(typing, mode_join(outer_mode, field_mode), &arg.a)?;
+                let mode_arg =
+                    check_expr(typing, atomic_insts, mode_join(outer_mode, field_mode), &arg.a)?;
                 if !mode_le(mode_arg, field_mode) {
                     // allow this arg by weakening whole struct's mode
                     mode = mode_join(mode, mode_arg);
@@ -186,14 +284,18 @@ fn check_expr(typing: &mut Typing, outer_mode: Mode, expr: &Expr) -> Result<Mode
 
             Ok(mode)
         }
-        ExprX::Unary(_, e1) => check_expr(typing, outer_mode, e1),
-        ExprX::UnaryOpr(UnaryOpr::Box(_), e1) => check_expr(typing, outer_mode, e1),
-        ExprX::UnaryOpr(UnaryOpr::Unbox(_), e1) => check_expr(typing, outer_mode, e1),
+        ExprX::Unary(_, e1) => check_expr(typing, atomic_insts, outer_mode, e1),
+        ExprX::UnaryOpr(UnaryOpr::Box(_), e1) => check_expr(typing, atomic_insts, outer_mode, e1),
+        ExprX::UnaryOpr(UnaryOpr::Unbox(_), e1) => check_expr(typing, atomic_insts, outer_mode, e1),
         ExprX::UnaryOpr(UnaryOpr::HasType(_), _) => panic!("internal error: HasType in modes.rs"),
-        ExprX::UnaryOpr(UnaryOpr::IsVariant { .. }, e1) => check_expr(typing, outer_mode, e1),
-        ExprX::UnaryOpr(UnaryOpr::TupleField { .. }, e1) => check_expr(typing, outer_mode, e1),
+        ExprX::UnaryOpr(UnaryOpr::IsVariant { .. }, e1) => {
+            check_expr(typing, atomic_insts, outer_mode, e1)
+        }
+        ExprX::UnaryOpr(UnaryOpr::TupleField { .. }, e1) => {
+            check_expr(typing, atomic_insts, outer_mode, e1)
+        }
         ExprX::UnaryOpr(UnaryOpr::Field { datatype, variant: _, field }, e1) => {
-            let e1_mode = check_expr(typing, outer_mode, e1)?;
+            let e1_mode = check_expr(typing, atomic_insts, outer_mode, e1)?;
             let datatype = &typing.datatypes[datatype];
             let field = get_field(&datatype.x.get_only_variant().a, field);
             Ok(mode_join(e1_mode, field.a.1))
@@ -208,8 +310,8 @@ fn check_expr(typing: &mut Typing, outer_mode: Mode, expr: &Expr) -> Result<Mode
                 BinaryOp::Implies => mode_join(outer_mode, Mode::Spec),
                 _ => outer_mode,
             };
-            let mode1 = check_expr(typing, outer_mode, e1)?;
-            let mode2 = check_expr(typing, outer_mode, e2)?;
+            let mode1 = check_expr(typing, atomic_insts, outer_mode, e1)?;
+            let mode2 = check_expr(typing, atomic_insts, outer_mode, e2)?;
             Ok(mode_join(op_mode, mode_join(mode1, mode2)))
         }
         ExprX::Quant(_, binders, e1) => {
@@ -217,7 +319,7 @@ fn check_expr(typing: &mut Typing, outer_mode: Mode, expr: &Expr) -> Result<Mode
             for binder in binders.iter() {
                 typing.insert(&expr.span, &binder.name, false, Mode::Spec);
             }
-            check_expr_has_mode(typing, Mode::Spec, e1, Mode::Spec)?;
+            check_expr_has_mode(typing, atomic_insts, Mode::Spec, e1, Mode::Spec)?;
             typing.vars.pop_scope();
             Ok(Mode::Spec)
         }
@@ -228,14 +330,15 @@ fn check_expr(typing: &mut Typing, outer_mode: Mode, expr: &Expr) -> Result<Mode
             for binder in params.iter() {
                 typing.insert(&expr.span, &binder.name, false, Mode::Spec);
             }
-            check_expr_has_mode(typing, Mode::Spec, body, Mode::Spec)?;
+            let mut atomic_insts = None;
+            check_expr_has_mode(typing, &mut atomic_insts, Mode::Spec, body, Mode::Spec)?;
             typing.vars.pop_scope();
             Ok(Mode::Spec)
         }
         ExprX::Choose(binder, e1) => {
             typing.vars.push_scope(true);
             typing.insert(&expr.span, &binder.name, false, Mode::Spec);
-            check_expr_has_mode(typing, Mode::Spec, e1, Mode::Spec)?;
+            check_expr_has_mode(typing, atomic_insts, Mode::Spec, e1, Mode::Spec)?;
             typing.vars.pop_scope();
             Ok(Mode::Spec)
         }
@@ -255,7 +358,7 @@ fn check_expr(typing: &mut Typing, outer_mode: Mode, expr: &Expr) -> Result<Mode
                         );
                     }
                     typing.erasure_modes.var_modes.push((lhs.span.clone(), x_mode));
-                    check_expr_has_mode(typing, outer_mode, rhs, x_mode)?;
+                    check_expr_has_mode(typing, atomic_insts, outer_mode, rhs, x_mode)?;
                     Ok(x_mode)
                 }
                 _ => panic!("expected var, found {:?}", &lhs),
@@ -273,9 +376,9 @@ fn check_expr(typing: &mut Typing, outer_mode: Mode, expr: &Expr) -> Result<Mode
             for var in vars.iter() {
                 typing.insert(&expr.span, &var.name, false, Mode::Spec);
             }
-            check_expr_has_mode(typing, Mode::Spec, require, Mode::Spec)?;
-            check_expr_has_mode(typing, Mode::Spec, ensure, Mode::Spec)?;
-            check_expr_has_mode(typing, Mode::Proof, proof, Mode::Proof)?;
+            check_expr_has_mode(typing, atomic_insts, Mode::Spec, require, Mode::Spec)?;
+            check_expr_has_mode(typing, atomic_insts, Mode::Spec, ensure, Mode::Spec)?;
+            check_expr_has_mode(typing, atomic_insts, Mode::Proof, proof, Mode::Proof)?;
             typing.vars.pop_scope();
             typing.in_forall_stmt = in_forall_stmt;
             Ok(Mode::Proof)
@@ -285,23 +388,23 @@ fn check_expr(typing: &mut Typing, outer_mode: Mode, expr: &Expr) -> Result<Mode
             Ok(Mode::Proof)
         }
         ExprX::If(e1, e2, e3) => {
-            let mode1 = check_expr(typing, outer_mode, e1)?;
+            let mode1 = check_expr(typing, atomic_insts, outer_mode, e1)?;
             typing.erasure_modes.condition_modes.push((expr.span.clone(), mode1));
             let mode_branch = match (outer_mode, mode1) {
                 (Mode::Exec, Mode::Spec) => Mode::Proof,
                 _ => outer_mode,
             };
-            let mode2 = check_expr(typing, mode_branch, e2)?;
+            let mode2 = check_expr(typing, atomic_insts, mode_branch, e2)?;
             match e3 {
                 None => Ok(mode2),
                 Some(e3) => {
-                    let mode3 = check_expr(typing, mode_branch, e3)?;
+                    let mode3 = check_expr(typing, atomic_insts, mode_branch, e3)?;
                     Ok(mode_join(mode2, mode3))
                 }
             }
         }
         ExprX::Match(e1, arms) => {
-            let mode1 = check_expr(typing, outer_mode, e1)?;
+            let mode1 = check_expr(typing, atomic_insts, outer_mode, e1)?;
             typing.erasure_modes.condition_modes.push((expr.span.clone(), mode1));
             match (mode1, arms.len()) {
                 (Mode::Spec, 0) => {
@@ -319,12 +422,12 @@ fn check_expr(typing: &mut Typing, outer_mode: Mode, expr: &Expr) -> Result<Mode
                     (Mode::Exec, Mode::Spec | Mode::Proof) => Mode::Proof,
                     (m, _) => m,
                 };
-                let guard_mode = check_expr(typing, arm_outer_mode, &arm.x.guard)?;
+                let guard_mode = check_expr(typing, atomic_insts, arm_outer_mode, &arm.x.guard)?;
                 let arm_outer_mode = match (arm_outer_mode, guard_mode) {
                     (Mode::Exec, Mode::Spec | Mode::Proof) => Mode::Proof,
                     (m, _) => m,
                 };
-                let arm_mode = check_expr(typing, arm_outer_mode, &arm.x.body)?;
+                let arm_mode = check_expr(typing, atomic_insts, arm_outer_mode, &arm.x.body)?;
                 final_mode = mode_join(final_mode, arm_mode);
                 typing.vars.pop_scope();
             }
@@ -332,10 +435,14 @@ fn check_expr(typing: &mut Typing, outer_mode: Mode, expr: &Expr) -> Result<Mode
         }
         ExprX::While { cond, body, invs } => {
             // We could also allow this for proof, if we check it for termination
-            check_expr_has_mode(typing, outer_mode, cond, Mode::Exec)?;
-            check_expr_has_mode(typing, outer_mode, body, Mode::Exec)?;
+            match atomic_insts {
+                None => {}
+                Some(ai) => ai.add_loop(&expr.span),
+            }
+            check_expr_has_mode(typing, atomic_insts, outer_mode, cond, Mode::Exec)?;
+            check_expr_has_mode(typing, atomic_insts, outer_mode, body, Mode::Exec)?;
             for inv in invs.iter() {
-                check_expr_has_mode(typing, Mode::Spec, inv, Mode::Spec)?;
+                check_expr_has_mode(typing, atomic_insts, Mode::Spec, inv, Mode::Spec)?;
             }
             Ok(Mode::Exec)
         }
@@ -347,7 +454,7 @@ fn check_expr(typing: &mut Typing, outer_mode: Mode, expr: &Expr) -> Result<Mode
                 (None, _) => {}
                 (_, None) => panic!("internal error: missing return type"),
                 (Some(e1), Some(ret_mode)) => {
-                    check_expr_has_mode(typing, outer_mode, e1, ret_mode)?;
+                    check_expr_has_mode(typing, atomic_insts, outer_mode, e1, ret_mode)?;
                 }
             }
             Ok(Mode::Exec)
@@ -355,11 +462,11 @@ fn check_expr(typing: &mut Typing, outer_mode: Mode, expr: &Expr) -> Result<Mode
         ExprX::Block(ss, e1) => {
             for stmt in ss.iter() {
                 typing.vars.push_scope(true);
-                check_stmt(typing, outer_mode, stmt)?;
+                check_stmt(typing, atomic_insts, outer_mode, stmt)?;
             }
             let mode = match e1 {
                 None => outer_mode,
-                Some(expr) => check_expr(typing, outer_mode, expr)?,
+                Some(expr) => check_expr(typing, atomic_insts, outer_mode, expr)?,
             };
             for _ in ss.iter() {
                 typing.vars.pop_scope();
@@ -370,15 +477,24 @@ fn check_expr(typing: &mut Typing, outer_mode: Mode, expr: &Expr) -> Result<Mode
             if outer_mode == Mode::Spec {
                 return err_string(&expr.span, format!("Cannot open invariant in Spec mode."));
             }
-            let mode1 = check_expr(typing, outer_mode, inv)?;
+            let mode1 = check_expr(typing, atomic_insts, outer_mode, inv)?;
             if mode1 != Mode::Proof {
                 return err_string(&inv.span, format!("Invariant must be Proof mode."));
             }
             typing.vars.push_scope(true);
             typing.insert(&expr.span, &binder.name, /* mutable */ true, Mode::Proof);
 
-            // TODO all a single atomic #[exec] action inside
-            let _ = check_expr(typing, Mode::Proof, body)?;
+            if atomic_insts.is_some() || outer_mode != Mode::Exec {
+                // If we're a nested atomic block, we don't need to create a new
+                // AtomicInstCollector. We just rely on the outer one.
+                // Also, if we're already in Proof mode, then we just recurse in Proof
+                // mode, and we don't need to do the atomicity check at all.
+                let _ = check_expr(typing, atomic_insts, outer_mode, body)?;
+            } else {
+                let mut my_atomic_insts = Some(AtomicInstCollector::new());
+                let _ = check_expr(typing, &mut my_atomic_insts, outer_mode, body)?;
+                my_atomic_insts.expect("my_atomic_insts").validate(&body.span)?;
+            }
 
             typing.vars.pop_scope();
             Ok(Mode::Exec)
@@ -386,10 +502,15 @@ fn check_expr(typing: &mut Typing, outer_mode: Mode, expr: &Expr) -> Result<Mode
     }
 }
 
-fn check_stmt(typing: &mut Typing, outer_mode: Mode, stmt: &Stmt) -> Result<(), VirErr> {
+fn check_stmt(
+    typing: &mut Typing,
+    atomic_insts: &mut Option<AtomicInstCollector>,
+    outer_mode: Mode,
+    stmt: &Stmt,
+) -> Result<(), VirErr> {
     match &stmt.x {
         StmtX::Expr(e) => {
-            let _ = check_expr(typing, outer_mode, e)?;
+            let _ = check_expr(typing, atomic_insts, outer_mode, e)?;
             Ok(())
         }
         StmtX::Decl { pattern, mode, init } => {
@@ -400,7 +521,7 @@ fn check_stmt(typing: &mut Typing, outer_mode: Mode, stmt: &Stmt) -> Result<(), 
             match init.as_ref() {
                 None => {}
                 Some(expr) => {
-                    check_expr_has_mode(typing, outer_mode, expr, *mode)?;
+                    check_expr_has_mode(typing, atomic_insts, outer_mode, expr, *mode)?;
                 }
             }
             Ok(())
@@ -439,7 +560,7 @@ fn check_function(typing: &mut Typing, function: &Function) -> Result<(), VirErr
         typing.ret_mode = Some(ret_mode);
     }
     if let Some(body) = &function.x.body {
-        check_expr_has_mode(typing, function.x.mode, body, function.x.ret.x.mode)?;
+        check_expr_has_mode(typing, &mut None, function.x.mode, body, function.x.ret.x.mode)?;
     }
     typing.ret_mode = None;
     typing.vars.pop_scope();

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -15,6 +15,17 @@ struct Ctxt {
 }
 
 fn check_function(ctxt: &Ctxt, function: &Function) -> Result<(), VirErr> {
+    if function.x.attrs.atomic {
+        if function.x.mode != Mode::Exec {
+            return err_str(&function.span, "'atomic' only makes sense on an 'exec' function");
+        }
+        if function.x.body.is_some() {
+            return err_str(
+                &function.span,
+                "'atomic' is a trusted annotation: it may not be used on a verified function",
+            );
+        }
+    }
     match &function.x.mask_spec {
         MaskSpec::NoSpec => {}
         _ => {


### PR DESCRIPTION
This PR depends on https://github.com/secure-foundations/verus/pull/19 and https://github.com/secure-foundations/verus/pull/22.

Here, I introduce the notion of an _atomic operation_ and ensure that any invariant block can have at most 1 atomic operation. I also introduce a stub Atomic library, and pull together a nontrivial example of a concurrent counter.

### Atomic operations

A function can be declared atomic with `#[verifier(atomic)]`. This is a trusted annotation, and it can only be used with `external_body`.

To check that any block only has a single atomic operation inside it, I added additional checks to `vir/src/modes.rs`. There's more information documented in the file. The gist is that, while processing an invariant block, we collect all the executable calls, then at the end of the block, we count up the atomic instructions we found and error if we found anything not right. Note that any "local" executable code (local variables or field accesses) count as "free" even if they are executable.

### Examples

`pervasive/atomics.rs` has a sample library. I'll fill in all the types and method later; right now we just have `PAtomicU32` and a couple of methods. This library is structured similar to `PCell`, the main difference being that its methods are marked atomic.

`rust_verify/examples/og_counter.rs` gives a nontrivial example of an atomic counter, incremented twice. It's incomplete, mostly because it has a system of unforgeable tokens which is currently trusted because we haven't yet built the state machine infrastructure. The tokens are based off the [example from this doc](https://docs.google.com/document/d/1Y6sigqVg1eWRcj8-j9tdJPG11pQHjardASNhIARO4-g/edit).

It does, however, showcase the atomics. One thing of note is how they do work slightly differently than they did in LinearDafny, where atomic blocks were tied to the atomic statements; here, we create an atomic along with a `Permission` object, and put the `Permission` in an invariant. Then we open up the invariant with an `open_invariant!` call, access the `Permission` token, and perform the atomic operation inside.

### Error messages

```
error: open_invariant cannot contain more than 1 atomic operation
  --> test.rs:24:36
   |
24 |       open_invariant!(&i => inner => {
   |  ____________________________________^
25 | |         atomic_op();
   | |         ----------- atomic here
26 | |         atomic_op();
   | |         ----------- atomic here
27 | |     });
   | |_____^


error: open_invariant cannot contain non-atomic operations
  --> test.rs:24:36
   |
24 |       open_invariant!(&i => inner => {
   |  ____________________________________^
25 | |         non_atomic_op();
   | |         --------------- non-atomic here
26 | |     });
   | |_____^


error: open_invariant cannot contain an 'exec' loop
  --> test.rs:25:36
   |
25 |        open_invariant!(&i => inner => {
   |   ____________________________________^
26 |  |         while x < 10 {
   |  |_________-
27 | ||             x = x + 1;
28 | ||         }
   | ||_________-
29 |  |     });
   |  |_____^ this invariant block contains a loop


error: 'atomic' is a trusted annotation: it may not be used on a verified function
  --> test.rs:24:1
   |
24 | fn untrusted_atomic_op() { }
   | ^^^^^^^^^^^^^^^^^^^^^^^^
```