### PR TITLE
support impl methods without a self argument

### DIFF
--- a/source/rust_verify/example/impl_basic.rs
+++ b/source/rust_verify/example/impl_basic.rs
@@ -9,9 +9,40 @@ struct Car {
 }
 
 impl Car {
+    fn new() -> Car {
+        ensures(|result: Car| equal(result.passengers, 201));
+        Car { four_doors: false, passengers: 201 }
+    }
+
     fn get_passengers(&self) -> u64 {
         ensures(|result: u64| result == self.passengers);
         self.passengers
+    }
+}
+
+#[derive(PartialEq, Eq)]
+struct TemplateCar<V> {
+    four_doors: bool,
+    passengers: u64,
+    the_v: V,
+}
+
+impl<V> TemplateCar<V> {
+    fn template_new(v: V) -> TemplateCar<V> {
+        ensures(|result: TemplateCar<V>|
+          equal(result.passengers, 205) && equal(result.the_v, v)
+        );
+        TemplateCar::<V> { four_doors: false, passengers: 205, the_v: v }
+    }
+
+    fn template_get_passengers(&self) -> u64 {
+        ensures(|result: u64| result == self.passengers);
+        self.passengers
+    }
+
+    fn template_get_v(self) -> V {
+        ensures(|result: V| equal(result, self.the_v));
+        self.the_v
     }
 }
 
@@ -19,4 +50,14 @@ fn main() {
     let c = Car { four_doors: true, passengers: 3 };
     let p = c.get_passengers();
     assert(p < 4);
+
+    let c2 = Car::new();
+    let p2 = c2.get_passengers();
+    assert(p2 == 201);
+
+    let c3 = TemplateCar::<u64>::template_new(5);
+    let p3 = c3.template_get_passengers();
+    assert(p3 == 205);
+    let v = c3.template_get_v();
+    assert(v == 5);
 }

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -178,7 +178,7 @@ fn check_item<'tcx>(
                     };
                     for impl_item_ref in impll.items {
                         match impl_item_ref.kind {
-                            AssocItemKind::Fn { has_self } if has_self => {
+                            AssocItemKind::Fn { has_self: _ } => {
                                 let impl_item = ctxt.tcx.hir().impl_item(impl_item_ref.id);
                                 let impl_item_visibility =
                                     mk_visibility(&Some(module_path.clone()), &impl_item.vis);

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -33,10 +33,10 @@ pub(crate) fn def_path_to_vir_path<'tcx>(tcx: TyCtxt<'tcx>, def_path: DefPath) -
 
 fn is_function_def_impl_item_node(node: rustc_hir::Node) -> bool {
     match node {
-        rustc_hir::Node::ImplItem(item) => match &item.kind {
-            rustc_hir::ImplItemKind::Fn(..) => true,
-            _ => false,
-        },
+        rustc_hir::Node::ImplItem(rustc_hir::ImplItem {
+            kind: rustc_hir::ImplItemKind::Fn(..),
+            ..
+        }) => true,
         _ => false,
     }
 }
@@ -58,27 +58,26 @@ pub(crate) fn def_id_to_vir_path<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> Path
             let parent_id = tcx.hir().get_parent_node(hir);
             let parent_node = tcx.hir().get(parent_id);
             match parent_node {
-                rustc_hir::Node::Item(item) => match &item.kind {
-                    rustc_hir::ItemKind::Impl(impll) => {
-                        let ty_path = match &impll.self_ty.kind {
-                            rustc_hir::TyKind::Path(QPath::Resolved(
-                                None,
-                                rustc_hir::Path {
-                                    res: rustc_hir::def::Res::Def(_, self_def_id),
-                                    ..
-                                },
-                            )) => def_path_to_vir_path(tcx, tcx.def_path(*self_def_id)),
-                            _ => {
-                                panic!("impl type is not given by a path");
-                            }
-                        };
-                        return typ_path_and_ident_to_vir_path(
-                            &ty_path,
-                            def_to_path_ident(tcx, def_id),
-                        );
-                    }
-                    _ => {}
-                },
+                rustc_hir::Node::Item(rustc_hir::Item {
+                    kind: rustc_hir::ItemKind::Impl(impll),
+                    ..
+                }) => {
+                    let ty_path = match &impll.self_ty.kind {
+                        rustc_hir::TyKind::Path(QPath::Resolved(
+                            None,
+                            rustc_hir::Path {
+                                res: rustc_hir::def::Res::Def(_, self_def_id), ..
+                            },
+                        )) => def_path_to_vir_path(tcx, tcx.def_path(*self_def_id)),
+                        _ => {
+                            panic!("impl type is not given by a path");
+                        }
+                    };
+                    return typ_path_and_ident_to_vir_path(
+                        &ty_path,
+                        def_to_path_ident(tcx, def_id),
+                    );
+                }
                 _ => {}
             }
         }

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -56,20 +56,6 @@ pub(crate) fn pat_to_var<'tcx>(pat: &Pat) -> String {
     }
 }
 
