### PR TITLE
extra_dependency directive

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -37,6 +37,12 @@ pub fn hide<F>(_f: F) {
 
 // Can only appear at beginning of function body
 #[proof]
+pub fn extra_dependency<F>(_f: F) {
+    unimplemented!();
+}
+
+// Can only appear at beginning of function body
+#[proof]
 pub fn opens_invariants_none() {
     unimplemented!();
 }

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -340,6 +340,7 @@ fn fn_call_to_vir<'tcx>(
     let is_choose_tuple = f_name == "builtin::choose_tuple";
     let is_equal = f_name == "builtin::equal";
     let is_hide = f_name == "builtin::hide";
+    let is_extra_dependency = f_name == "builtin::extra_dependency";
     let is_reveal = f_name == "builtin::reveal";
     let is_reveal_fuel = f_name == "builtin::reveal_with_fuel";
     let is_implies = f_name == "builtin::imply";
@@ -365,7 +366,7 @@ fn fn_call_to_vir<'tcx>(
         || is_opens_invariants
         || is_opens_invariants_except;
     let is_quant = is_forall || is_exists;
-    let is_directive = is_hide || is_reveal || is_reveal_fuel;
+    let is_directive = is_extra_dependency || is_hide || is_reveal || is_reveal_fuel;
     let is_cmp = is_equal || is_eq || is_ne || is_le || is_ge || is_lt || is_gt;
     let is_arith_binary = is_add || is_sub || is_mul;
 
@@ -388,6 +389,7 @@ fn fn_call_to_vir<'tcx>(
         && !is_opens_invariants_any
         && !is_opens_invariants
         && !is_opens_invariants_except
+        && !is_extra_dependency
     {
         return Ok(spanned_typed_new(
             expr.span,
@@ -508,11 +510,14 @@ fn fn_call_to_vir<'tcx>(
         );
     }
 
-    if is_hide || is_reveal {
+    if is_extra_dependency || is_hide || is_reveal {
         unsupported_err_unless!(len == 1, expr.span, "expected hide/reveal", &args);
         let x = get_fn_path(bctx, &args[0])?;
         if is_hide {
             let header = Arc::new(HeaderExprX::Hide(x));
+            return Ok(mk_expr(ExprX::Header(header)));
+        } else if is_extra_dependency {
+            let header = Arc::new(HeaderExprX::ExtraDependency(x));
             return Ok(mk_expr(ExprX::Header(header)));
         } else {
             return Ok(mk_expr(ExprX::Fuel(x, 1)));

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -291,6 +291,7 @@ pub(crate) fn check_item_fn<'tcx>(
         is_abstract: vattrs.is_abstract,
         attrs: Arc::new(fattrs),
         body: if vattrs.external_body { None } else { Some(vir_body) },
+        extra_dependencies: header.extra_dependencies,
     };
     let function = spanned_new(sig.span, func);
     vir.functions.push(function);
@@ -349,6 +350,7 @@ pub(crate) fn check_item_const<'tcx>(
         is_abstract: vattrs.is_abstract,
         attrs: Default::default(),
         body: if vattrs.external_body { None } else { Some(vir_body) },
+        extra_dependencies: vec![],
     };
     let function = spanned_new(span, func);
     vir.functions.push(function);
@@ -410,6 +412,7 @@ pub(crate) fn check_foreign_item_fn<'tcx>(
         is_abstract: false,
         attrs: Default::default(),
         body: None,
+        extra_dependencies: vec![],
     };
     let function = spanned_new(span, func);
     vir.functions.push(function);

--- a/source/rust_verify/tests/recursion.rs
+++ b/source/rust_verify/tests/recursion.rs
@@ -513,3 +513,21 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_one_fails(err)
 }
+
+test_verify_one_file! {
+    #[test] extra_dep_fail code! {
+        // We expect this to complain about the lack of 'decreases' clause
+
+        #[proof]
+        fn dec1(i: nat) {
+            dec2(i);
+        }
+
+        #[proof]
+        #[verifier(external_body)]
+        fn dec2(i: nat) {
+            extra_dependency(dec1);
+            unimplemented!();
+        }
+    } => Err(err) => assert_vir_error(err)
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -193,6 +193,9 @@ pub enum HeaderExprX {
     /// Make a function f opaque (definition hidden) within the current function body.
     /// (The current function body can later reveal f in specific parts of the current function body if desired.)
     Hide(Fun),
+    /// `extra_dependency(f)` means that recursion-checking should act as if the current
+    /// function calls `f`
+    ExtraDependency(Fun),
 }
 
 /// Primitive constant values
@@ -439,6 +442,9 @@ pub struct FunctionX {
     pub attrs: FunctionAttrs,
     /// Body of the function (may be None for foreign functions or for external_body functions)
     pub body: Option<Expr>,
+    /// Extra dependencies, only used for for the purposes of recursion-well-foundedness
+    /// Useful only for trusted fns.
+    pub extra_dependencies: Vec<Fun>,
 }
 
 /// Single field in a variant

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -611,6 +611,7 @@ where
         is_abstract,
         attrs,
         body,
+        extra_dependencies,
     } = &function.x;
     let name = name.clone();
     let visibility = visibility.clone();
