### PR TITLE
Add #[is_variant] to enable adt.is_Variant() and adt.get_Variant()

### DIFF
--- a/source/builtin_macros/src/is_variant.rs
+++ b/source/builtin_macros/src/is_variant.rs
@@ -14,16 +14,38 @@ pub fn attribute_is_variant(
         .variants()
         .iter()
         .map(|v| {
-            let variant_ident = v.ast().ident.to_string();
-
+            let variant_ident = v.ast().ident;
+            let variant_ident_str = variant_ident.to_string();
             let fun_ident =
-                syn::Ident::new(&format!("is_{}", &variant_ident), v.ast().ident.span());
+                syn::Ident::new(&format!("is_{}", &variant_ident_str), v.ast().ident.span());
+            let get_ident =
+                syn::Ident::new(&format!("get_{}", &variant_ident_str), v.ast().ident.span());
+            let get_fn = match v.ast().fields {
+                &syn::Fields::Named(_) | &syn::Fields::Unit => { quote! { } }
+                &syn::Fields::Unnamed(syn::FieldsUnnamed { unnamed: ref fields, .. }) => {
+                    let field_tys = fields.iter().map(|f| &f.ty).collect::<Vec<_>>();
+                    let field_idents = fields.iter().zip(0..).map(|(_, i)| syn::Ident::new(&format!("e{}", i), v.ast().ident.span())).collect::<Vec<_>>();
+                    quote! {
+                        #[allow(non_snake_case)]
+                        #[spec]
+                        pub fn #get_ident(self) -> (#(#field_tys),*,) {
+                            match self {
+                                #struct_name::#variant_ident(#(#field_idents),*) => (#(#field_idents),*,),
+                                _ => arbitrary(),
+                            }
+                        }
+                    }
+                },
+            };
+
             quote! {
                 #[doc(hidden)]
                 #[spec]
                 #[verifier(is_variant)]
                 #[allow(non_snake_case)]
-                fn #fun_ident(&self) -> bool { unimplemented!() }
+                pub fn #fun_ident(&self) -> bool { unimplemented!() }
+
+                #get_fn
             }
         })
         .collect::<proc_macro2::TokenStream>();

--- a/source/builtin_macros/src/is_variant.rs
+++ b/source/builtin_macros/src/is_variant.rs
@@ -1,0 +1,40 @@
+use quote::quote;
+
+pub fn attribute_is_variant(
+    _attr: proc_macro2::TokenStream,
+    s: synstructure::Structure,
+) -> proc_macro2::TokenStream {
+    let ast = &s.ast();
+    match ast.data {
+        syn::Data::Enum(_) => {}
+        _ => panic!("#[is_variant] is only allowed on enums"),
+    }
+    let struct_name = &s.ast().ident;
+    let is_impls = s
+        .variants()
+        .iter()
+        .map(|v| {
+            let variant_ident = v.ast().ident.to_string();
+
+            let fun_ident =
+                syn::Ident::new(&format!("is_{}", &variant_ident), v.ast().ident.span());
+            quote! {
+                #[doc(hidden)]
+                #[spec]
+                #[verifier(is_variant)]
+                #[allow(non_snake_case)]
+                fn #fun_ident(&self) -> bool { unimplemented!() }
+            }
+        })
+        .collect::<proc_macro2::TokenStream>();
+
+    let generics = &ast.generics;
+    quote! {
+        #ast
+
+        #[automatically_derived]
+        impl#generics #struct_name#generics {
+            #is_impls
+        }
+    }
+}

--- a/source/builtin_macros/src/lib.rs
+++ b/source/builtin_macros/src/lib.rs
@@ -1,28 +1,7 @@
-use quote::quote;
-use synstructure::decl_derive;
+use synstructure::{decl_attribute, decl_derive};
+mod is_variant;
+mod structural;
 
-decl_derive!([Structural] => derive_structural);
+decl_derive!([Structural] => structural::derive_structural);
 