-fn expr_to_function<'hir>(expr: &Expr<'hir>) -> DefId {
-    let v = match &expr.kind {
-        ExprKind::Path(rustc_hir::QPath::Resolved(_, path)) => match path.res {
-            rustc_hir::def::Res::Def(_, def_id) => Some(def_id),
-            _ => None,
-        },
-        _ => None,
-    };
-    match v {
-        Some(def_id) => def_id,
-        None => unsupported!(format!("complex function call {:?} {:?}", expr, expr.span)),
-    }
-}
-
 fn extract_array<'tcx>(expr: &'tcx Expr<'tcx>) -> Vec<&'tcx Expr<'tcx>> {
     match &expr.kind {
         ExprKind::Array(fields) => fields.iter().collect(),
@@ -1032,7 +1018,7 @@ pub(crate) fn expr_to_vir_inner<'tcx>(
             }
         }
         ExprKind::Call(fun, args_slice) => {
-            match fun.kind {
+            let res = match &fun.kind {
                 // a tuple-style datatype constructor
                 ExprKind::Path(QPath::Resolved(
                     None,
@@ -1041,30 +1027,65 @@ pub(crate) fn expr_to_vir_inner<'tcx>(
                         span: path_span,
                         ..
                     },
-                )) => expr_tuple_datatype_ctor_to_vir(
-                    bctx,
-                    expr,
-                    res,
-                    *args_slice,
-                    *path_span,
-                    modifier,
-                ),
-                // a statically resolved function
-                ExprKind::Path(QPath::Resolved(
-                    None,
-                    rustc_hir::Path { res: Res::Def(DefKind::Fn, _), .. },
-                )) => fn_call_to_vir(
-                    bctx,
-                    expr,
-                    None,
-                    expr_to_function(fun),
-                    bctx.types.node_substs(fun.hir_id),
-                    fun.span,
-                    args_slice,
-                    None,
-                ),
-                // a dynamically computed function
+                )) => {
+                    Some(expr_tuple_datatype_ctor_to_vir(bctx, expr, res, *args_slice, *path_span, modifier))
+                }
+                ExprKind::Path(qpath) => {
+                    let def = bctx.types.qpath_res(&qpath, fun.hir_id);
+                    match def {
+                        // a statically resolved function
+                        rustc_hir::def::Res::Def(_, def_id) => {
+                            let self_path = match qpath {
+                                QPath::Resolved(_, _) => None,
+                                QPath::LangItem(_, _) => None,
+                                QPath::TypeRelative(ty, _) => match &ty.kind {
+                                    rustc_hir::TyKind::Path(qpath) => {
+                                        match bctx.types.qpath_res(&qpath, ty.hir_id) {
+                                            rustc_hir::def::Res::Def(_, def_id) => {
+                                                Some(def_id_to_vir_path(bctx.ctxt.tcx, def_id))
+                                            }
+                                            _ => {
+                                                panic!("failed to look up def_id for impl");
+                                            }
+                                        }
+                                    }
+                                    _ => {
+                                        panic!("failed to look up def_id for impl");
+                                    }
+                                },
+                            };
+
+                            Some(fn_call_to_vir(
+                                bctx,
+                                expr,
+                                self_path,
+                                def_id,
+                                bctx.types.node_type(fun.hir_id),
+                                bctx.types.node_substs(fun.hir_id),
+                                fun.span,
+                                args_slice,
+                                None,
+                            ))
+                        }
+                        rustc_hir::def::Res::Local(_) => {
+                            None // dynamically computed function, see below
+                        }
+                        _ => {
+                            unsupported!(format!(
+                                "function call {:?} {:?} {:?}",
+                                def, expr, expr.span
+                            ))
+                        }
+                    }
+                }
                 _ => {
+                    None // dynamically computed function, see below
+                }
+            };
+            match res {
+                Some(res) => res,
+                None => {
+                    // a dynamically computed function
                     if bctx.external_body {
                         return Ok(mk_expr(ExprX::Block(Arc::new(vec![]), None)));
                     }

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -3,7 +3,7 @@ use crate::erase::ResolvedCall;
 use crate::rust_to_vir_base::{
     def_id_to_vir_path, def_to_path_ident, get_range, get_trigger, get_var_mode, hack_get_def_name,
     ident_to_var, is_smt_arith, is_smt_equality, mid_ty_to_vir, mk_range, parse_attrs, ty_to_vir,
-    typ_of_node, typ_of_node_expect_mut_ref, Attr, typ_path_and_ident_to_vir_path,
+    typ_of_node, typ_of_node_expect_mut_ref, typ_path_and_ident_to_vir_path, Attr,
 };
 use crate::util::{
     err_span_str, err_span_string, slice_vec_map_result, spanned_new, spanned_typed_new,
@@ -1025,9 +1025,14 @@ pub(crate) fn expr_to_vir_inner<'tcx>(
                         span: path_span,
                         ..
                     },
-                )) => {
-                    Some(expr_tuple_datatype_ctor_to_vir(bctx, expr, res, *args_slice, *path_span, modifier))
-                }
+                )) => Some(expr_tuple_datatype_ctor_to_vir(
+                    bctx,
+                    expr,
+                    res,
+                    *args_slice,
+                    *path_span,
+                    modifier,
+                )),
                 ExprKind::Path(qpath) => {
                     let def = bctx.types.qpath_res(&qpath, fun.hir_id);
                     match def {

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -1041,7 +1041,6 @@ pub(crate) fn expr_to_vir_inner<'tcx>(
                             bctx,
                             expr,
                             def_id,
-                            bctx.types.node_type(fun.hir_id),
                             bctx.types.node_substs(fun.hir_id),
                             fun.span,
                             args_slice,

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -1,7 +1,7 @@
 use crate::context::{BodyCtxt, Context};
 use crate::rust_to_vir_base::{
-    check_generics, check_generics_bounds, def_id_to_vir_path, def_to_path_ident, get_fuel,
-    get_mode, get_ret_mode, get_var_mode, get_verifier_attrs, ident_to_var, ty_to_vir,
+    check_generics, check_generics_bounds, def_id_to_vir_path, get_fuel, get_mode, get_ret_mode,
+    get_var_mode, get_verifier_attrs, ident_to_var, ty_to_vir,
 };
 use crate::rust_to_vir_expr::{expr_to_vir, pat_to_var, ExprModifier};
 use crate::util::{err_span_str, err_span_string, spanned_new, unsupported_err_span, vec_map};
@@ -98,13 +98,7 @@ pub(crate) fn check_item_fn<'tcx>(
     generics: &'tcx Generics,
     body_id: &BodyId,
 ) -> Result<(), VirErr> {
-    let path = if let Some((self_path, _)) = &self_path_mode {
-        let mut full_path = (**self_path).clone();
-        Arc::make_mut(&mut full_path.segments).push(def_to_path_ident(ctxt.tcx, id));
-        Arc::new(full_path)
-    } else {
-        def_id_to_vir_path(ctxt.tcx, id)
-    };
+    let path = def_id_to_vir_path(ctxt.tcx, id);
     let name = Arc::new(FunX { path, trait_path });
     let mode = get_mode(Mode::Exec, attrs);
     let adt_mode_trait_impl: Option<(_, Mode)> = if let (Some(_), Some((self_path, adt_mode))) =

--- a/source/rust_verify/tests/impl.rs
+++ b/source/rust_verify/tests/impl.rs
@@ -33,8 +33,21 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] test_impl_no_self STRUCT.to_string() + code_str! {
+        impl Bike {
+            pub fn new() -> Bike {
+                ensures(|result: Bike| result.hard_tail);
+                Bike { hard_tail: true }
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
     #[test] test_impl_mod_1 code! {
         mod M1 {
+            use builtin::*;
+
             #[derive(PartialEq, Eq)]
             pub struct Bike {
                 pub hard_tail: bool,
@@ -44,6 +57,11 @@ test_verify_one_file! {
                 #[spec]
                 pub fn is_hard_tail(&self) -> bool {
                     self.hard_tail
+                }
+
+                pub fn new() -> Bike {
+                    ensures(|result: Bike| result.hard_tail);
+                    Bike { hard_tail: true }
                 }
             }
         }
@@ -55,6 +73,11 @@ test_verify_one_file! {
 
             fn test_impl_1(b: Bike) {
                 requires(b.is_hard_tail());
+                assert(b.is_hard_tail());
+            }
+
+            fn test_impl_2() {
+                let b = Bike::new();
                 assert(b.is_hard_tail());
             }
         }
@@ -239,4 +262,42 @@ test_verify_one_file! {
             fn index(&self, #[spec]idx: usize) -> &bool { &true }
         }
     } => Err(_)
+}
+
+test_verify_one_file! {
+    #[test] test_generic_struct code! {
+        #[derive(PartialEq, Eq)]
+        struct TemplateCar<V> {
+            four_doors: bool,
+            passengers: u64,
+            the_v: V,
+        }
+
+        impl<V> TemplateCar<V> {
+            fn template_new(v: V) -> TemplateCar<V> {
+                ensures(|result: TemplateCar<V>|
+                  equal(result.passengers, 205) && equal(result.the_v, v)
+                );
+                TemplateCar::<V> { four_doors: false, passengers: 205, the_v: v }
+            }
+
+            fn template_get_passengers(&self) -> u64 {
+                ensures(|result: u64| result == self.passengers);
+                self.passengers
+            }
+
+            fn template_get_v(self) -> V {
+                ensures(|result: V| equal(result, self.the_v));
+                self.the_v
+            }
+        }
+
+        fn test1() {
+            let c3 = TemplateCar::<u64>::template_new(5);
+            let p3 = c3.template_get_passengers();
+            assert(p3 == 205);
+            let v = c3.template_get_v();
+            assert(v == 5);
+        }
+    } => Ok(())
 }


### PR DESCRIPTION
Trying to support this so I can write proper `new` methods for the atomics library. This task _almost_ seemed like it would be really easy: rustc has a function called `qpath_res` which can look up any `QPath` and return a `DefId`, so for any call, I could just look up a `DefId` and we're off to the races; unless the `DefIf` is a Local, in which case we fall back to a dynamically computed function.

The trouble was converting the DefId to a VIR path. Naively, this results in paths that includes something like `impl#0` in it. I then realized the rest of the code does this conversion by taking the path to the type and using that path (the `self_path`) instead.

So, I still had to determine the `self_path` when handling the call expression. So to do that, I had to check if the `qpath` was type relative, get the type, and call `qpath_res` _again_ on the type to get the def id of the type, which was all slightly awkward.

It seems to me that currently, the rustc DefId -> VIR Path conversion is fairly brittle. Currently every place we do this conversion (including this new place) seems like it's using redundant information, whereas we really ought to be able to get all the information we need from the DefId. But I couldn't figure out how to use rustc's library to get from the DefId directly to the type ... which might be why it's written this way to begin with?