### PR TITLE
LocalInvariant

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(rustc_attrs)]
+#![feature(negative_impls)]
 
 #[proof]
 pub fn admit() {
@@ -272,3 +273,10 @@ impl_structural! {
     // TODO: support f32 f64 ?
     bool char
 }
+
+// XXX the reason this is here is because a negative-impl needs the crate feature
+// #![feature(negative_impls)]
+// However, due to the way the 'pervasive' pseudo-crate is set up, there is no way to add this
+// as a crate feature to 'pervasive'. So we have it here instead.
+pub struct PhantomNoSync {}
+impl !Sync for PhantomNoSync {}

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -27,7 +27,8 @@ use rustc_span::Span;
 use std::sync::Arc;
 use vir::ast::{
     ArmX, BinaryOp, CallTarget, Constant, ExprX, FunX, HeaderExpr, HeaderExprX, Ident, IntRange,
-    Mode, PatternX, SpannedTyped, StmtX, Stmts, Typ, TypX, UnaryOp, UnaryOpr, VarAt, VirErr,
+    InvAtomicity, Mode, PatternX, SpannedTyped, StmtX, Stmts, Typ, TypX, UnaryOp, UnaryOpr, VarAt,
+    VirErr,
 };
 use vir::ast_util::{ident_binder, path_as_rust_name};
 use vir::def::positional_field_ident;
@@ -276,6 +277,7 @@ fn get_fn_path<'tcx>(tcx: TyCtxt<'tcx>, expr: &Expr<'tcx>) -> Result<vir::ast::F
     }
 }
 
+const BUILTIN_INV_LOCAL_BEGIN: &str = "crate::pervasive::invariants::open_local_invariant_begin";
 const BUILTIN_INV_BEGIN: &str = "crate::pervasive::invariants::open_invariant_begin";
 const BUILTIN_INV_END: &str = "crate::pervasive::invariants::open_invariant_end";
 
@@ -371,7 +373,8 @@ fn fn_call_to_vir<'tcx>(
     let is_cmp = is_equal || is_eq || is_ne || is_le || is_ge || is_lt || is_gt;
     let is_arith_binary = is_add || is_sub || is_mul;
 