-fn derive_structural(s: synstructure::Structure) -> proc_macro2::TokenStream {
-    let assert_receiver_is_structural_body = s
-        .variants()
-        .iter()
-        .flat_map(|v| v.ast().fields)
-        .map(|f| {
-            let ty = &f.ty;
-            quote! {
-                let _: ::builtin::AssertParamIsStructural<#ty>;
-            }
-        })
-        .collect::<proc_macro2::TokenStream>();
-    s.gen_impl(quote! {
-        #[automatically_derived]
-        gen impl ::builtin::Structural for @Self {
-            #[inline]
-            #[doc(hidden)]
-            fn assert_receiver_is_structural(&self) -> () {
-                #assert_receiver_is_structural_body
-            }
-        }
-    })
-}
+decl_attribute!([is_variant] => is_variant::attribute_is_variant);

--- a/source/builtin_macros/src/structural.rs
+++ b/source/builtin_macros/src/structural.rs
@@ -1,0 +1,25 @@
+use quote::quote;
+
+pub fn derive_structural(s: synstructure::Structure) -> proc_macro2::TokenStream {
+    let assert_receiver_is_structural_body = s
+        .variants()
+        .iter()
+        .flat_map(|v| v.ast().fields)
+        .map(|f| {
+            let ty = &f.ty;
+            quote! {
+                let _: ::builtin::AssertParamIsStructural<#ty>;
+            }
+        })
+        .collect::<proc_macro2::TokenStream>();
+    s.gen_impl(quote! {
+        #[automatically_derived]
+        gen impl ::builtin::Structural for @Self {
+            #[inline]
+            #[doc(hidden)]
+            fn assert_receiver_is_structural(&self) -> () {
+                #assert_receiver_is_structural_body
+            }
+        }
+    })
+}

--- a/source/docs/air/enum_field.air
+++ b/source/docs/air/enum_field.air
@@ -1,0 +1,68 @@
+(declare-datatypes () (
+ (Maybe.
+  (Maybe./Some
+    (Maybe./Some/_0 Int)
+  )
+  (Maybe./None)
+ )
+))
+
+(check-valid
+ (declare-const m@ Maybe.)
+ (block
+  (assume
+   (= m@ (Maybe./None))
+  )
+  (assert ("000") (= (Maybe./Some/_0 m@) 3)) ; FAILS
+ )
+)
+
+(check-valid
+ (declare-const m@ Maybe.)
+ (block
+  (assume
+   (and
+    (is-Maybe./Some m@)
+    (= (Maybe./Some/_0 m@) 3)
+   )
+  )
+  (assert ("001") (= m@ (Maybe./Some 3)))
+ )
+)
+
+(check-valid
+ (declare-const m@ Maybe.)
+ (block
+  (assume
+   (and
+    (is-Maybe./None m@)
+    (= (Maybe./Some/_0 m@) 3)
+   )
+  )
+  (assert ("002a")
+   (= (Maybe./Some/_0 m@) 3)
+  )
+  (assert ("002b")
+   (is-Maybe./None m@)
+  )
+ )
+)
+
+ (declare-fun req%foo. (Maybe.) Bool)
+ (axiom (forall ((m@ Maybe.)) (!
+    (= (req%foo. m@) (and
+      (axiom_location ("failed precondition") (= (Maybe./Some/_0 m@) 3))
+    ))
+ )))
+
+(check-valid
+ (declare-const m@ Maybe.)
+ (block
+  (assume
+   (is-Maybe./None m@)
+  )
+  (assert ("003") ; FAILS
+   (req%foo. m@)
+  )
+ )
+)

--- a/source/rust_verify/Cargo.toml
+++ b/source/rust_verify/Cargo.toml
@@ -11,6 +11,7 @@ air = { path = "../air" }
 vir = { path = "../vir" }
 sise = "0.6.0"
 getopts = { git = "https://github.com/utaal/getopts.git", branch = "parse-partial" }
+regex = "1"
 
 [target.'cfg(windows)'.dependencies]
 win32job = "1"

