### PR TITLE
Bitvector bit-wise negation, boolean and/or

### DIFF
--- a/source/air/src/ast.rs
+++ b/source/air/src/ast.rs
@@ -38,6 +38,7 @@ pub enum Constant {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum UnaryOp {
     Not,
+    BitNot,
     BitExtract(u32, u32),
 }
 

--- a/source/air/src/closure.rs
+++ b/source/air/src/closure.rs
@@ -407,11 +407,12 @@ fn simplify_expr(ctxt: &mut Context, state: &mut State, expr: &Expr) -> (Typ, Ex
             (typ.clone(), Arc::new(ExprX::Apply(apply_fun, Arc::new(es))), t)
         }
         ExprX::Unary(op, e1) => {
+            let (es, ts) = simplify_exprs_ref(ctxt, state, &vec![e1]);
             let typ = match op {
                 UnaryOp::Not => Arc::new(TypX::Bool),
                 UnaryOp::BitExtract(high, _) => Arc::new(TypX::BitVec(high + 1)),
+                UnaryOp::BitNot => ts[0].0.clone(),
             };
-            let (es, ts) = simplify_exprs_ref(ctxt, state, &vec![e1]);
             let (es, t) = enclose(state, App::Unary(*op), es, ts);
             (typ, Arc::new(ExprX::Unary(*op, es[0].clone())), t)
         }

--- a/source/air/src/printer.rs
+++ b/source/air/src/printer.rs
@@ -145,11 +145,11 @@ impl Printer {
             ExprX::Unary(op, expr) => {
                 let sop = match op {
                     UnaryOp::Not => "not",
+                    UnaryOp::BitNot => "bvnot",
                     UnaryOp::BitExtract(_, _) => "extract",
                 };
                 // ( (_extract numeral numeral) BitVec )
                 match op {
-                    UnaryOp::Not => Node::List(vec![str_to_node(sop), self.expr_to_node(expr)]),
                     UnaryOp::BitExtract(high, low) => {
                         let mut nodes: Vec<Node> = Vec::new();
                         let mut nodes_in: Vec<Node> = Vec::new();
@@ -161,6 +161,7 @@ impl Printer {
                         nodes.push(self.expr_to_node(expr));
                         Node::List(nodes)
                     }
+                    _ => Node::List(vec![str_to_node(sop), self.expr_to_node(expr)]),
                 }
             }
             ExprX::Binary(op, lhs, rhs) => {

--- a/source/air/src/typecheck.rs
+++ b/source/air/src/typecheck.rs
@@ -141,6 +141,13 @@ fn check_bv_unary_exprs(
             }
             Ok(Arc::new(TypX::BitVec(w_new)))
         }
+        UnaryOp::BitNot => {
+            let t0 = check_expr(typing, &exprs[0])?;
+            match get_bv_width(&t0) {
+                Ok(_) => Ok(t0.clone()),
+                Err(..) => panic!("Interner Error: not a bv type inside a bvnot"),
+            }
+        }
         _ => panic!("Interner Error: not a bv unary op, got {}", f_name),
     }
 }
@@ -205,6 +212,9 @@ fn check_expr(typing: &mut Typing, expr: &Expr) -> Result<Typ, TypeError> {
             }
         }
         ExprX::Unary(UnaryOp::Not, e1) => check_exprs(typing, "not", &[bt()], &bt(), &[e1.clone()]),