@@ -653,6 +654,7 @@ where
         }
     };
     let attrs = attrs.clone();
+    let extra_dependencies = extra_dependencies.clone();
     let is_const = *is_const;
     let is_abstract = *is_abstract;
     let body = body.as_ref().map(|e| map_expr_visitor_env(e, map, env, fe, fs, ft)).transpose()?;
@@ -673,6 +675,7 @@ where
         is_abstract,
         attrs,
         body,
+        extra_dependencies,
     };
     Ok(Spanned::new(function.span.clone(), functionx))
 }

--- a/source/vir/src/headers.rs
+++ b/source/vir/src/headers.rs
@@ -11,10 +11,12 @@ pub struct Header {
     pub invariant: Exprs,
     pub decrease: Exprs,
     pub invariant_mask: MaskSpec,
+    pub extra_dependencies: Vec<Fun>,
 }
 
 fn read_header_block(block: &mut Vec<Stmt>) -> Result<Header, VirErr> {
     let mut hidden: Vec<Fun> = Vec::new();
+    let mut extra_dependencies: Vec<Fun> = Vec::new();
     let mut require: Option<Exprs> = None;
     let mut ensure: Option<(Option<(Ident, Typ)>, Exprs)> = None;
     let mut invariant: Option<Exprs> = None;
@@ -64,6 +66,9 @@ fn read_header_block(block: &mut Vec<Stmt>) -> Result<Header, VirErr> {
                     HeaderExprX::Hide(x) => {
                         hidden.push(x.clone());
                     }
+                    HeaderExprX::ExtraDependency(x) => {
+                        extra_dependencies.push(x.clone());
+                    }
                     HeaderExprX::InvariantOpens(es) => {
                         match invariant_mask {
                             MaskSpec::NoSpec => {}
@@ -97,7 +102,16 @@ fn read_header_block(block: &mut Vec<Stmt>) -> Result<Header, VirErr> {
     };
     let invariant = invariant.unwrap_or(Arc::new(vec![]));
     let decrease = decrease.unwrap_or(Arc::new(vec![]));
-    Ok(Header { hidden, require, ensure_id_typ, ensure, invariant, decrease, invariant_mask })
+    Ok(Header {
+        hidden,
+        require,
+        ensure_id_typ,
+        ensure,
+        invariant,
+        decrease,
+        invariant_mask,
+        extra_dependencies,
+    })
 }
 
 pub fn read_header(body: &mut Expr) -> Result<Header, VirErr> {

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -511,6 +511,7 @@ fn poly_function(ctx: &Ctx, function: &Function) -> Function {
         is_abstract,
         attrs,
         body,
+        extra_dependencies,
     } = &function.x;
 
     let mut types = ScopeMap::new();
@@ -589,6 +590,7 @@ fn poly_function(ctx: &Ctx, function: &Function) -> Function {
         is_abstract: *is_abstract,
         attrs: attrs.clone(),
         body,
+        extra_dependencies: extra_dependencies.clone(),
     };
     Spanned::new(function.span.clone(), functionx)
 }

--- a/source/vir/src/printer.rs
+++ b/source/vir/src/printer.rs
@@ -138,6 +138,7 @@ fn header_expr_to_node(header_expr: &HeaderExprX) -> Node {
             nodes!(invariantOpensExcept {exprs_to_node(exprs)})
         }
         HeaderExprX::Hide(fun) => nodes!(hide {fun_to_node(fun)}),
+        HeaderExprX::ExtraDependency(fun) => nodes!(extra_dependency {fun_to_node(fun)}),
     }
 }
 
@@ -329,6 +330,7 @@ fn function_to_node(function: &FunctionX) -> Node {
         is_abstract,
         attrs,
         body,
+        extra_dependencies,
     } = function;
     let typ_bounds_node = Node::List(
         typ_bounds
@@ -403,6 +405,11 @@ fn function_to_node(function: &FunctionX) -> Node {
 
         Node::List(nodes)
     };
+    let extra_dependencies_node = {
+        let mut nodes: Vec<Node> = vec![str_to_node("extra_dependencies")];
+        nodes.extend(extra_dependencies.iter().map(|ed| fun_to_node(ed)));
+        Node::List(nodes)
+    };
     let mut nodes = vec![
         str_to_node("function"),
         fun_to_node(name),
@@ -424,6 +431,7 @@ fn function_to_node(function: &FunctionX) -> Node {
         str_to_node(":decrease"),
         exprs_to_node(decrease),
         mask_spec_node,
+        extra_dependencies_node,
     ];
     if *is_const {
         nodes.push(str_to_node("+is_const"));

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -387,4 +387,8 @@ pub(crate) fn expand_call_graph(call_graph: &mut Graph<Fun>, function: &Function
         })
         .expect("expr_visitor_check failed unexpectedly");
     }
+
+    for fun in &function.x.extra_dependencies {
+        call_graph.add_edge(function.x.name.clone(), fun.clone());
+    }
 }


### PR DESCRIPTION
I decided to make this a separate PR from the state-machine branch to make it a self-contained change easier to review.

Introduces a new header type (I made it a header type rather than an attribute in order to get path resolution) that serves as an extra dependency edge for recursion purposes. 