--- a/source/rust_verify/example/adts.rs
+++ b/source/rust_verify/example/adts.rs
@@ -11,30 +11,42 @@ struct Car<P> {
 
 #[derive(Structural, PartialEq, Eq)]
 enum Vehicle {
-    Car(Car<int>),
+    Car(Car<u64>),
     Train(bool),
 }
 
-fn test_struct_1(p: int) {
+fn test_struct_1(p: u64) {
     let c1 = Car { four_doors: true, passengers: p };
     assert(c1.passengers == p);
     assert((Car { passengers: p, four_doors: true }).passengers == p);
 }
 
-// fn test_structural_eq(passengers: int) {
-//     let c1 = Car { passengers, four_doors: true };
-//     let c2 = Car { passengers, four_doors: false };
-//     let c3 = Car { passengers, four_doors: true };
-// 
-//     assert(c1 == c3);
-//     assert(c1 != c2);
-// 
-//     let t = Vehicle::Train(true);
-//     let ca = Vehicle::Car(c1);
-// 
-//     assert(t != ca);
-//     // assert(t == ca); // FAILS
-// }
+fn test_structural_eq(passengers: u64) {
+    let c1 = Car { passengers, four_doors: true };
+    let c2 = Car { passengers, four_doors: false };
+    let c3 = Car { passengers, four_doors: true };
+
+    assert(c1 == c3);
+    assert(c1 != c2);
+
+    let t = Vehicle::Train(true);
+    let ca = Vehicle::Car(c1);
+
+    assert(t != ca);
+}
+
+#[is_variant] #[derive(Structural, PartialEq, Eq)]
+enum Vehicle2<T> {
+    Car(Car<T>),
+    Train(bool),
+}
+
+fn test_is_variant_1(v: Vehicle2<u64>) {
+    match v {
+        Vehicle2::Car(_) => assert(v.is_Car()),
+        Vehicle2::Train(_) => assert(v.is_Train()),
+    };
+}
 
 fn main() {
 }

--- a/source/rust_verify/example/adts.rs
+++ b/source/rust_verify/example/adts.rs
@@ -49,7 +49,7 @@ fn test_is_variant_1(v: Vehicle2<u64>) {
 }
 
 fn test_is_variant_2(v: Vehicle2<u64>) {
-    requires(v.is_Train() && v.get_Train().0);
+    requires(v.is_Train() && v.get_Train_0());
 }
 
 #[is_variant]

--- a/source/rust_verify/example/adts.rs
+++ b/source/rust_verify/example/adts.rs
@@ -48,5 +48,15 @@ fn test_is_variant_1(v: Vehicle2<u64>) {
     };
 }
 
+fn test_is_variant_2(v: Vehicle2<u64>) {
+    requires(v.is_Train() && v.get_Train().0);
+}
+
+#[is_variant]
+pub enum Maybe<T> {
+    Some(T),
+    None,
+}
+
 fn main() {
 }

--- a/source/rust_verify/src/def.rs
+++ b/source/rust_verify/src/def.rs
@@ -1,0 +1,1 @@
+pub const IS_VARIANT_PREFIX: &str = "is_";

--- a/source/rust_verify/src/def.rs
+++ b/source/rust_verify/src/def.rs
@@ -1,1 +1,29 @@
+use regex::Regex;
+
 pub const IS_VARIANT_PREFIX: &str = "is_";
+pub const GET_VARIANT_PREFIX: &str = "get_";
+
+/// Returns `Some((name, field))` if the ident matches the expected name for #[is_variant] functions
+/// `name` is the variant name
+/// `field` is `Some(num)` if this was a `.get_Variant_num()` function
+/// `field` is `None` if this was a `.is_Variant` function
+pub(crate) fn is_get_variant_fn_name(
+    ident: &rustc_span::symbol::Ident,
+) -> Option<(String, Option<usize>)> {
+    let fn_name = ident.as_str();
+    fn_name.strip_prefix(crate::def::IS_VARIANT_PREFIX).map(|n| (n.to_string(), None)).or_else(
+        || {
+            let re =
+                Regex::new(&("^".to_string() + crate::def::GET_VARIANT_PREFIX + r"(.*)_(\d+)$"))
+                    .unwrap();
+            re.captures(&fn_name).and_then(|c| {
+                c.get(2)
+                    .unwrap()
+                    .as_str()
+                    .parse::<usize>()
+                    .ok()
+                    .map(|f| (c.get(1).unwrap().as_str().to_string(), Some(f)))
+            })
+        },
+    )
+}

--- a/source/rust_verify/src/def.rs
+++ b/source/rust_verify/src/def.rs
@@ -3,26 +3,35 @@ use regex::Regex;
 pub const IS_VARIANT_PREFIX: &str = "is_";
 pub const GET_VARIANT_PREFIX: &str = "get_";
 
+pub(crate) enum FieldName {
+    Named(String),
+    Unnamed(usize),
+}
+
 /// Returns `Some((name, field))` if the ident matches the expected name for #[is_variant] functions
 /// `name` is the variant name
 /// `field` is `Some(num)` if this was a `.get_Variant_num()` function
 /// `field` is `None` if this was a `.is_Variant` function
 pub(crate) fn is_get_variant_fn_name(
     ident: &rustc_span::symbol::Ident,
-) -> Option<(String, Option<usize>)> {
+) -> Option<(String, Option<FieldName>)> {
     let fn_name = ident.as_str();
     fn_name.strip_prefix(crate::def::IS_VARIANT_PREFIX).map(|n| (n.to_string(), None)).or_else(
         || {
             let re =
-                Regex::new(&("^".to_string() + crate::def::GET_VARIANT_PREFIX + r"(.*)_(\d+)$"))
+                Regex::new(&("^".to_string() + crate::def::GET_VARIANT_PREFIX + r"(.+)_(.+)$"))
                     .unwrap();
-            re.captures(&fn_name).and_then(|c| {
-                c.get(2)
-                    .unwrap()
-                    .as_str()
-                    .parse::<usize>()
-                    .ok()
-                    .map(|f| (c.get(1).unwrap().as_str().to_string(), Some(f)))
+            re.captures(&fn_name).map(|c| {
+                let f_name = c.get(2).unwrap().as_str().to_string();
+                let v_name = c.get(1).unwrap().as_str().to_string();
+
+                (
+                    v_name,
+                    Some(match f_name.parse::<usize>().ok() {
+                        Some(i) => FieldName::Unnamed(i),
+                        None => FieldName::Named(f_name),
+                    }),
+                )
             })
         },
     )

--- a/source/rust_verify/src/erase.rs
+++ b/source/rust_verify/src/erase.rs
@@ -994,6 +994,9 @@ fn erase_assoc_item(ctxt: &Ctxt, mctxt: &mut MCtxt, item: &AssocItem) -> Option<
             if vattrs.external {
                 return Some(item.clone());
             }
+            if vattrs.is_variant {
+                return None;
+            }
             let erased = erase_fn(ctxt, mctxt, f, vattrs.external_body);
             erased.map(|f| update_item(item, AssocItemKind::Fn(Box::new(f))))
         }

--- a/source/rust_verify/src/lib.rs
+++ b/source/rust_verify/src/lib.rs
@@ -21,6 +21,7 @@ extern crate rustc_typeck;
 pub mod config;
 pub mod context;
 pub mod debugger;
+pub mod def;
 pub mod driver;
 pub mod erase;
 pub mod file_loader;

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -205,11 +205,24 @@ fn check_item<'tcx>(
                                                                 v.ident.as_str() == variant_name
                                                             })
                                                             .and_then(|variant| {
-                                                                if let Some(field) = variant_field {
-                                                                    (field < variant.fields.len())
-                                                                        .then(|| ())
-                                                                } else {
-                                                                    Some(())
+                                                                use crate::def::FieldName;
+                                                                match variant_field {
+                                                                    Some(FieldName::Named(
+                                                                        f_name,
+                                                                    )) => variant
+                                                                        .fields
+                                                                        .iter()
+                                                                        .find(|f| {
+                                                                            f.ident.as_str()
+                                                                                == f_name
+                                                                        })
+                                                                        .map(|_| ()),
+                                                                    Some(FieldName::Unnamed(
+                                                                        f_num,
+                                                                    )) => (f_num
+                                                                        < variant.fields.len())
+                                                                    .then(|| ()),
+                                                                    None => Some(()),
                                                                 }
                                                             })
                                                     },

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -47,6 +47,28 @@ pub(crate) fn typ_path_and_ident_to_vir_path<'tcx>(path: &Path, ident: vir::ast:
     return Arc::new(path);
 }
 
