### PR TITLE
invariant_new -> Invariant::new

### DIFF
--- a/source/pervasive/invariants.rs
+++ b/source/pervasive/invariants.rs
@@ -1,35 +1,15 @@
 #[allow(unused_imports)] use builtin::*;
 #[allow(unused_imports)] use crate::pervasive::*;
 
-// TODO right now this file contains the minimal type definitions needed for rust_verify
-// but we need to make a library to make the Invariant type actually usable
-//  * constructors, destructors
-//  * utility for creating unique namespaces
+// TODO:
+//  * utility for conveniently creating unique namespaces
+
+// note the names of `inv` and `namespace` are harcoded into the VIR crate.
 
 #[proof]
 #[verifier(external_body)]
 pub struct Invariant<#[verifier(maybe_negative)] V> {
     dummy: std::marker::PhantomData<V>,
-}
-
-// note the names of `inv` and `namespace` are harcoded.
-// TODO right now they are only translated if the user refers to them in their code
-// which can cause a crash otherwise
-
-// TODO move this to be inside the `impl`:
-#[proof]
-#[verifier(external_body)]
-#[verifier(returns(proof))]
-pub fn invariant_new<V, F: Fn(V) -> bool>(#[proof] v: V, #[spec] inv: F, #[spec] ns: int) -> Invariant<V> {
-  requires([
-    inv(v),
-  ]);
-  ensures(|i: Invariant<V>|
-    forall(|v: V| i.inv(v) == inv(v)) // TODO replace this with function equality?
-    && equal(i.namespace(), ns)
-  );
-
-  unimplemented!();
 }
 
 #[proof]
@@ -38,6 +18,21 @@ impl<V> Invariant<V> {
     #[spec]
     pub fn inv(&self, _v: V) -> bool {
         arbitrary()
+    }
+
+    #[proof]
+    #[verifier(external_body)]
+    #[verifier(returns(proof))]
+    pub fn new<F: Fn(V) -> bool>(#[proof] v: V, #[spec] inv: F, #[spec] ns: int) -> Invariant<V> {
+        requires([
+            inv(v),
+        ]);
+        ensures(|i: Invariant<V>|
+            forall(|v: V| i.inv(v) == inv(v)) // TODO replace this with function equality?
+            && equal(i.namespace(), ns)
+        );
+
+        unimplemented!();
     }
 
     // If you want to open two invariants I and J at the same time,
@@ -53,7 +48,7 @@ impl<V> Invariant<V> {
     #[proof]
     #[verifier(external_body)]
     #[verifier(returns(proof))]
-    pub fn destruct(#[proof] self) -> V {
+    pub fn into_inner(#[proof] self) -> V {
         ensures(|v: V| self.inv(v));
 
         unimplemented!();

--- a/source/rust_verify/example/invariants.rs
+++ b/source/rust_verify/example/invariants.rs
@@ -7,7 +7,7 @@ use crate::pervasive::{invariants::*};
 pub fn main() {
   #[proof] let u: u32 = 5;
 
-  #[proof] let i = invariant_new(u, |u: u32| u % 2 == 1, 0);
+  #[proof] let i = Invariant::new(u, |u: u32| u % 2 == 1, 0);
 
   open_invariant!(&i => inner => {
     if inner == 1 {
@@ -15,7 +15,7 @@ pub fn main() {
     }
   });
 
-  #[proof] let j = invariant_new(7, |u: u32| u % 2 == 1, 1);
+  #[proof] let j = Invariant::new(7, |u: u32| u % 2 == 1, 1);
 
   open_invariant!(&i => inner_i => {
     open_invariant!(&j => inner_j => {
@@ -25,6 +25,6 @@ pub fn main() {
     });
   });
 
-  #[proof] let j = i.destruct();
+  #[proof] let j = i.into_inner();
   assert(j % 2 == 1);
 }

--- a/source/rust_verify/example/og_counter.rs
+++ b/source/rust_verify/example/og_counter.rs
@@ -129,7 +129,7 @@ fn main() {
 
   let (at, proof(perm_token)) = PAtomicU32::new(0);
 
-  #[proof] let at_inv: Invariant<G> = invariant_new(
+  #[proof] let at_inv: Invariant<G> = Invariant::new(
       G { counter: counter_token, perm: perm_token },
       |g: G| g.wf(at),
       0);

--- a/source/rust_verify/src/erase.rs
+++ b/source/rust_verify/src/erase.rs
@@ -946,7 +946,20 @@ fn erase_fn(ctxt: &Ctxt, mctxt: &mut MCtxt, f: &FnKind, external_body: bool) -> 
     }
     let Generics { params, where_clause, span: generics_span } = generics;
     let mut new_params: Vec<GenericParam> = Vec::new();
-    let mut typ_bounds_iter = f_vir.x.typ_bounds.iter();
+
+    // Skip over type params in impl<...>
+    let mut num_typ_params = 0;
+    for param in params.iter() {
+        match &param.kind {
+            GenericParamKind::Type { .. } => {
+                num_typ_params += 1;
+            }
+            _ => {}
+        }
+    }
+    let n_skip = f_vir.x.typ_bounds.len() - num_typ_params;
+    let mut typ_bounds_iter = f_vir.x.typ_bounds.iter().skip(n_skip);
+
     for param in params.iter() {
         match param.kind {
             GenericParamKind::Lifetime => {
@@ -1079,6 +1092,7 @@ fn erase_item(ctxt: &Ctxt, mctxt: &mut MCtxt, item: &Item) -> Vec<P<Item>> {
                     items.push(P(item));
                 }
             }
+            // TODO we may need to erase some generic params
             // for asymptotic efficiency, don't call kind.clone():
             let ImplKind { unsafety, polarity, defaultness, constness, .. } = **kind;
             let ImplKind { generics, of_trait, self_ty, .. } = &**kind;

--- a/source/rust_verify/tests/impl.rs
+++ b/source/rust_verify/tests/impl.rs
@@ -304,3 +304,31 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] test_erased_assoc_type_param code! {
+        struct Foo<V> {
+            v: V
+        }
+
+        impl<V> Foo<V> {
+            #[verifier(returns(spec))]
+            fn bar<F: Fn(V) -> bool>(#[spec] f: F, #[spec] v: V) -> bool {
+                f(v)
+            }
+
+            #[verifier(returns(spec))]
+            fn bar2<F: Fn(V) -> bool>(self, #[spec] f: F) -> bool {
+                f(self.v)
+            }
+        }
+
+        fn test() {
+            #[spec] let x: u64 = 0;
+            Foo::<u64>::bar(|y: u64| true, x);
+
+            let f = Foo::<u64> { v: 17 };
+            #[spec] let b = f.bar2(|y: u64| true);
+        }
+    } => Ok(())
+}


### PR DESCRIPTION
I started out attempting 2 easy changes:

* change `invariant_new` to `Invariant::new`
* rename `destruct` to `into_inner` (to match Rust conventions)

I also fixed a bug I encountered in erasure, which was caused by this scenario:

```
impl<V> Invariant<V> {
    ...
    pub fn new<F: Fn(V) -> bool>(...) { ... }
```

The erasure code needs to erase `F`, but it failed to do so because it wasn't accounting for the fact that `new` doesn't include the `V` param, while our VIR representation does. So it just needs to be offset.

I think there's probably another lurking bug here where we might also need to erase params off the impl, but that one seemed more challenging, so I didn't tackle it in this PR.