-    if f_name == BUILTIN_INV_BEGIN || f_name == BUILTIN_INV_END {
+    if f_name == BUILTIN_INV_BEGIN || f_name == BUILTIN_INV_LOCAL_BEGIN || f_name == BUILTIN_INV_END
+    {
         // `open_invariant_begin` and `open_invariant_end` calls should only appear
         // through use of the `open_invariant!` macro, which creates an invariant block.
         // Thus, they should end up being processed by `invariant_block_to_vir` before
@@ -924,7 +927,7 @@ fn invariant_block_to_vir<'tcx>(
     let mid_stmt = &body.stmts[1];
     let close_stmt = &body.stmts[body.stmts.len() - 1];
 
-    let (guard_hir, inner_hir, inner_pat, inv_arg) = match open_stmt.kind {
+    let (guard_hir, inner_hir, inner_pat, inv_arg, atomicity) = match open_stmt.kind {
         StmtKind::Local(Local {
             pat:
                 Pat {
@@ -968,10 +971,15 @@ fn invariant_block_to_vir<'tcx>(
             ..
         }) => {
             let f_name = path_as_rust_name(&def_id_to_vir_path(bctx.ctxt.tcx, *fun_id));
-            if f_name != BUILTIN_INV_BEGIN {
+            if f_name != BUILTIN_INV_BEGIN && f_name != BUILTIN_INV_LOCAL_BEGIN {
                 return malformed_inv_block_err(expr);
             }
-            (guard_hir, inner_hir, inner_pat, arg)
+            let atomicity = if f_name == BUILTIN_INV_BEGIN {
+                InvAtomicity::Atomic
+            } else {
+                InvAtomicity::NonAtomic
+            };
+            (guard_hir, inner_hir, inner_pat, arg, atomicity)
         }
         _ => {
             return malformed_inv_block_err(expr);
@@ -1050,7 +1058,7 @@ fn invariant_block_to_vir<'tcx>(
     let inner_ty = typ_of_node(bctx, &inner_hir);
     let vir_binder = Arc::new(BinderX { name, a: inner_ty });
 
-    let e = ExprX::OpenInvariant(vir_arg, vir_binder, vir_body);
+    let e = ExprX::OpenInvariant(vir_arg, vir_binder, vir_body, atomicity);
     Ok(spanned_typed_new(expr.span, &typ_of_node(bctx, &expr.hir_id), e))
 }
 

--- a/source/rust_verify/tests/atomics.rs
+++ b/source/rust_verify/tests/atomics.rs
@@ -117,3 +117,51 @@ test_verify_one_file! {
         fn untrusted_atomic_op() { }
     } => Err(err) => assert_vir_error(err)
 }
+
+test_verify_one_file! {
+    #[test] nonatomic_everything_ok
+    COMMON.to_string() + code_str! {
+        pub fn do_nothing(#[proof] i: LocalInvariant<u8>) -> u32 {
+            let mut x: u32 = 5;
+            open_local_invariant!(&i => inner => {
+                atomic_op();
+                atomic_op();
+                atomic_op();
+                non_atomic_op();
+                non_atomic_op();
+                while x < 10 {
+                    x = x + 1;
+                }
+            });
+            x
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] two_atomic_fail_nest1
+    COMMON.to_string() + code_str! {
+        pub fn do_nothing(#[proof] i: Invariant<u8>, #[proof] j: LocalInvariant<u8>) {
+            open_local_invariant!(&j => inner => {
+                open_invariant!(&i => inner => {
+                    atomic_op();
+                    atomic_op();
+                });
+            });
+        }
+    } => Err(err) => assert_vir_error(err)
+}
+
+test_verify_one_file! {
+    #[test] two_atomic_fail_nest2
+    COMMON.to_string() + code_str! {
+        pub fn do_nothing(#[proof] i: Invariant<u8>, #[proof] j: LocalInvariant<u8>) {
+            open_invariant!(&i => inner => {
+                open_local_invariant!(&j => inner => {
+                    atomic_op();
+                    atomic_op();
+                });
+            });
+        }
+    } => Err(err) => assert_vir_error(err)
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -267,6 +267,12 @@ pub enum VarAt {
     Pre,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum InvAtomicity {
+    Atomic,
+    NonAtomic,
+}
+
 /// Expression, similar to rustc_hir::Expr
 pub type Expr = Arc<SpannedTyped<ExprX>>;
 pub type Exprs = Arc<Vec<Expr>>;
@@ -322,7 +328,7 @@ pub enum ExprX {
     /// While loop, with invariants
     While { cond: Expr, body: Expr, invs: Exprs },
     /// Open invariant
-    OpenInvariant(Expr, Binder<Typ>, Expr),
+    OpenInvariant(Expr, Binder<Typ>, Expr, InvAtomicity),
     /// Return from function
     Return(Option<Expr>),
     /// Sequence of statements, optionally including an expression at the end

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -675,7 +675,7 @@ pub(crate) fn expr_to_stm_opt(
             );
             Ok((vec![while_stm], None))
         }
-        ExprX::OpenInvariant(inv, binder, body) => {
+        ExprX::OpenInvariant(inv, binder, body, atomicity) => {
             // Evaluate `inv`
             let (mut stms0, big_inv_exp) = expr_to_stm(ctx, state, inv)?;
 
@@ -699,7 +699,7 @@ pub(crate) fn expr_to_stm_opt(
 
             stms0.push(Spanned::new(
                 expr.span.clone(),
-                StmX::OpenInvariant(temp_var, ident, binder.a.clone(), body_stm),
+                StmX::OpenInvariant(temp_var, ident, binder.a.clone(), body_stm, *atomicity),
             ));
 
             return Ok((stms0, None));

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -269,7 +269,7 @@ where
                         expr_visitor_control_flow!(expr_visitor_dfs(inv, map, mf));
                     }
                 }
-                ExprX::OpenInvariant(inv, binder, body) => {
+                ExprX::OpenInvariant(inv, binder, body, _atomicity) => {
                     expr_visitor_control_flow!(expr_visitor_dfs(inv, map, mf));
                     map.push_scope(true);
                     let _ = map.insert(binder.name.clone(), binder.a.clone());
@@ -502,14 +502,14 @@ where
             }
             ExprX::Block(Arc::new(stmts), expr1)
         }
-        ExprX::OpenInvariant(e1, binder, e2) => {
+        ExprX::OpenInvariant(e1, binder, e2, atomicity) => {
             let expr1 = map_expr_visitor_env(e1, map, env, fe, fs, ft)?;
             let binder = binder.map_result(|t| map_typ_visitor_env(t, env, ft))?;
             map.push_scope(true);
             let _ = map.insert(binder.name.clone(), binder.a.clone());
             let expr2 = map_expr_visitor_env(e2, map, env, fe, fs, ft)?;
             map.pop_scope();
-            ExprX::OpenInvariant(expr1, binder, expr2)
+            ExprX::OpenInvariant(expr1, binder, expr2, *atomicity)
         }
     };
     let expr = SpannedTyped::new(&expr.span, &map_typ_visitor_env(&expr.typ, env, ft)?, exprx);

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -1,4 +1,4 @@
-use crate::ast::{Fun, FunX, Path, PathX};
+use crate::ast::{Fun, FunX, InvAtomicity, Path, PathX};
 use crate::sst::UniqueIdent;
 use crate::util::vec_map;
 use air::ast::{Ident, Span};
@@ -376,25 +376,32 @@ impl<X: Debug> Debug for Spanned<X> {
     }
 }
 
-pub fn datatype_invariant_path() -> Path {
+fn atomicity_type_name(atomicity: InvAtomicity) -> Ident {
+    match atomicity {
+        InvAtomicity::Atomic => Arc::new("Invariant".to_string()),
+        InvAtomicity::NonAtomic => Arc::new("LocalInvariant".to_string()),
+    }
+}
+
+pub fn datatype_invariant_path(atomicity: InvAtomicity) -> Path {
     Arc::new(PathX {
         krate: None,
         segments: Arc::new(vec![
             Arc::new("pervasive".to_string()),
             Arc::new("invariants".to_string()),
-            Arc::new("Invariant".to_string()),
+            atomicity_type_name(atomicity),
         ]),
     })
 }
 
-pub fn fn_inv_name() -> Fun {
+pub fn fn_inv_name(atomicity: InvAtomicity) -> Fun {
     Arc::new(FunX {
         path: Arc::new(PathX {
             krate: None,
             segments: Arc::new(vec![
                 Arc::new("pervasive".to_string()),
                 Arc::new("invariants".to_string()),
-                Arc::new("Invariant".to_string()),
+                atomicity_type_name(atomicity),
                 Arc::new("inv".to_string()),
             ]),
         }),
@@ -402,14 +409,14 @@ pub fn fn_inv_name() -> Fun {
     })
 }
 
-pub fn fn_namespace_name() -> Fun {
+pub fn fn_namespace_name(atomicity: InvAtomicity) -> Fun {
     Arc::new(FunX {
         path: Arc::new(PathX {
             krate: None,
             segments: Arc::new(vec![
                 Arc::new("pervasive".to_string()),
                 Arc::new("invariants".to_string()),
-                Arc::new("Invariant".to_string()),
+                atomicity_type_name(atomicity),
                 Arc::new("namespace".to_string()),
             ]),
         }),

--- a/source/vir/src/early_exit_cf.rs
+++ b/source/vir/src/early_exit_cf.rs
@@ -83,7 +83,7 @@ fn expr_get_early_exits_rec(
                 });
                 VisitorControlFlow::Recurse
             }
-            ExprX::OpenInvariant(inv, _binder, _body) => {
+            ExprX::OpenInvariant(inv, _binder, _body, _atomicity) => {
                 expr_get_early_exits_rec(inv, in_loop, scope_map, results);
                 // Skip checking nested loops to avoid quadratic behavior:
                 VisitorControlFlow::Return

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -1,6 +1,6 @@
 use crate::ast::{
-    BinaryOp, CallTarget, Datatype, Expr, ExprX, Fun, Function, Ident, Krate, Mode, Path, Pattern,
-    PatternX, Stmt, StmtX, UnaryOpr, VirErr,
+    BinaryOp, CallTarget, Datatype, Expr, ExprX, Fun, Function, Ident, InvAtomicity, Krate, Mode,
+    Path, Pattern, PatternX, Stmt, StmtX, UnaryOpr, VirErr,
 };
 use crate::ast_util::{err_str, err_string, get_field};
 use crate::util::vec_map_result;
@@ -484,7 +484,7 @@ fn check_expr(typing: &mut Typing, outer_mode: Mode, expr: &Expr) -> Result<Mode
             }
             Ok(mode)
         }
-        ExprX::OpenInvariant(inv, binder, body) => {
+        ExprX::OpenInvariant(inv, binder, body, atomicity) => {
             if outer_mode == Mode::Spec {
                 return err_string(&expr.span, format!("Cannot open invariant in Spec mode."));
             }
@@ -495,11 +495,16 @@ fn check_expr(typing: &mut Typing, outer_mode: Mode, expr: &Expr) -> Result<Mode
             typing.vars.push_scope(true);
             typing.insert(&expr.span, &binder.name, /* mutable */ true, Mode::Proof);
 
-            if typing.atomic_insts.is_some() || outer_mode != Mode::Exec {
+            if *atomicity == InvAtomicity::NonAtomic
+                || typing.atomic_insts.is_some()
+                || outer_mode != Mode::Exec
+            {
                 // If we're a nested atomic block, we don't need to create a new
                 // AtomicInstCollector. We just rely on the outer one.
                 // Also, if we're already in Proof mode, then we just recurse in Proof
                 // mode, and we don't need to do the atomicity check at all.
+                // And of course, we don't do atomicity checks for the 'NonAtomic'
+                // invariant type.
                 let _ = check_expr(typing, outer_mode, body)?;
             } else {
                 let mut my_atomic_insts = Some(AtomicInstCollector::new());

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -423,7 +423,7 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
             let invs = Arc::new(invs.collect());
             mk_expr(ExprX::While { cond, body, invs })
         }
-        ExprX::OpenInvariant(inv, binder, body) => {
+        ExprX::OpenInvariant(inv, binder, body, atomicity) => {
             let inv = coerce_expr_to_poly(ctx, &poly_expr(ctx, state, inv));
             state.types.push_scope(true);
             let typ = coerce_typ_to_native(ctx, &binder.a);
@@ -431,7 +431,7 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
             let body = poly_expr(ctx, state, body);
             state.types.pop_scope();
             let binder = binder.new_a(typ.clone());
-            mk_expr(ExprX::OpenInvariant(inv, binder, body))
+            mk_expr(ExprX::OpenInvariant(inv, binder, body, *atomicity))
         }
         ExprX::Return(None) => expr.clone(),
         ExprX::Return(Some(e1)) => {

--- a/source/vir/src/prune.rs
+++ b/source/vir/src/prune.rs
@@ -5,8 +5,8 @@
 /// 3) Also compute names for abstract datatype sorts for the module,
 ///    since we're traversing the module-visible datatypes anyway.
 use crate::ast::{
-    CallTarget, Datatype, Expr, ExprX, Fun, Function, Ident, Krate, KrateX, Mode, Path, Stmt, Typ,
-    TypX, Visibility,
+    CallTarget, Datatype, Expr, ExprX, Fun, Function, Ident, InvAtomicity, Krate, KrateX, Mode,
+    Path, Stmt, Typ, TypX, Visibility,
 };
 use crate::ast_util::is_visible_to;
 use crate::datatype_to_air::is_datatype_transparent;
@@ -230,9 +230,11 @@ pub fn prune_krate_for_module(krate: &Krate, module: &Path) -> (Krate, Vec<MonoT
 
     // Add function decls that should always exist
     // (references to these might be generated in SST -> AIR)
-    state.reached_functions.insert(fn_inv_name());
-    state.reached_functions.insert(fn_namespace_name());
-    state.reached_datatypes.insert(datatype_invariant_path());
+    for atomicity in vec![InvAtomicity::Atomic, InvAtomicity::NonAtomic] {
+        state.reached_functions.insert(fn_inv_name(atomicity));
+        state.reached_functions.insert(fn_namespace_name(atomicity));
+        state.reached_datatypes.insert(datatype_invariant_path(atomicity));
+    }
 
     let kratex = KrateX {
         functions: functions

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -7,7 +7,7 @@
 //! SST is designed to make the translation to AIR as straightforward as possible.
 
 use crate::ast::{
-    BinaryOp, Constant, Fun, Path, SpannedTyped, Typ, Typs, UnaryOp, UnaryOpr, VarAt,
+    BinaryOp, Constant, Fun, InvAtomicity, Path, SpannedTyped, Typ, Typs, UnaryOp, UnaryOpr, VarAt,
 };
 use crate::def::Spanned;
 use air::ast::{Binders, Ident, Quant};
@@ -81,7 +81,7 @@ pub enum StmX {
         typ_inv_vars: Arc<Vec<(UniqueIdent, Typ)>>,
         modified_vars: Arc<Vec<UniqueIdent>>,
     },
-    OpenInvariant(Exp, UniqueIdent, Typ, Stm),
+    OpenInvariant(Exp, UniqueIdent, Typ, Stm, InvAtomicity),
     Block(Stms),
 }
 

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1,6 +1,6 @@
 use crate::ast::{
-    BinaryOp, Fun, Ident, Idents, IntRange, MaskSpec, Mode, Params, Path, PathX, SpannedTyped, Typ,
-    TypX, Typs, UnaryOp, UnaryOpr, VarAt,
+    BinaryOp, Fun, Ident, Idents, IntRange, InvAtomicity, MaskSpec, Mode, Params, Path, PathX,
+    SpannedTyped, Typ, TypX, Typs, UnaryOp, UnaryOpr, VarAt,
 };
 use crate::ast_util::{bitwidth_from_type, get_field, get_variant};
 use crate::context::Ctx;
@@ -264,16 +264,16 @@ fn try_unbox(ctx: &Ctx, expr: Expr, typ: &Typ) -> Option<Expr> {
     f_name.map(|f_name| ident_apply(&f_name, &vec![expr]))
 }
 
-fn call_inv(ctx: &Ctx, outer: Expr, inner: Expr, typ: &Typ) -> Expr {
-    let inv_fn_ident = suffix_global_id(&fun_to_air_ident(&fn_inv_name()));
+fn call_inv(ctx: &Ctx, outer: Expr, inner: Expr, typ: &Typ, atomicity: InvAtomicity) -> Expr {
+    let inv_fn_ident = suffix_global_id(&fun_to_air_ident(&fn_inv_name(atomicity)));
     let typ_expr = typ_to_id(typ);
     let boxed_inner = try_box(ctx, inner.clone(), typ).unwrap_or(inner);
     let args = vec![typ_expr, outer, boxed_inner];
     ident_apply(&inv_fn_ident, &args)
 }
 
-fn call_namespace(arg: Expr, typ: &Typ) -> Expr {
-    let inv_fn_ident = suffix_global_id(&fun_to_air_ident(&fn_namespace_name()));
+fn call_namespace(arg: Expr, typ: &Typ, atomicity: InvAtomicity) -> Expr {
+    let inv_fn_ident = suffix_global_id(&fun_to_air_ident(&fn_namespace_name(atomicity)));
     let typ_expr = typ_to_id(typ);
     let args = vec![typ_expr, arg];
     ident_apply(&inv_fn_ident, &args)
@@ -1041,7 +1041,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
             }
             stmts
         }
-        StmX::OpenInvariant(inv_exp, uid, typ, body_stm) => {
+        StmX::OpenInvariant(inv_exp, uid, typ, body_stm, atomicity) => {
             let mut stmts = vec![];
 
             // Build the inv_expr. Note: In the SST, this should have been assigned
@@ -1051,7 +1051,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
             let inv_expr = exp_to_expr(ctx, inv_exp, ExprCtxt::Body);
 
             // Assert that the namespace of the inv we are opening is in the mask set
-            let namespace_expr = call_namespace(inv_expr.clone(), typ);
+            let namespace_expr = call_namespace(inv_expr.clone(), typ, *atomicity);
             state.mask.assert_contains(&inv_exp.span, &namespace_expr, &mut stmts);
 
             // add an 'assume' that inv holds
@@ -1061,7 +1061,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
             if let Some(ty_inv) = ty_inv_opt {
                 stmts.push(Arc::new(StmtX::Assume(ty_inv)));
             }
-            let main_inv = call_inv(ctx, inv_expr, inner_expr, typ);
+            let main_inv = call_inv(ctx, inv_expr, inner_expr, typ, *atomicity);
             stmts.push(Arc::new(StmtX::Assume(main_inv.clone())));
 
             // process the body

--- a/source/vir/src/sst_vars.rs
+++ b/source/vir/src/sst_vars.rs
@@ -102,13 +102,13 @@ pub(crate) fn stm_assign(
             };
             Spanned::new(stm.span.clone(), while_x)
         }
-        StmX::OpenInvariant(inv, ident, ty, body_stm) => {
+        StmX::OpenInvariant(inv, ident, ty, body_stm, atomicity) => {
             assigned.insert(ident.clone());
             modified.insert(ident.clone());
             let body_stm = stm_assign(assign_map, declared, assigned, modified, body_stm);
             Spanned::new(
                 stm.span.clone(),
-                StmX::OpenInvariant(inv.clone(), ident.clone(), ty.clone(), body_stm),
+                StmX::OpenInvariant(inv.clone(), ident.clone(), ty.clone(), body_stm, *atomicity),
             )
         }
         StmX::Block(stms) => {

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -160,7 +160,7 @@ where
                     }
                     expr_visitor_control_flow!(stm_visitor_dfs(body, f));
                 }
-                StmX::OpenInvariant(_inv, _ident, _ty, body) => {
+                StmX::OpenInvariant(_inv, _ident, _ty, body, _atomicity) => {
                     expr_visitor_control_flow!(stm_visitor_dfs(body, f));
                 }
                 StmX::Block(ss) => {
@@ -215,7 +215,7 @@ where
                     expr_visitor_control_flow!(exp_visitor_dfs(inv, &mut ScopeMap::new(), f));
                 }
             }
-            StmX::OpenInvariant(inv, _ident, _ty, _body) => {
+            StmX::OpenInvariant(inv, _ident, _ty, _body, _atomicity) => {
                 expr_visitor_control_flow!(exp_visitor_dfs(inv, &mut ScopeMap::new(), f))
             }
             StmX::Block(_) => (),
@@ -407,11 +407,11 @@ where
             );
             f(&stm)
         }
-        StmX::OpenInvariant(inv, ident, ty, body) => {
+        StmX::OpenInvariant(inv, ident, ty, body, atomicity) => {
             let body = map_stm_visitor(body, f)?;
             let stm = Spanned::new(
                 stm.span.clone(),
-                StmX::OpenInvariant(inv.clone(), ident.clone(), ty.clone(), body),
+                StmX::OpenInvariant(inv.clone(), ident.clone(), ty.clone(), body, *atomicity),
             );
             f(&stm)
         }
@@ -465,11 +465,11 @@ where
                     },
                 )
             }
-            StmX::OpenInvariant(inv, ident, ty, body) => {
+            StmX::OpenInvariant(inv, ident, ty, body, atomicity) => {
                 let inv = f(inv);
                 Spanned::new(
                     span,
-                    StmX::OpenInvariant(inv, ident.clone(), ty.clone(), body.clone()),
+                    StmX::OpenInvariant(inv, ident.clone(), ty.clone(), body.clone(), *atomicity),
                 )
             }
             StmX::Block(_) => stm.clone(),

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -201,7 +201,7 @@ fn check_function(ctxt: &Ctxt, function: &Function) -> Result<(), VirErr> {
                         panic!("field access of undefined datatype");
                     }
                 }
-                ExprX::OpenInvariant(_inv, _binder, body) => {
+                ExprX::OpenInvariant(_inv, _binder, body, _atomicity) => {
                     assert_no_early_exit_in_inv_block(&body.span, body)?;
                 }
                 _ => {}


### PR DESCRIPTION
This introduces `LocalInvariant`, which is like `Invariant`, but with two key differences:

 * A `LocalInvariant` is not marked `Sync`
 * When opening `LocalInvariant`, the inside is not restricted to a single atomic operation.

The second point is okay because the first point ensures that we can never have two threads open the invariant at the same time.

This is a new, experimental type that didn't have any analogue in LinearDafny (which didn't have a notion of `Sync`/`Send` at all). I hypothesize that it will be useful for certain (thread-local) interior mutability patterns. The example I have in mind is an untrusted implementation of `Rc`, but that example will need to wait until more of the concurrent-state-machine stuff is done.