+pub(crate) fn fn_item_hir_id_to_self_def_id<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    hir_id: HirId,
+) -> Option<DefId> {
+    let parent_id = tcx.hir().get_parent_node(hir_id);
+    let parent_node = tcx.hir().get(parent_id);
+    match parent_node {
+        rustc_hir::Node::Item(rustc_hir::Item {
+            kind: rustc_hir::ItemKind::Impl(impll), ..
+        }) => match &impll.self_ty.kind {
+            rustc_hir::TyKind::Path(QPath::Resolved(
+                None,
+                rustc_hir::Path { res: rustc_hir::def::Res::Def(_, self_def_id), .. },
+            )) => Some(*self_def_id),
+            _ => {
+                panic!("impl type is not given by a path");
+            }
+        },
+        _ => None,
+    }
+}
+
 pub(crate) fn def_id_to_vir_path<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> Path {
     // The path that rustc gives a DefId might be given in terms of an 'impl' path
     // However, it makes for a better path name to use the path to the *type*.
@@ -55,30 +77,9 @@ pub(crate) fn def_id_to_vir_path<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> Path
     if let Some(local_id) = def_id.as_local() {
         let hir = tcx.hir().local_def_id_to_hir_id(local_id);
         if is_function_def_impl_item_node(tcx.hir().get(hir)) {
-            let parent_id = tcx.hir().get_parent_node(hir);
-            let parent_node = tcx.hir().get(parent_id);
-            match parent_node {
-                rustc_hir::Node::Item(rustc_hir::Item {
-                    kind: rustc_hir::ItemKind::Impl(impll),
-                    ..
-                }) => {
-                    let ty_path = match &impll.self_ty.kind {
-                        rustc_hir::TyKind::Path(QPath::Resolved(
-                            None,
-                            rustc_hir::Path {
-                                res: rustc_hir::def::Res::Def(_, self_def_id), ..
-                            },
-                        )) => def_path_to_vir_path(tcx, tcx.def_path(*self_def_id)),
-                        _ => {
-                            panic!("impl type is not given by a path");
-                        }
-                    };
-                    return typ_path_and_ident_to_vir_path(
-                        &ty_path,
-                        def_to_path_ident(tcx, def_id),
-                    );
-                }
-                _ => {}
+            if let Some(self_def_id) = fn_item_hir_id_to_self_def_id(tcx, hir) {
+                let ty_path = def_path_to_vir_path(tcx, tcx.def_path(self_def_id));
+                return typ_path_and_ident_to_vir_path(&ty_path, def_to_path_ident(tcx, def_id));
             }
         }
     }
@@ -267,6 +268,8 @@ pub(crate) enum Attr {
     Atomic,
     // specifies an invariant block
     InvariantBlock,
+    // an enum variant is_Variant
+    IsVariant,
 }
 
 fn get_trigger_arg(span: Span, attr_tree: &AttrTree) -> Result<u64, VirErr> {
@@ -327,6 +330,9 @@ pub(crate) fn parse_attrs(attrs: &[Attribute]) -> Result<Vec<Attr>, VirErr> {
                 Some(box [AttrTree::Fun(_, arg, None)]) if arg == "atomic" => v.push(Attr::Atomic),
                 Some(box [AttrTree::Fun(_, arg, None)]) if arg == "invariant_block" => {
                     v.push(Attr::InvariantBlock)
+                }
+                Some(box [AttrTree::Fun(_, arg, None)]) if arg == "is_variant" => {
+                    v.push(Attr::IsVariant)
                 }
                 Some(box [AttrTree::Fun(_, arg, Some(box [AttrTree::Fun(_, msg, None)]))])
                     if arg == "custom_req_err" =>
@@ -428,6 +434,7 @@ pub(crate) struct VerifierAttrs {
     pub(crate) bit_vector: bool,
     pub(crate) unforgeable: bool,
     pub(crate) atomic: bool,
+    pub(crate) is_variant: bool,
 }
 
 pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, VirErr> {
@@ -441,6 +448,7 @@ pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, V
         bit_vector: false,
         unforgeable: false,
         atomic: false,
+        is_variant: false,
     };
     for attr in parse_attrs(attrs)? {
         match attr {
@@ -453,6 +461,7 @@ pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, V
             Attr::BitVector => vs.bit_vector = true,
             Attr::Unforgeable => vs.unforgeable = true,
             Attr::Atomic => vs.atomic = true,
+            Attr::IsVariant => vs.is_variant = true,
             _ => {}
         }
     }

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -1,9 +1,10 @@
 use crate::context::BodyCtxt;
 use crate::erase::ResolvedCall;
 use crate::rust_to_vir_base::{
-    def_id_to_vir_path, def_to_path_ident, get_range, get_trigger, get_var_mode, hack_get_def_name,
-    ident_to_var, is_smt_arith, is_smt_equality, mid_ty_to_vir, mk_range, parse_attrs, ty_to_vir,
-    typ_of_node, typ_of_node_expect_mut_ref, typ_path_and_ident_to_vir_path, Attr,
+    def_id_to_vir_path, def_to_path_ident, get_range, get_trigger, get_var_mode,
+    get_verifier_attrs, hack_get_def_name, ident_to_var, is_smt_arith, is_smt_equality,
+    mid_ty_to_vir, mk_range, parse_attrs, ty_to_vir, typ_of_node, typ_of_node_expect_mut_ref,
+    typ_path_and_ident_to_vir_path, Attr,
 };
 use crate::util::{
     err_span_str, err_span_string, slice_vec_map_result, spanned_new, spanned_typed_new,
@@ -269,6 +270,34 @@ fn fn_call_to_vir<'tcx>(
         def_id_to_vir_path(tcx, f)
     };
 
+    let is_variant = {
+        match tcx.hir().get_if_local(f) {
+            Some(rustc_hir::Node::ImplItem(
+                impl_item
+                @
+                rustc_hir::ImplItem {
+                    kind: rustc_hir::ImplItemKind::Fn(..),
+                    ident: fn_ident,
+                    ..
+                },
+            )) => {
+                let fn_attrs = bctx.ctxt.tcx.hir().attrs(impl_item.hir_id());
+                let fn_vattrs = get_verifier_attrs(fn_attrs)?;
+                if fn_vattrs.is_variant {
+                    let variant_name = fn_ident
+                        .as_str()
+                        .strip_prefix(crate::def::IS_VARIANT_PREFIX)
+                        .expect("invalid is_variant function")
+                        .to_string();
+                    Some(variant_name)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    };
+
     let f_name = path_as_rust_name(&def_id_to_vir_path(tcx, f));
     let is_admit = f_name == "builtin::admit";
     let is_requires = f_name == "builtin::requires";
@@ -349,7 +378,7 @@ fn fn_call_to_vir<'tcx>(
         expr.span,
         "call of trait impl"
     );
-    let name = Arc::new(FunX { path: path, trait_path: None });
+    let name = Arc::new(FunX { path: path.clone(), trait_path: None });
 
     record_fun(
         &bctx.ctxt,
@@ -361,7 +390,8 @@ fn fn_call_to_vir<'tcx>(
             || is_assert_by
             || is_choose
             || is_assert_bit_vector
-            || is_old,
+            || is_old
+            || is_variant.is_some(),
         is_implies,
     );
 
@@ -488,7 +518,7 @@ fn fn_call_to_vir<'tcx>(
         }
         _ => expr_to_vir(bctx, arg, ExprModifier::Regular),
     })?;
-    if let Some(autoview_typ) = autoview_typ {
+    let self_path = if let Some(autoview_typ) = autoview_typ {
         // replace f(arg0, arg1, ..., argn) with f(arg0.view(), arg1, ..., argn)
         let typ_args = if let TypX::Datatype(_, args) = &**autoview_typ {
             args.clone()
@@ -507,6 +537,19 @@ fn fn_call_to_vir<'tcx>(
         let target = CallTarget::Static(fun, typ_args);
         let viewx = ExprX::Call(target, Arc::new(vec![vir_args[0].clone()]));
         vir_args[0] = spanned_typed_new(expr.span, autoview_typ, viewx);
+        self_path
+    } else {
+        let mut self_path = path.clone();
+        let self_path_mut = Arc::make_mut(&mut self_path);
+        Arc::make_mut(&mut self_path_mut.segments).pop();
+        self_path
+    };
+
+    if let Some(variant_name) = is_variant {
+        return Ok(mk_expr(ExprX::UnaryOpr(
+            UnaryOpr::IsVariant { datatype: self_path, variant: str_ident(&variant_name) },
+            vir_args.into_iter().next().expect("missing arg for is_variant"),
+        )));
     }
 
     let is_smt_binary = if is_equal {

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -549,11 +549,16 @@ fn fn_call_to_vir<'tcx>(
             )));
         }
         Some((variant_name, Some(variant_field))) => {
+            use crate::def::FieldName;
+            let variant_name_ident = str_ident(&variant_name);
             return Ok(mk_expr(ExprX::UnaryOpr(
                 UnaryOpr::Field {
-                    datatype: self_path,
-                    variant: str_ident(&variant_name),
-                    field: positional_field_ident(variant_field),
+                    datatype: self_path.clone(),
+                    variant: variant_name_ident.clone(),
+                    field: match variant_field {
+                        FieldName::Unnamed(i) => positional_field_ident(i),
+                        FieldName::Named(f) => str_ident(&f),
+                    },
                 },
                 vir_args.into_iter().next().expect("missing arg for is_variant"),
             )));

--- a/source/rust_verify/tests/adts.rs
+++ b/source/rust_verify/tests/adts.rs
@@ -229,3 +229,43 @@ test_verify_one_file! {
         }
     } => Err(e) => assert_vir_error(e)
 }
+
+test_verify_one_file! {
+    #[test] test_is_variant_pass code! {
+        #[is_variant]
+        pub enum Maybe<T> {
+            Some(T),
+            None,
+        }
+
+        pub fn test1(m: Maybe<u64>) {
+            match m {
+                Maybe::Some(_) => assert(m.is_Some()),
+                Maybe::None => assert(m.is_None()),
+            };
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_is_variant_illegal code! {
+        pub enum Maybe<T> {
+            Some(T),
+            None,
+        }
+
+        impl <T> Maybe<T> {
+            #[doc(hidden)] #[spec] #[verifier(is_variant)] #[allow(non_snake_case)]
+            fn is_Thing(&self) -> bool { ::core::panicking::panic("not implemented") }
+        }
+    } => Err(e) => assert_vir_error(e)
+}
+
+test_verify_one_file! {
+    #[test] test_is_variant_not_enum code! {
+        #[is_variant]
+        pub struct Maybe<T> {
+            t: T,
+        }
+    } => Err(_)
+}

--- a/source/rust_verify/tests/adts.rs
+++ b/source/rust_verify/tests/adts.rs
@@ -275,7 +275,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_is_variant_get_1 IS_VARIANT_MAYBE.to_string() + code_str! {
         pub fn test1(m: Maybe<u64>) {
-            requires(m.is_Some() && m.get_Some().0 > 10);
+            requires(m.is_Some() && m.get_Some_0() > 10);
         }
     } => Ok(())
 }
