### PR TITLE
erase code without depending on expr spans in the AST

### DIFF
--- a/source/rust_verify/example/adts.rs
+++ b/source/rust_verify/example/adts.rs
@@ -68,5 +68,16 @@ fn test_result<E>(r: Result<u64, E>) -> u64 {
     }
 }
 
+fn if_let_test(r: Result<u64, u64>) -> bool {
+    requires(r.is_Ok());
+    ensures(|b: bool| b == true);
+
+    if let Result::Ok(r_inner) = r {
+        return true;
+    }
+
+    false
+}
+
 fn main() {
 }

--- a/source/rust_verify/src/context.rs
+++ b/source/rust_verify/src/context.rs
@@ -1,17 +1,19 @@
-use crate::erase::ResolvedCall;
 use rustc_hir::{Crate, HirId};
 use rustc_middle::ty::{TyCtxt, TypeckResults};
 use rustc_span::SpanData;
 use std::collections::HashMap;
 use std::sync::Arc;
-use vir::ast::{Expr, Mode, Pattern, Typ};
+use vir::ast::{Mode, Typ};
 
 pub struct ErasureInfo {
-    pub(crate) resolved_calls: Vec<(SpanData, ResolvedCall)>,
-    pub(crate) resolved_exprs: Vec<(SpanData, Expr)>,
-    pub(crate) resolved_pats: Vec<(SpanData, Pattern)>,
     pub(crate) external_functions: Vec<vir::ast::Fun>,
     pub(crate) ignored_functions: Vec<SpanData>,
+    pub(crate) external_body_functions: Vec<(SpanData, ExternalBodyErasureInfo)>,
+}
+
+#[derive(Clone)]
+pub struct ExternalBodyErasureInfo {
+    pub num_header_stmts: usize,
 }
 
 type ErasureInfoRef = std::rc::Rc<std::cell::RefCell<ErasureInfo>>;

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -493,11 +493,9 @@ impl Verifier {
 
         let hir = tcx.hir();
         let erasure_info = ErasureInfo {
-            resolved_calls: vec![],
-            resolved_exprs: vec![],
-            resolved_pats: vec![],
             external_functions: vec![],
             ignored_functions: vec![],
+            external_body_functions: vec![],
         };
         let erasure_info = std::rc::Rc::new(std::cell::RefCell::new(erasure_info));
         let ctxt =
@@ -524,19 +522,15 @@ impl Verifier {
         let time4 = Instant::now();
 
         let erasure_info = ctxt.erasure_info.borrow();
-        let resolved_calls = erasure_info.resolved_calls.clone();
-        let resolved_exprs = erasure_info.resolved_exprs.clone();
-        let resolved_pats = erasure_info.resolved_pats.clone();
         let external_functions = erasure_info.external_functions.clone();
         let ignored_functions = erasure_info.ignored_functions.clone();
+        let external_body_functions = erasure_info.external_body_functions.clone();
         let erasure_hints = crate::erase::ErasureHints {
             vir_crate,
-            resolved_calls,
-            resolved_exprs,
-            resolved_pats,
             erasure_modes,
             external_functions,
             ignored_functions,
+            external_body_functions,
         };
         self.erasure_hints = Some(erasure_hints);
 

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -313,6 +313,9 @@ pub enum ExprX {
     /// Note: this only appears temporarily during rust_to_vir construction, and should not
     /// appear in the final Expr produced by rust_to_vir (see vir::headers::read_header).
     Header(HeaderExpr),
+    /// Indicates that a header *used* to be here. This has no effect, but it is useful
+    /// for erasure.
+    HeaderStub,
     /// Assume false
     Admit,
     /// Forall or assert-by statement; proves "forall vars. ensure" via proof.

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -573,6 +573,7 @@ pub(crate) fn expr_to_stm_opt(
         ExprX::Header(_) => {
             return err_str(&expr.span, "header expression not allowed here");
         }
+        ExprX::HeaderStub => Ok((vec![], None)),
         ExprX::Admit => {
             let expx = ExpX::Const(Constant::Bool(false));
             let exp = SpannedTyped::new(&expr.span, &Arc::new(TypX::Bool), expx);

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -241,6 +241,7 @@ where
                 ExprX::Header(_) => {
                     panic!("header expression not allowed here: {:?}", &expr.span);
                 }
+                ExprX::HeaderStub => (),
                 ExprX::Admit => (),
                 ExprX::Forall { vars, require, ensure, proof } => {
                     map.push_scope(true);
@@ -438,6 +439,7 @@ where
         ExprX::Header(_) => {
             return err_str(&expr.span, "header expression not allowed here");
         }
+        ExprX::HeaderStub => ExprX::HeaderStub,
         ExprX::Admit => ExprX::Admit,
         ExprX::Forall { vars, require, ensure, proof } => {
             let vars =

--- a/source/vir/src/early_exit_cf.rs
+++ b/source/vir/src/early_exit_cf.rs
@@ -71,6 +71,7 @@ fn expr_get_early_exits_rec(
             | ExprX::AssertBV(..)
             | ExprX::Fuel(..)
             | ExprX::Header(..)
+            | ExprX::HeaderStub
             | ExprX::Admit
             | ExprX::Forall { .. } => VisitorControlFlow::Return,
             ExprX::While { cond, body, invs: _ } => {

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -379,6 +379,7 @@ fn check_expr(typing: &mut Typing, outer_mode: Mode, expr: &Expr) -> Result<Mode
         }
         ExprX::Fuel(_, _) => Ok(outer_mode),
         ExprX::Header(_) => panic!("internal error: Header shouldn't exist here"),
+        ExprX::HeaderStub => Ok(outer_mode),
         ExprX::Admit => Ok(outer_mode),
         ExprX::Forall { vars, require, ensure, proof } => {
             let in_forall_stmt = typing.in_forall_stmt;

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -391,6 +391,7 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
         ExprX::AssertBV(_) => expr.clone(),
         ExprX::Fuel(..) => expr.clone(),
         ExprX::Header(..) => panic!("Header should already be removed"),
+        ExprX::HeaderStub => expr.clone(),
         ExprX::Admit => expr.clone(),
         ExprX::Forall { vars, require, ensure, proof } => {
             let mut bs: Vec<Binder<Typ>> = Vec::new();

--- a/source/vir/src/printer.rs
+++ b/source/vir/src/printer.rs
@@ -254,6 +254,7 @@ fn expr_to_node(expr: &Expr) -> Node {
             nodes!(fuel {fun_to_node(fun)} {str_to_node(&format!("{}", fuel))})
         }
         ExprX::Header(header_expr) => nodes!(header {header_expr_to_node(header_expr)}),
+        ExprX::HeaderStub => nodes!(header_stub),
         ExprX::Admit => node!(admit),
         ExprX::Forall { vars, require, ensure, proof } => {
             nodes!(forall {binders_node(vars, &typ_to_node)} {str_to_node(":require")} {expr_to_node(require)} {str_to_node(":ensure")} {expr_to_node(ensure)} {str_to_node(":proof")} {expr_to_node(proof)})


### PR DESCRIPTION
This is the VIR-walking strategy I was talking about on Slack, which removes the need to depend on any expr spans from the Rust AST. This PR should help ground the discussion of the trade-offs between the 2 different approaches.

Doing it this way, we can entirely remove `resolved_calls`, `resolved_exprs`, and `resolve_pats`. 

By walking the VIR directly along with the Rust AST, we can "resolve" calls instead by pattern matching, e.g., 

```rust
(ExprKind::Call(..), ExprX::Fuel(..)) => { return None; }
```

This simplifies rust_vir_to_expr, since we no longer need to collect all that extra information.

I also think it's easier to be confident in the correctness this way; since we match on VIR, the cases line up better with the cases in `vir/src/modes.rs`. Also, the act of successfully pattern-matching the whole tree provides evidence we got the correspondence right; if we've forgotten a case, it ought to manifest as a pattern-match failure.

There are a couple of tricky things:
  * There are differences between Rust's AST and VIR, so these need to be accounted for. For example, VIR introduces `Clip` (which can pretty much just be skipped). Another example is if-let statements, which become match statements.
  * Since the rust->VIR stage removes headers, there was nothing for them to match against. So instead of removing the Header expressions, I changed the pipeline to replace them with HeaderStub expressions, which aren't removed until the 'simplify' phase. This seemed like a small price for the other simplifications.

Note that, while this is in service of the goal of removing decisions that depend on spans, this doesn't accomplish that goal; `condition_modes` and `var_modes` still depend on spans, although they now depend on spans found in the VIR tree. However, the only function of the spans at this point is to provide a unique identifier for each node of the VIR tree, which could easily be accomplished by other means in a follow-up.

Also, function definitions are still matched up by spans - I didn't touch that part at all.