### PR TITLE
Demarcate VIR phases by checking that simplified VIR does not use nodes that should have been simplified

### DIFF
--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -360,8 +360,8 @@ impl Verifier {
         let mut global_ctx = vir::context::GlobalCtx::new(&krate, air_no_span);
         let krate = vir::ast_simplify::simplify_krate(&mut global_ctx, &krate)?;
 
-        #[cfg(build = "debug")]
-        vir::ast_util::check_krate_simplified(&krate);
+        #[cfg(debug_assertions)]
+        vir::check_ast_flavor::check_krate_simplified(&krate);
 
         air_context.blank_line();
         air_context.comment("Prelude");

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -360,6 +360,9 @@ impl Verifier {
         let mut global_ctx = vir::context::GlobalCtx::new(&krate, air_no_span);
         let krate = vir::ast_simplify::simplify_krate(&mut global_ctx, &krate)?;
 
+        #[cfg(build = "debug")]
+        vir::ast_util::check_krate_simplified(&krate);
+
         air_context.blank_line();
         air_context.comment("Prelude");
         for command in vir::context::Ctx::prelude().iter() {

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -1,9 +1,8 @@
 use crate::ast::{
-    BinaryOp, Constant, DatatypeX, Expr, ExprX, Fun, FunX, FunctionX, GenericBoundX, Ident, Idents,
-    IntRange, Krate, KrateX, Mode, Param, Params, Path, PathX, SpannedTyped, Typ, TypX, Typs,
-    UnaryOpr, Variant, Variants, VirErr, Visibility,
+    BinaryOp, Constant, DatatypeX, Expr, ExprX, Fun, FunX, FunctionX, Ident, Idents, IntRange,
+    Mode, Param, Params, Path, PathX, SpannedTyped, Typ, TypX, Typs, Variant, Variants, VirErr,
+    Visibility,
 };
-use crate::ast_visitor::{expr_visitor_check, typ_visitor_check};
 use crate::util::vec_map;
 use air::ast::{Binder, BinderX, Binders, Span};
 pub use air::ast_util::{ident_binder, str_ident};
@@ -190,67 +189,5 @@ impl DatatypeX {
 
     pub fn get_variant(&self, variant: &Ident) -> &Variant {
         get_variant(&self.variants, variant)
-    }
-}
-
-fn check_expr_simplified(expr: &Expr) -> Result<(), ()> {
-    match expr.x {
-        ExprX::UnaryOpr(UnaryOpr::TupleField { .. }, _) | ExprX::Tuple(_) | ExprX::Match(..) => {
-            Err(())
-        }
-        _ => Ok(()),
-    }
-}
-
-fn check_typ_simplified(typ: &Typ) -> Result<(), ()> {
-    match &**typ {
-        TypX::Tuple(..) => Err(()),
-        _ => Ok(()),
-    }
-}
-
-/// Panics if the ast uses nodes that should have been removed by ast_simplify
-pub fn check_krate_simplified(krate: &Krate) {
-    let KrateX { functions, datatypes, module_ids: _ } = &**krate;
-
-    for function in functions {
-        let FunctionX { require, ensure, decrease, body, typ_bounds, params, ret, .. } =
-            &function.x;
-
-        let all_exprs =
-            require.iter().chain(ensure.iter()).chain(decrease.iter()).chain(body.iter());
-        for expr in all_exprs {
-            expr_visitor_check(expr, &mut check_expr_simplified)
-                .expect("function AST expression uses node that should have been simplified");
-        }
-
-        for (_, bound) in typ_bounds.iter() {
-            match &**bound {
-                GenericBoundX::None => (),
-                GenericBoundX::FnSpec(typs, typ) => {
-                    let all_typs = typs.iter().chain(std::iter::once(typ));
-                    for typ in all_typs {
-                        typ_visitor_check(typ, &mut check_typ_simplified).expect(
-                            "function typ bound uses node that should have been simplified",
-                        );
-                    }
-                }
-            }
-        }
-
-        for param in params.iter().chain(std::iter::once(ret)) {
-            typ_visitor_check(&param.x.typ, &mut check_typ_simplified)
-                .expect("function param typ uses node that should have been simplified");
-        }
-    }
-
-    for datatype in datatypes {
-        for variant in datatype.x.variants.iter() {
-            for field in variant.a.iter() {
-                let (typ, _, _) = &field.a;
-                typ_visitor_check(typ, &mut check_typ_simplified)
-                    .expect("datatype field typ uses node that should have been simplified");
-            }
-        }
     }
 }

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -1,8 +1,9 @@
 use crate::ast::{
-    BinaryOp, Constant, DatatypeX, Expr, ExprX, Fun, FunX, FunctionX, Ident, Idents, IntRange,
-    Mode, Param, Params, Path, PathX, SpannedTyped, Typ, TypX, Typs, Variant, Variants, VirErr,
-    Visibility,
+    BinaryOp, Constant, DatatypeX, Expr, ExprX, Fun, FunX, FunctionX, GenericBoundX, Ident, Idents,
+    IntRange, Krate, KrateX, Mode, Param, Params, Path, PathX, SpannedTyped, Typ, TypX, Typs,
+    UnaryOpr, Variant, Variants, VirErr, Visibility,
 };
+use crate::ast_visitor::{expr_visitor_check, typ_visitor_check};
 use crate::util::vec_map;
 use air::ast::{Binder, BinderX, Binders, Span};
 pub use air::ast_util::{ident_binder, str_ident};
@@ -189,5 +190,67 @@ impl DatatypeX {
 
     pub fn get_variant(&self, variant: &Ident) -> &Variant {
         get_variant(&self.variants, variant)
+    }
+}
+
+fn check_expr_simplified(expr: &Expr) -> Result<(), ()> {
+    match expr.x {
+        ExprX::UnaryOpr(UnaryOpr::TupleField { .. }, _) | ExprX::Tuple(_) | ExprX::Match(..) => {
+            Err(())
+        }
+        _ => Ok(()),
+    }
+}
+
+fn check_typ_simplified(typ: &Typ) -> Result<(), ()> {
+    match &**typ {
+        TypX::Tuple(..) => Err(()),
+        _ => Ok(()),
+    }
+}
+
+/// Panics if the ast uses nodes that should have been removed by ast_simplify
+pub fn check_krate_simplified(krate: &Krate) {
+    let KrateX { functions, datatypes, module_ids: _ } = &**krate;
+
+    for function in functions {
+        let FunctionX { require, ensure, decrease, body, typ_bounds, params, ret, .. } =
+            &function.x;
+
+        let all_exprs =
+            require.iter().chain(ensure.iter()).chain(decrease.iter()).chain(body.iter());
+        for expr in all_exprs {
+            expr_visitor_check(expr, &mut check_expr_simplified)
+                .expect("function AST expression uses node that should have been simplified");
+        }
+
+        for (_, bound) in typ_bounds.iter() {
+            match &**bound {
+                GenericBoundX::None => (),
+                GenericBoundX::FnSpec(typs, typ) => {
+                    let all_typs = typs.iter().chain(std::iter::once(typ));
+                    for typ in all_typs {
+                        typ_visitor_check(typ, &mut check_typ_simplified).expect(
+                            "function typ bound uses node that should have been simplified",
+                        );
+                    }
+                }
+            }
+        }
+
+        for param in params.iter().chain(std::iter::once(ret)) {
+            typ_visitor_check(&param.x.typ, &mut check_typ_simplified)
+                .expect("function param typ uses node that should have been simplified");
+        }
+    }
+
+    for datatype in datatypes {
+        for variant in datatype.x.variants.iter() {
+            for field in variant.a.iter() {
+                let (typ, _, _) = &field.a;
+                typ_visitor_check(typ, &mut check_typ_simplified)
+                    .expect("datatype field typ uses node that should have been simplified");
+            }
+        }
     }
 }

--- a/source/vir/src/check_ast_flavor.rs
+++ b/source/vir/src/check_ast_flavor.rs
@@ -1,0 +1,65 @@
+use crate::ast::{Expr, ExprX, FunctionX, GenericBoundX, Krate, KrateX, Typ, TypX, UnaryOpr};
+use crate::ast_visitor::{expr_visitor_check, typ_visitor_check};
+pub use air::ast_util::{ident_binder, str_ident};
+
+fn check_expr_simplified(expr: &Expr) -> Result<(), ()> {
+    match expr.x {
+        ExprX::UnaryOpr(UnaryOpr::TupleField { .. }, _) | ExprX::Tuple(_) | ExprX::Match(..) => {
+            Err(())
+        }
+        _ => Ok(()),
+    }
+}
+
+fn check_typ_simplified(typ: &Typ) -> Result<(), ()> {
+    match &**typ {
+        TypX::Tuple(..) => Err(()),
+        _ => Ok(()),
+    }
+}
+
+/// Panics if the ast uses nodes that should have been removed by ast_simplify
+pub fn check_krate_simplified(krate: &Krate) {
+    let KrateX { functions, datatypes, module_ids: _ } = &**krate;
+
+    for function in functions {
+        let FunctionX { require, ensure, decrease, body, typ_bounds, params, ret, .. } =
+            &function.x;
+
+        let all_exprs =
+            require.iter().chain(ensure.iter()).chain(decrease.iter()).chain(body.iter());
+        for expr in all_exprs {
+            expr_visitor_check(expr, &mut check_expr_simplified)
+                .expect("function AST expression uses node that should have been simplified");
+        }
+
+        for (_, bound) in typ_bounds.iter() {
+            match &**bound {
+                GenericBoundX::None => (),
+                GenericBoundX::FnSpec(typs, typ) => {
+                    let all_typs = typs.iter().chain(std::iter::once(typ));
+                    for typ in all_typs {
+                        typ_visitor_check(typ, &mut check_typ_simplified).expect(
+                            "function typ bound uses node that should have been simplified",
+                        );
+                    }
+                }
+            }
+        }
+
+        for param in params.iter().chain(std::iter::once(ret)) {
+            typ_visitor_check(&param.x.typ, &mut check_typ_simplified)
+                .expect("function param typ uses node that should have been simplified");
+        }
+    }
+
+    for datatype in datatypes {
+        for variant in datatype.x.variants.iter() {
+            for field in variant.a.iter() {
+                let (typ, _, _) = &field.a;
+                typ_visitor_check(typ, &mut check_typ_simplified)
+                    .expect("datatype field typ uses node that should have been simplified");
+            }
+        }
+    }
+}

--- a/source/vir/src/lib.rs
+++ b/source/vir/src/lib.rs
@@ -33,6 +33,7 @@ pub mod ast_simplify;
 mod ast_to_sst;
 pub mod ast_util;
 mod ast_visitor;
+pub mod check_ast_flavor;
 pub mod context;
 pub mod datatype_to_air;
 pub mod def;


### PR DESCRIPTION
So that we are reminded if we make changes to the phases that use different nodes, and as a template for phases after simplify.