### PR TITLE
Add the fndef macro that defines an uninterpreted spec function (with no body)

### DIFF
--- a/source/builtin_macros/src/fndecl.rs
+++ b/source/builtin_macros/src/fndecl.rs
@@ -1,9 +1,8 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{braced, parse_macro_input, Error, Expr, Field, FieldsNamed, Ident, Token, Type};
 
 #[inline(always)]
-pub fn fndef(input: TokenStream) -> TokenStream {
+pub fn fndecl(input: TokenStream) -> TokenStream {
     quote! {
         #[spec] #[verifier(external_body)] #input { unimplemented!() }
     }

--- a/source/builtin_macros/src/fndef.rs
+++ b/source/builtin_macros/src/fndef.rs
@@ -1,0 +1,10 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{braced, parse_macro_input, Error, Expr, Field, FieldsNamed, Ident, Token, Type};
+
+#[inline(always)]
+pub fn fndef(input: TokenStream) -> TokenStream {
+    quote! {
+        #[spec] #[verifier(external_body)] #input { unimplemented!() }
+    }
+}

--- a/source/builtin_macros/src/lib.rs
+++ b/source/builtin_macros/src/lib.rs
@@ -1,5 +1,5 @@
 use synstructure::{decl_attribute, decl_derive};
-mod fndef;
+mod fndecl;
 mod is_variant;
 mod structural;
 
@@ -9,6 +9,6 @@ decl_attribute!([is_variant] => is_variant::attribute_is_variant);
 
 // Proc macros must reside at the root of the crate
 #[proc_macro]
-pub fn fndef(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    proc_macro::TokenStream::from(fndef::fndef(proc_macro2::TokenStream::from(input)))
+pub fn fndecl(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    proc_macro::TokenStream::from(fndecl::fndecl(proc_macro2::TokenStream::from(input)))
 }

--- a/source/builtin_macros/src/lib.rs
+++ b/source/builtin_macros/src/lib.rs
@@ -1,7 +1,14 @@
 use synstructure::{decl_attribute, decl_derive};
+mod fndef;
 mod is_variant;
 mod structural;
 
 decl_derive!([Structural] => structural::derive_structural);
 
 decl_attribute!([is_variant] => is_variant::attribute_is_variant);
+
+// Proc macros must reside at the root of the crate
+#[proc_macro]
+pub fn fndef(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    proc_macro::TokenStream::from(fndef::fndef(proc_macro2::TokenStream::from(input)))
+}

--- a/source/pervasive/atomic.rs
+++ b/source/pervasive/atomic.rs
@@ -114,7 +114,7 @@ macro_rules! atomic_types {
 
 macro_rules! atomic_common_methods {
     ($at_ident:ident, $p_ident:ident, $rust_ty: ty, $value_ty: ty) => {
-        fndef!(pub fn view(&self) -> int);
+        fndecl!(pub fn view(&self) -> int);
 
         #[inline(always)]
         #[verifier(external_body)]

--- a/source/pervasive/atomic.rs
+++ b/source/pervasive/atomic.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::{
     Ordering};
 
 #[allow(unused_imports)] use builtin::*;
+#[allow(unused_imports)] use builtin_macros::*;
 #[allow(unused_imports)] use crate::pervasive::*;
 #[allow(unused_imports)] use crate::pervasive::modes::*;
 #[allow(unused_imports)] use crate::pervasive::result::*;
@@ -113,11 +114,7 @@ macro_rules! atomic_types {
 
 macro_rules! atomic_common_methods {
     ($at_ident:ident, $p_ident:ident, $rust_ty: ty, $value_ty: ty) => {
-        #[verifier(external_body)]
-        #[spec]
-        pub fn view(&self) -> int {
-            unimplemented!()
-        }
+        fndef!(pub fn view(&self) -> int);
 
         #[inline(always)]
         #[verifier(external_body)]

--- a/source/pervasive/cell.rs
+++ b/source/pervasive/cell.rs
@@ -2,6 +2,7 @@ use std::cell::UnsafeCell;
 use std::mem::MaybeUninit;
 
 #[allow(unused_imports)] use builtin::*;
+#[allow(unused_imports)] use builtin_macros::*;
 #[allow(unused_imports)] use crate::pervasive::*;
 
 // TODO Identifier should be some opaque type, not necessarily an int
@@ -42,11 +43,7 @@ impl<V> PCell<V> {
     PCellWithToken {pcell: p, token: t}
   }
 
-  #[verifier(external_body)]
-  #[spec]
-  pub fn view(&self) -> int {
-    unimplemented!()
-  }
+  fndef!(pub fn view(&self) -> int);
 
   //// Put
 

--- a/source/pervasive/cell.rs
+++ b/source/pervasive/cell.rs
@@ -43,7 +43,7 @@ impl<V> PCell<V> {
     PCellWithToken {pcell: p, token: t}
   }
 
-  fndef!(pub fn view(&self) -> int);
+  fndecl!(pub fn view(&self) -> int);
 
   //// Put
 

--- a/source/pervasive/invariants.rs
+++ b/source/pervasive/invariants.rs
@@ -1,4 +1,5 @@
 #[allow(unused_imports)] use builtin::*;
+#[allow(unused_imports)] use builtin_macros::*;
 #[allow(unused_imports)] use crate::pervasive::*;
 
 // TODO:
@@ -14,11 +15,7 @@ pub struct Invariant<#[verifier(maybe_negative)] V> {
 
 #[proof]
 impl<V> Invariant<V> {
-    #[verifier(external_body)]
-    #[spec]
-    pub fn inv(&self, _v: V) -> bool {
-        unimplemented!()
-    }
+    fndef!(pub fn inv(&self, _v: V) -> bool);
 
     #[proof]
     #[verifier(external_body)]
@@ -39,11 +36,7 @@ impl<V> Invariant<V> {
     // you need to show that I.namespace() != J.namespace()
     // The namespace can be declared upon allocation of the invariant.
 
-    #[verifier(external_body)]
-    #[spec]
-    pub fn namespace(&self) -> int {
-        unimplemented!()
-    }
+    fndef!(pub fn namespace(&self) -> int);
 
     #[proof]
     #[verifier(external_body)]

--- a/source/pervasive/invariants.rs
+++ b/source/pervasive/invariants.rs
@@ -15,7 +15,7 @@ pub struct Invariant<#[verifier(maybe_negative)] V> {
 
 #[proof]
 impl<V> Invariant<V> {
-    fndef!(pub fn inv(&self, _v: V) -> bool);
+    fndecl!(pub fn inv(&self, _v: V) -> bool);
 
     #[proof]
     #[verifier(external_body)]
@@ -36,7 +36,7 @@ impl<V> Invariant<V> {
     // you need to show that I.namespace() != J.namespace()
     // The namespace can be declared upon allocation of the invariant.
 
-    fndef!(pub fn namespace(&self) -> int);
+    fndecl!(pub fn namespace(&self) -> int);
 
     #[proof]
     #[verifier(external_body)]

--- a/source/pervasive/map.rs
+++ b/source/pervasive/map.rs
@@ -14,18 +14,18 @@ pub struct Map<#[verifier(maybe_negative)] K, #[verifier(strictly_positive)] V> 
 }
 
 impl<K, V> Map<K, V> {
-    fndef!(pub fn empty() -> Map<K, V>);
+    fndecl!(pub fn empty() -> Map<K, V>);
 
     #[spec]
     pub fn total<F: Fn(K) -> V>(f: F) -> Map<K, V> {
         Set::full().mk_map(f)
     }
 
-    fndef!(pub fn dom(self) -> Set<K>);
+    fndecl!(pub fn dom(self) -> Set<K>);
 
-    fndef!(pub fn index(self, key: K) -> V);
+    fndecl!(pub fn index(self, key: K) -> V);
 
-    fndef!(pub fn insert(self, key: K, value: V) -> Map<K, V>);
+    fndecl!(pub fn insert(self, key: K, value: V) -> Map<K, V>);
 
     #[spec]
     pub fn ext_equal(self, m2: Map<K, V>) -> bool {

--- a/source/pervasive/map.rs
+++ b/source/pervasive/map.rs
@@ -1,6 +1,8 @@
 #[allow(unused_imports)]
 use builtin::*;
 #[allow(unused_imports)]
+use builtin_macros::*;
+#[allow(unused_imports)]
 use crate::pervasive::*;
 #[allow(unused_imports)]
 use crate::pervasive::set::*;
@@ -12,34 +14,18 @@ pub struct Map<#[verifier(maybe_negative)] K, #[verifier(strictly_positive)] V> 
 }
 
 impl<K, V> Map<K, V> {
-    #[spec]
-    #[verifier(external_body)]
-    pub fn empty() -> Map<K, V> {
-        unimplemented!()
-    }
+    fndef!(pub fn empty() -> Map<K, V>);
 
     #[spec]
     pub fn total<F: Fn(K) -> V>(f: F) -> Map<K, V> {
         Set::full().mk_map(f)
     }
 
-    #[spec]
-    #[verifier(external_body)]
-    pub fn dom(self) -> Set<K> {
-        unimplemented!()
-    }
+    fndef!(pub fn dom(self) -> Set<K>);
 
-    #[spec]
-    #[verifier(external_body)]
-    pub fn index(self, key: K) -> V {
-        unimplemented!()
-    }
+    fndef!(pub fn index(self, key: K) -> V);
 
-    #[spec]
-    #[verifier(external_body)]
-    pub fn insert(self, key: K, value: V) -> Map<K, V> {
-        unimplemented!()
-    }
+    fndef!(pub fn insert(self, key: K, value: V) -> Map<K, V>);
 
     #[spec]
     pub fn ext_equal(self, m2: Map<K, V>) -> bool {

--- a/source/pervasive/seq.rs
+++ b/source/pervasive/seq.rs
@@ -1,6 +1,8 @@
 #[allow(unused_imports)]
 use builtin::*;
 #[allow(unused_imports)]
+use builtin_macros::*;
+#[allow(unused_imports)]
 use crate::pervasive::*;
 
 /// sequence type for specifications
@@ -10,41 +12,17 @@ pub struct Seq<#[verifier(strictly_positive)] A> {
 }
 
 impl<A> Seq<A> {
-    #[spec]
-    #[verifier(external_body)]
-    pub fn empty() -> Seq<A> {
-        unimplemented!()
-    }
+    fndef!(pub fn empty() -> Seq<A>);
 
-    #[spec]
-    #[verifier(external_body)]
-    pub fn new<F: Fn(int) -> A>(len: nat, f: F) -> Seq<A> {
-        unimplemented!()
-    }
+    fndef!(pub fn new<F: Fn(int) -> A>(len: nat, f: F) -> Seq<A>);
 
-    #[spec]
-    #[verifier(external_body)]
-    pub fn len(self) -> nat {
-        unimplemented!()
-    }
+    fndef!(pub fn len(self) -> nat);
 
-    #[spec]
-    #[verifier(external_body)]
-    pub fn index(self, i: int) -> A {
-        unimplemented!()
-    }
+    fndef!(pub fn index(self, i: int) -> A);
 
-    #[spec]
-    #[verifier(external_body)]
-    pub fn push(self, a: A) -> Seq<A> {
-        unimplemented!()
-    }
+    fndef!(pub fn push(self, a: A) -> Seq<A>);
 
-    #[spec]
-    #[verifier(external_body)]
-    pub fn update(self, i: int, a: A) -> Seq<A> {
-        unimplemented!()
-    }
+    fndef!(pub fn update(self, i: int, a: A) -> Seq<A>);
 
     #[spec]
     pub fn ext_equal(self, s2: Seq<A>) -> bool {
@@ -52,17 +30,9 @@ impl<A> Seq<A> {
         forall(|i: int| 0 <= i && i < self.len() >>= equal(self.index(i), s2.index(i)))
     }
 
-    #[spec]
-    #[verifier(external_body)]
-    pub fn subrange(self, start_inclusive: int, end_exclusive: int) -> Seq<A> {
-        unimplemented!()
-    }
+    fndef!(pub fn subrange(self, start_inclusive: int, end_exclusive: int) -> Seq<A>);
 
-    #[spec]
-    #[verifier(external_body)]
-    pub fn add(self, rhs: Seq<A>) -> Seq<A> {
-        unimplemented!()
-    }
+    fndef!(pub fn add(self, rhs: Seq<A>) -> Seq<A>);
 }
 
 // Trusted axioms

--- a/source/pervasive/seq.rs
+++ b/source/pervasive/seq.rs
@@ -12,17 +12,17 @@ pub struct Seq<#[verifier(strictly_positive)] A> {
 }
 
 impl<A> Seq<A> {
-    fndef!(pub fn empty() -> Seq<A>);
+    fndecl!(pub fn empty() -> Seq<A>);
 
-    fndef!(pub fn new<F: Fn(int) -> A>(len: nat, f: F) -> Seq<A>);
+    fndecl!(pub fn new<F: Fn(int) -> A>(len: nat, f: F) -> Seq<A>);
 
-    fndef!(pub fn len(self) -> nat);
+    fndecl!(pub fn len(self) -> nat);
 
-    fndef!(pub fn index(self, i: int) -> A);
+    fndecl!(pub fn index(self, i: int) -> A);
 
-    fndef!(pub fn push(self, a: A) -> Seq<A>);
+    fndecl!(pub fn push(self, a: A) -> Seq<A>);
 
-    fndef!(pub fn update(self, i: int, a: A) -> Seq<A>);
+    fndecl!(pub fn update(self, i: int, a: A) -> Seq<A>);
 
     #[spec]
     pub fn ext_equal(self, s2: Seq<A>) -> bool {
@@ -30,9 +30,9 @@ impl<A> Seq<A> {
         forall(|i: int| 0 <= i && i < self.len() >>= equal(self.index(i), s2.index(i)))
     }
 
-    fndef!(pub fn subrange(self, start_inclusive: int, end_exclusive: int) -> Seq<A>);
+    fndecl!(pub fn subrange(self, start_inclusive: int, end_exclusive: int) -> Seq<A>);
 
-    fndef!(pub fn add(self, rhs: Seq<A>) -> Seq<A>);
+    fndecl!(pub fn add(self, rhs: Seq<A>) -> Seq<A>);
 }
 
 // Trusted axioms

--- a/source/pervasive/set.rs
+++ b/source/pervasive/set.rs
@@ -1,6 +1,8 @@
 #[allow(unused_imports)]
 use builtin::*;
 #[allow(unused_imports)]
+use builtin_macros::*;
+#[allow(unused_imports)]
 use crate::pervasive::*;
 #[allow(unused_imports)]
 use crate::pervasive::map::*;
@@ -18,22 +20,14 @@ pub fn set_new<A, F: Fn(A) -> bool>(f: F) -> Set<A> {
 }
 
 impl<A> Set<A> {
-    #[spec]
-    #[verifier(external_body)]
-    pub fn empty() -> Set<A> {
-        unimplemented!()
-    }
+    fndef!(pub fn empty() -> Set<A>);
 
     #[spec]
     pub fn full() -> Set<A> {
         Set::empty().complement()
     }
 
-    #[spec]
-    #[verifier(external_body)]
-    pub fn contains(self, a: A) -> bool {
-        unimplemented!()
-    }
+    fndef!(pub fn contains(self, a: A) -> bool);
 
     #[spec]
     pub fn ext_equal(self, s2: Set<A>) -> bool {
@@ -45,69 +39,33 @@ impl<A> Set<A> {
         forall(|a: A| self.contains(a) >>= s2.contains(a))
     }
 
-    #[spec]
-    #[verifier(external_body)]
-    pub fn insert(self, a: A) -> Set<A> {
-        unimplemented!()
-    }
+    fndef!(pub fn insert(self, a: A) -> Set<A>);
 
-    #[spec]
-    #[verifier(external_body)]
-    pub fn remove(self, a: A) -> Set<A> {
-        unimplemented!()
-    }
+    fndef!(pub fn remove(self, a: A) -> Set<A>);
 
-    #[spec]
-    #[verifier(external_body)]
-    pub fn union(self, s2: Set<A>) -> Set<A> {
-        unimplemented!()
-    }
+    fndef!(pub fn union(self, s2: Set<A>) -> Set<A>);
 
-    #[spec]
-    #[verifier(external_body)]
-    pub fn intersect(self, s2: Set<A>) -> Set<A> {
-        unimplemented!()
-    }
+    fndef!(pub fn intersect(self, s2: Set<A>) -> Set<A>);
 
-    #[spec]
-    #[verifier(external_body)]
-    pub fn difference(self, s2: Set<A>) -> Set<A> {
-        unimplemented!()
-    }
+    fndef!(pub fn difference(self, s2: Set<A>) -> Set<A>);
 
-    #[spec]
-    #[verifier(external_body)]
-    pub fn complement(self) -> Set<A> {
-        unimplemented!()
-    }
+    fndef!(pub fn complement(self) -> Set<A>);
 
     #[spec]
     pub fn filter<F: Fn(A) -> bool>(self, f: F) -> Set<A> {
         self.intersect(set_new(f))
     }
 
-    #[spec]
-    #[verifier(external_body)]
-    pub fn finite(self) -> bool {
-        unimplemented!()
-    }
+    fndef!(pub fn finite(self) -> bool);
 
-    #[spec]
-    #[verifier(external_body)]
-    pub fn len(self) -> nat {
-        unimplemented!()
-    }
+    fndef!(pub fn len(self) -> nat);
 
     #[spec]
     pub fn choose(self) -> A {
         choose(|a: A| self.contains(a))
     }
 
-    #[spec]
-    #[verifier(external_body)]
-    pub fn mk_map<V, F: Fn(A) -> V>(self, f: F) -> Map<A, V> {
-        unimplemented!()
-    }
+    fndef!(pub fn mk_map<V, F: Fn(A) -> V>(self, f: F) -> Map<A, V>);
 
 }
 

--- a/source/pervasive/set.rs
+++ b/source/pervasive/set.rs
@@ -20,14 +20,14 @@ pub fn set_new<A, F: Fn(A) -> bool>(f: F) -> Set<A> {
 }
 
 impl<A> Set<A> {
-    fndef!(pub fn empty() -> Set<A>);
+    fndecl!(pub fn empty() -> Set<A>);
 
     #[spec]
     pub fn full() -> Set<A> {
         Set::empty().complement()
     }
 
-    fndef!(pub fn contains(self, a: A) -> bool);
+    fndecl!(pub fn contains(self, a: A) -> bool);
 
     #[spec]
     pub fn ext_equal(self, s2: Set<A>) -> bool {
@@ -39,33 +39,33 @@ impl<A> Set<A> {
         forall(|a: A| self.contains(a) >>= s2.contains(a))
     }
 
-    fndef!(pub fn insert(self, a: A) -> Set<A>);
+    fndecl!(pub fn insert(self, a: A) -> Set<A>);
 
-    fndef!(pub fn remove(self, a: A) -> Set<A>);
+    fndecl!(pub fn remove(self, a: A) -> Set<A>);
 
-    fndef!(pub fn union(self, s2: Set<A>) -> Set<A>);
+    fndecl!(pub fn union(self, s2: Set<A>) -> Set<A>);
 
-    fndef!(pub fn intersect(self, s2: Set<A>) -> Set<A>);
+    fndecl!(pub fn intersect(self, s2: Set<A>) -> Set<A>);
 
-    fndef!(pub fn difference(self, s2: Set<A>) -> Set<A>);
+    fndecl!(pub fn difference(self, s2: Set<A>) -> Set<A>);
 
-    fndef!(pub fn complement(self) -> Set<A>);
+    fndecl!(pub fn complement(self) -> Set<A>);
 
     #[spec]
     pub fn filter<F: Fn(A) -> bool>(self, f: F) -> Set<A> {
         self.intersect(set_new(f))
     }
 
-    fndef!(pub fn finite(self) -> bool);
+    fndecl!(pub fn finite(self) -> bool);
 
-    fndef!(pub fn len(self) -> nat);
+    fndecl!(pub fn len(self) -> nat);
 
     #[spec]
     pub fn choose(self) -> A {
         choose(|a: A| self.contains(a))
     }
 
-    fndef!(pub fn mk_map<V, F: Fn(A) -> V>(self, f: F) -> Map<A, V>);
+    fndecl!(pub fn mk_map<V, F: Fn(A) -> V>(self, f: F) -> Map<A, V>);
 
 }
 

--- a/source/pervasive/vec.rs
+++ b/source/pervasive/vec.rs
@@ -1,6 +1,8 @@
 #[allow(unused_imports)]
 use builtin::*;
 #[allow(unused_imports)]
+use builtin_macros::*;
+#[allow(unused_imports)]
 use crate::pervasive::*;
 #[allow(unused_imports)]
 use crate::pervasive::seq::*;
@@ -11,11 +13,7 @@ pub struct Vec<#[verifier(strictly_positive)] A> {
 }
 
 impl<A> Vec<A> {
-    #[verifier(external_body)]
-    #[spec]
-    pub fn view(&self) -> Seq<A> {
-        unimplemented!()
-    }
+    fndef!(pub fn view(&self) -> Seq<A>);
 
     #[verifier(external_body)]
     #[verifier(autoview)]

--- a/source/pervasive/vec.rs
+++ b/source/pervasive/vec.rs
@@ -13,7 +13,7 @@ pub struct Vec<#[verifier(strictly_positive)] A> {
 }
 
 impl<A> Vec<A> {
-    fndef!(pub fn view(&self) -> Seq<A>);
+    fndecl!(pub fn view(&self) -> Seq<A>);
 
     #[verifier(external_body)]
     #[verifier(autoview)]


### PR DESCRIPTION
Following up from @tjhance and @Chris-Hawblitzel's conversation about these functions.