+        ExprX::Unary(UnaryOp::BitNot, e1) => {
+            check_bv_unary_exprs(typing, UnaryOp::BitNot, "bvnot", &[e1.clone()])
+        }
         ExprX::Unary(UnaryOp::BitExtract(high, low), e1) => {
             check_bv_unary_exprs(typing, UnaryOp::BitExtract(*high, *low), "extract", &[e1.clone()])
         }

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -1129,8 +1129,13 @@ pub(crate) fn expr_to_vir_inner<'tcx>(
         ExprKind::Box(e) => expr_to_vir_inner(bctx, e, ExprModifier::Regular),
         ExprKind::Unary(op, arg) => match op {
             UnOp::Not => {
+                let not_op = match (tc.node_type(expr.hir_id)).kind() {
+                    TyKind::Adt(_, _) | TyKind::Uint(_) | TyKind::Int(_) => UnaryOp::BitNot,
+                    TyKind::Bool => UnaryOp::Not,
+                    _ => panic!("Internal error on UnOp::Not translation"),
+                };
                 let varg = expr_to_vir(bctx, arg, modifier)?;
-                Ok(mk_expr(ExprX::Unary(UnaryOp::Not, varg)))
+                Ok(mk_expr(ExprX::Unary(not_op, varg)))
             }
             UnOp::Neg => {
                 let zero_const = vir::ast::Constant::Nat(Arc::new("0".to_string()));

--- a/source/rust_verify/tests/bitvector.rs
+++ b/source/rust_verify/tests/bitvector.rs
@@ -96,7 +96,6 @@ test_verify_one_file! {
             assert_bit_vector( !b1 != !b2 >>= !(b1==b2));
             assert_bit_vector(((b1 == (1 as u64)) && (b2 == b3)) >>= (b1 + b2 == b3 + 1));
             assert_bit_vector((b1 == b2)  >>= (!b1 == !b2));
-            assert_bit_vector( b1 + (!b1) + 1 == 0);
             assert_bit_vector( b1 == (!(!b1)));
         }
     } => Ok(())

--- a/source/rust_verify/tests/bitvector.rs
+++ b/source/rust_verify/tests/bitvector.rs
@@ -16,8 +16,8 @@ test_verify_one_file! {
             assert_bit_vector(b & b == b);
             assert(b & b == b);
 
-            assert_bit_vector(b & 0 == 0);
-            assert(b & 0 == 0);
+            assert_bit_vector(b + (!b) + 1 == 0);
+            assert(b + (!b) + 1 == 0);
 
             assert_bit_vector(b | b == b);
             assert(b | b == b);
@@ -38,7 +38,7 @@ test_verify_one_file! {
             assert(b < 256 >>= ((b<<2) as int) == (b as int) *4);
 
             assert_bit_vector(b>>1 == b/2);
-            assert(b>>1 == b/2);    
+            assert(b>>1 == b/2);
         }
     } => Ok(())
 }