@@ -284,7 +284,7 @@ test_verify_one_file! {
     #[test] test_is_variant_get_2 IS_VARIANT_MAYBE.to_string() + code_str! {
         pub fn test1(m: Maybe<u64>) -> bool {
             ensures(|res: bool|
-                (m.is_Some() >>= res == (m.get_Some().0 == 3)) &&
+                (m.is_Some() >>= res == (m.get_Some_0() == 3)) &&
                 (m.is_None() >>= !res)
             );
             match m {
@@ -298,6 +298,15 @@ test_verify_one_file! {
             let res = test1(m);
             assert(res);
         }
+
+        pub fn test3(v: Maybe<u64>) {
+            requires(v.is_Some() && v.get_Some_0() == 5);
+            if let Maybe::Some(a) = v {
+                assert(a == 5);
+            } else {
+                unreached::<()>();
+            }
+        }
     } => Ok(())
 }
 
@@ -310,4 +319,12 @@ test_verify_one_file! {
             None,
         }
     } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_is_variant_no_field IS_VARIANT_MAYBE.to_string() + code_str! {
+        fn test1(v: Maybe<u64>) {
+            assert(v.get_Some_1() == 3);
+        }
+    } => Err(_) // type-checking error
 }

--- a/source/rust_verify/tests/adts.rs
+++ b/source/rust_verify/tests/adts.rs
@@ -330,12 +330,32 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_is_variant_no_get code! {
+    #[test] test_is_variant_get_named_field code! {
         #[is_variant]
-        pub enum Maybe<T> {
-            // #[is_variant] won't generate a get_Some for this, but should not panic
-            Some { t: T },
-            None,
+        pub enum Res<T> {
+            Ok { t: T },
+            Err { v: u64 },
+        }
+
+        fn test1(m: Res<bool>) {
+            requires(m.is_Err() && m.get_Err_v() == 42);
+            match m {
+                Res::Ok { .. } => assert(false),
+                Res::Err { v } => assert(v == 42),
+            };
+        }
+
+        fn test2(m: &Res<bool>) -> bool {
+            ensures(|res: bool| equal(res, m.is_Ok() && m.get_Ok_t()));
+            match m {
+                Res::Ok { t } if *t => true,
+                _ => false,
+            }
+        }
+
+        fn caller() {
+            let r = test2(&Res::Ok { t: false });
+            assert(!r);
         }
     } => Ok(())
 }

