### PR TITLE
fix overflow bug in preconditions of fetch_add and fetch_sub

### DIFF
--- a/source/pervasive/atomic.rs
+++ b/source/pervasive/atomic.rs
@@ -290,8 +290,8 @@ macro_rules! atomic_integer_methods {
         pub fn fetch_add(&self, #[proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty {
             requires([
                 equal(self.view(), old(perm).patomic),
-                $int_min <= old(perm).value + n,
-                old(perm).value + n <= $int_max,
+                $int_min as int <= old(perm).value as int + n as int,
+                old(perm).value as int + n as int <= $int_max as int,
             ]);
             ensures(|ret: $value_ty| equal(old(perm).value, ret)
                 && perm.patomic == old(perm).patomic
@@ -308,8 +308,8 @@ macro_rules! atomic_integer_methods {
         pub fn fetch_sub(&self, #[proof] perm: &mut $p_ident, n: $value_ty) -> $value_ty {
             requires([
                 equal(self.view(), old(perm).patomic),
-                $int_min <= old(perm).value - n,
-                old(perm).value - n <= $int_max,
+                $int_min as int <= old(perm).value as int - n as int,
+                old(perm).value as int - n  as int<= $int_max as int,
             ]);
             ensures(|ret: $value_ty| equal(old(perm).value, ret)
                 && perm.patomic == old(perm).patomic

--- a/source/rust_verify/tests/atomic_lib.rs
+++ b/source/rust_verify/tests/atomic_lib.rs
@@ -916,3 +916,69 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_atomic_bool_smoke test_body(ATOMIC_BOOL, true) => Err(e) => assert_one_fails(e)
 }
+
+test_verify_one_file! {
+    #[test] test_unsigned_add_overflow_fail
+    IMPORTS.to_string() + code_str! {
+        pub fn do_nothing() {
+            let (at, Proof(mut perm)) = PAtomicU32::new(0xf000_0000);
+
+            at.fetch_add(&mut perm, 0xf000_0000); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_unsigned_sub_underflow_fail
+    IMPORTS.to_string() + code_str! {
+        pub fn do_nothing() {
+            let (at, Proof(mut perm)) = PAtomicU32::new(5);
+
+            at.fetch_sub(&mut perm, 6); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_signed_add_overflow_fail
+    IMPORTS.to_string() + code_str! {
+        pub fn do_nothing() {
+            let (at, Proof(mut perm)) = PAtomicI32::new(0x7000_0000);
+
+            at.fetch_add(&mut perm, 0x7000_0000); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_signed_add_underflow_fail
+    IMPORTS.to_string() + code_str! {
+        pub fn do_nothing() {
+            let (at, Proof(mut perm)) = PAtomicI32::new(-0x7000_0000);
+
+            at.fetch_add(&mut perm, -0x7000_0000); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_signed_sub_overflow_fail
+    IMPORTS.to_string() + code_str! {
+        pub fn do_nothing() {
+            let (at, Proof(mut perm)) = PAtomicI32::new(0x7000_0000);
+
+            at.fetch_sub(&mut perm, -0x7000_0000); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] test_signed_sub_underflow_fail
+    IMPORTS.to_string() + code_str! {
+        pub fn do_nothing() {
+            let (at, Proof(mut perm)) = PAtomicI32::new(-0x7000_0000);
+
+            at.fetch_sub(&mut perm, 0x7000_0000); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}


### PR DESCRIPTION
`fetch_add` and `fetch_sub`, which were intended to make it easier for the user to catch overflow/underflow bugs... ironically had overflow & underflow bugs in their trusted specs

Specifically, I had written the preconditions like this:

```rust
$int_min <= old(perm).value + n
```

when they should have been like this:

```rust
$int_min as int <= old(perm).value as int + n as int
```