### PR TITLE
handle closure where params have inferred types

### DIFF
--- a/source/rust_verify/tests/assert_forall_by.rs
+++ b/source/rust_verify/tests/assert_forall_by.rs
@@ -75,6 +75,14 @@ test_verify_one_file! {
             assert(f1(3) > 3);
         }
 
+        fn forallstmt_test_inference() {
+            assert_forall_by(|x| {
+                ensures(f1(x) > x);
+                reveal(f1);
+            });
+            assert(f1(3) > 3);
+        }
+
         #[proof]
         fn no_consume(x: bool) {
         }

--- a/source/rust_verify/tests/basic.rs
+++ b/source/rust_verify/tests/basic.rs
@@ -280,3 +280,21 @@ test_verify_one_file! {
         }
     } => Err(TestErr { has_vir_error: true, .. })
 }
+
+test_verify_one_file! {
+    #[test] test_ensures_type_inference code! {
+        struct Foo {
+            pub b: bool,
+        }
+
+        #[spec]
+        fn get_b(foo: Foo) -> bool {
+            foo.b
+        }
+
+        fn test1() -> Foo {
+            ensures(|b| get_b(b));
+            Foo {b: true}
+        }
+    } => Ok(())
+}

--- a/source/rust_verify/tests/choose.rs
+++ b/source/rust_verify/tests/choose.rs
@@ -20,6 +20,14 @@ test_verify_one_file! {
         }
 
         #[proof]
+        fn test_choose_inference() {
+            let i = choose(|i| f(i));
+            assert(f(7));
+            assert(5 <= i);
+        }
+
+
+        #[proof]
         fn test_choose_eq() {
             let i1 = choose(|i: int| f(i) && (1 + 1 == 2));
             let i2 = choose(|i: int| f(i) && (2 + 2 == 4));

--- a/source/rust_verify/tests/closures.rs
+++ b/source/rust_verify/tests/closures.rs
@@ -66,6 +66,20 @@ test_verify_one_file! {
             let q: u32 = 3;
             assert(specf(10, |z: u32| z + 1 + p + q) == 18 + 2 * p);
         }
+
+        #[proof]
+        fn test_specf_inference(p: u32) {
+            requires(p < 100);
+
+            let q: u32 = 3;
+            assert(specf(10, |z| z + 1 + p + q) == 18 + 2 * p);
+        }
+
+        #[proof]
+        fn test_refine_inference<F: Fn(bool, bool) -> nat>(f: F) {
+            refine_takefun(|x, y| 10);
+            assert(apply_to_1(|u| 10) >= 0);
+        }
     } => Ok(())
 }
 

--- a/source/rust_verify/tests/quantifiers.rs
+++ b/source/rust_verify/tests/quantifiers.rs
@@ -15,6 +15,12 @@ test_verify_one_file! {
             assert(tr(300));
             assert(exists(|i: nat| i >= 0 && tr(i)));
         }
+
+        #[proof]
+        fn test1_inference() {
+            assert(tr(300));
+            assert(exists(|i| i >= 0 && tr(i)));
+        }
     } => Ok(())
 }
 


### PR DESCRIPTION
pretty simple, since the types won't necessarily be on the params, we just look up the type of the lambda node and get the types from there