--- a/source/rust_verify/tests/adts.rs
+++ b/source/rust_verify/tests/adts.rs
@@ -311,6 +311,25 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] test_is_variant_get_fail IS_VARIANT_MAYBE.to_string() + code_str! {
+        pub fn test1(m: Maybe<u64>) -> u64 {
+            requires(m.get_Some_0() == 4);
+            if let Maybe::Some(v) = m {
+                v
+            } else {
+                unreached() // FAILS
+            }
+        }
+
+        pub fn test2() {
+            let m = Maybe::None;
+            assume(m.get_Some_0() == 4);
+            test1(m);
+        }
+    } => Err(e) => assert_one_fails(e)
+}
+
+test_verify_one_file! {
     #[test] test_is_variant_no_get code! {
         #[is_variant]
         pub enum Maybe<T> {

--- a/source/rust_verify/tests/adts.rs
+++ b/source/rust_verify/tests/adts.rs
@@ -269,3 +269,28 @@ test_verify_one_file! {
         }
     } => Err(_)
 }
+
+test_verify_one_file! {
+    #[test] test_is_variant_get code! {
+        #[is_variant]
+        pub enum Maybe<T> {
+            Some(T),
+            None,
+        }
+
+        pub fn test1(m: Maybe<u64>) {
+            requires(m.is_Some() && m.get_Some().0 > 10);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_is_variant_no_get code! {
+        #[is_variant]
+        pub enum Maybe<T> {
+            // #[is_variant] won't generate a get_Some for this, but should not panic
+            Some { t: T },
+            None,
+        }
+    } => Ok(())
+}

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -285,10 +285,10 @@ fn check_expr(typing: &mut Typing, outer_mode: Mode, expr: &Expr) -> Result<Mode
         ExprX::UnaryOpr(UnaryOpr::HasType(_), _) => panic!("internal error: HasType in modes.rs"),
         ExprX::UnaryOpr(UnaryOpr::IsVariant { .. }, e1) => check_expr(typing, outer_mode, e1),
         ExprX::UnaryOpr(UnaryOpr::TupleField { .. }, e1) => check_expr(typing, outer_mode, e1),
-        ExprX::UnaryOpr(UnaryOpr::Field { datatype, variant: _, field }, e1) => {
+        ExprX::UnaryOpr(UnaryOpr::Field { datatype, variant, field }, e1) => {
             let e1_mode = check_expr(typing, outer_mode, e1)?;
             let datatype = &typing.datatypes[datatype];
-            let field = get_field(&datatype.x.get_only_variant().a, field);
+            let field = get_field(&datatype.x.get_variant(variant).a, field);
             Ok(mode_join(e1_mode, field.a.1))
         }
         ExprX::Binary(op, e1, e2) => {


### PR DESCRIPTION
This adds support for the following:

```rust
#[is_variant]
pub enum Maybe<T> {
    Some(T),
    None,
}

pub fn test1(m: Maybe<u64>) {
    match m {
        Maybe::Some(_) => assert(m.is_Some()),
        Maybe::None => assert(m.is_None()),
    };
}

pub fn test2(m: Maybe<u64>) -> bool {
    ensures(|res: bool|
        (m.is_Some() >>= res == (m.get_Some().0 == 3)) &&
        (m.is_None() >>= !res)
    );
    match m {
        Maybe::Some(v) => v == 3,
        Maybe::None => false,
    }
}
```

where `is_Some`, `is_None`, and `get_Some` are auto-generated by the `#[is_variant]` attribute-proc-macro.
`is_Some` and `is_None` are tagged as `#[verifier(is_variant)]` and encoded using AIR/SMT's builtin `(is-Variant)` (like pattern matching VCs).

---

Once this is approved, I'll add `#[is_variant]` to, e.g. `pervasive::Option`.