@@ -82,7 +82,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test6 code! {
         #[proof]
-        fn test6(u:u64) {
+        fn test6(a:u64, b:u64, c:u64) {
             assert_bit_vector((a ^ b == a ^ c) >>= (b == c));
             assert((a ^ b == a ^ c) >>= (b == c));
         }
@@ -139,6 +139,7 @@ test_verify_one_file! {
     #[test] test6_fails code! {
         #[proof]
         fn test6(b: u32) {
+            assert_bit_vector(b<<2 == b*4);
             assert(((b<<2) as int) == (b as int) *4);  // FAILS
         }
     } => Err(err) => assert_one_fails(err)

--- a/source/rust_verify/tests/bitvector.rs
+++ b/source/rust_verify/tests/bitvector.rs
@@ -90,6 +90,19 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] test7 code! {
+        #[proof]
+        fn test8(b1:u64, b2:u64, b3:u64) {
+            assert_bit_vector( !b1 != !b2 >>= !(b1==b2));
+            assert_bit_vector(((b1 == (1 as u64)) && (b2 == b3)) >>= (b1 + b2 == b3 + 1));
+            assert_bit_vector((b1 == b2)  >>= (!b1 == !b2));
+            assert_bit_vector( b1 + (!b1) + 1 == 0);
+            assert_bit_vector( b1 == (!(!b1)));
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
     #[test] test1_fails code! {
         #[proof]
         fn test1(b: u32) {

--- a/source/rust_verify/tests/bitvector.rs
+++ b/source/rust_verify/tests/bitvector.rs
@@ -35,9 +35,10 @@ test_verify_one_file! {
 
             assert_bit_vector(b<<2 == b*4);
             assert(b<<2 == b*4);
+            assert(b < 256 >>= ((b<<2) as int) == (b as int) *4);
 
             assert_bit_vector(b>>1 == b/2);
-            assert(b>>1 == b/2);
+            assert(b>>1 == b/2);    
         }
     } => Ok(())
 }
@@ -74,6 +75,16 @@ test_verify_one_file! {
         fn test5(u:u64) {
             assert_bit_vector( (u >> (32 as u64)) as u32  ==  (u / (0x100000000 as u64)) as u32);
             assert( (u >> (32 as u64)) as u32  ==  (u / (0x100000000 as u64)) as u32);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test6 code! {
+        #[proof]
+        fn test6(u:u64) {
+            assert_bit_vector((a ^ b == a ^ c) >>= (b == c));
+            assert((a ^ b == a ^ c) >>= (b == c));
         }
     } => Ok(())
 }
@@ -120,6 +131,15 @@ test_verify_one_file! {
         fn test5(b: u32) {
             assert_bit_vector((b << 1) == b*2);
             assert((b << 1) == b*4); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test6_fails code! {
+        #[proof]
+        fn test6(b: u32) {
+            assert(((b<<2) as int) == (b as int) *4);  // FAILS
         }
     } => Err(err) => assert_one_fails(err)
 }

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -95,6 +95,8 @@ pub enum TypX {
 pub enum UnaryOp {
     /// boolean not
     Not,
+    /// bitwise not
+    BitNot,
     /// Mark an expression as a member of an SMT quantifier trigger group.
     /// Each trigger group becomes one SMT trigger containing all the expressions in the trigger group.
     /// Each group is named by either Some integer, or the unnamed group None.

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -113,6 +113,7 @@ pub const UINT_AND: &str = "uintand";
 pub const UINT_OR: &str = "uintor";
 pub const UINT_SHR: &str = "uintshr";
 pub const UINT_SHL: &str = "uintshl";
+pub const UINT_NOT: &str = "uintnot";
 
 // We assume that usize is at least ARCH_SIZE_MIN_BITS wide
 pub const ARCH_SIZE_MIN_BITS: u32 = 32;

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -284,7 +284,7 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
         ExprX::Unary(op, e1) => {
             let e1 = poly_expr(ctx, state, e1);
             match op {
-                UnaryOp::Not | UnaryOp::Clip(_) => {
+                UnaryOp::Not | UnaryOp::Clip(_) | UnaryOp::BitNot => {
                     let e1 = coerce_expr_to_native(ctx, &e1);
                     mk_expr(ExprX::Unary(*op, e1))
                 }

--- a/source/vir/src/prelude.rs
+++ b/source/vir/src/prelude.rs
@@ -49,6 +49,7 @@ pub(crate) fn prelude_nodes() -> Vec<Node> {
     let uint_or = str_to_node(UINT_OR);
     let uint_shr = str_to_node(UINT_SHR);
     let uint_shl = str_to_node(UINT_SHL);
+    let uint_not = str_to_node(UINT_NOT);
 
     nodes_vec!(
         // Fuel
@@ -280,6 +281,7 @@ pub(crate) fn prelude_nodes() -> Vec<Node> {
         (declare-fun [uint_or] (Int Int) Int)
         (declare-fun [uint_shr] (Int Int) Int)
         (declare-fun [uint_shl] (Int Int) Int)
+        (declare-fun [uint_not] (Int) Int)
     )
 }
 

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -654,6 +654,7 @@ fn exp_to_bv_expr(state: &State, exp: &Exp) -> Expr {
                 BinaryOp::BitOr => air::ast::BinaryOp::BitOr,
                 BinaryOp::Shl => air::ast::BinaryOp::Shl,
                 BinaryOp::Shr => air::ast::BinaryOp::LShr,
+                BinaryOp::Implies => air::ast::BinaryOp::Implies,
                 _ => panic!("unhandled bv binary operation {:?}", op),
             };
             // disallow signed integer from bitvec reasoning. However, allow that for shift

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -697,7 +697,6 @@ fn exp_to_bv_expr(state: &State, exp: &Exp) -> Expr {
                     let bop = air::ast::UnaryOp::Not;
                     return Arc::new(ExprX::Unary(bop, bv_e));
                 }
-                // translate Not into boolean not and bitwise not according to operand type
                 UnaryOp::BitNot => {
                     let bop = air::ast::UnaryOp::BitNot;
                     return Arc::new(ExprX::Unary(bop, bv_e));
@@ -710,11 +709,11 @@ fn exp_to_bv_expr(state: &State, exp: &Exp) -> Expr {
                             // expand with zero using concat
                             if new_n > old_n {
                                 let bop = air::ast::BinaryOp::BitConcat;
-                                let lh = Arc::new(ExprX::Const(Constant::BitVec(
+                                let zero_pad = Arc::new(ExprX::Const(Constant::BitVec(
                                     Arc::new("0".to_string()),
                                     new_n - old_n,
                                 )));
-                                return Arc::new(ExprX::Binary(bop, lh, bv_e));
+                                return Arc::new(ExprX::Binary(bop, zero_pad, bv_e));
                             }
                             // extract lower new_n bits
                             else if new_n < old_n {
@@ -734,7 +733,7 @@ fn exp_to_bv_expr(state: &State, exp: &Exp) -> Expr {
                     "IntRange error: should be I(_) or U(_) for bit-vector, got {:?}",
                     exp.typ
                 ),
-                UnaryOp::Trigger(_) => panic!("Trigger is not allowed in bit-vector"),
+                UnaryOp::Trigger(_) => panic!("Trigger is not supported in bit-vector"),
             }
         }
         _ => panic!("unhandled bv expr conversion {:?}", exp.x),

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -56,7 +56,7 @@ fn check_trigger_expr(exp: &Exp, free_vars: &mut HashSet<Ident>) -> Result<(), V
         ExpX::VarAt(_, VarAt::Pre) => Ok(exp.clone()),
         ExpX::Old(_, _) => panic!("internal error: Old"),
         ExpX::Unary(op, _) => match op {
-            UnaryOp::Trigger(_) | UnaryOp::Clip(_) => Ok(exp.clone()),
+            UnaryOp::Trigger(_) | UnaryOp::Clip(_) | UnaryOp::BitNot => Ok(exp.clone()),
             UnaryOp::Not => err_str(&exp.span, "triggers cannot contain boolean operators"),
         },
         ExpX::UnaryOpr(op, _) => match op {

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -246,7 +246,7 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
         ExpX::Unary(op, e1) => {
             let depth = match op {
                 UnaryOp::Not => 0,
-                UnaryOp::Trigger(_) | UnaryOp::Clip(_) => 1,
+                UnaryOp::Trigger(_) | UnaryOp::Clip(_) | UnaryOp::BitNot => 1,
             };
             let (_, term1) = gather_terms(ctxt, ctx, e1, depth);
             (false, Arc::new(TermX::App(ctxt.other(), Arc::new(vec![term1]))))


### PR DESCRIPTION
This is to add bit-wise negation and boolean operators for bit-vector. Since rust hir shares the`!` operator for both boolean and bit operator, I checked operand's type to choose what operator to use. 


One example I need help with is the below one.

`assert_bit_vector( (b1 == b2) || (b1 == b3) >>= (b1 | b2 | b3  == b2 | b3) );`

Currently, this example timeouts for 60 seconds. In the smt file, however, when I comment out the following option, Z3 returns `unsat` instantly. 
`(set-option :smt.case_split 3)`

I tried manually changing the `bvor` encoding from binaryOp style to multiOp, (  using (bvor b1 b2 b3) instead of (bvor (bvor b1 b2) b3) ) , but it still makes 60 seconds timeout. 

