### PR TITLE
clean up PCell, add PPtr

### DIFF
--- a/source/pervasive/cell.rs
+++ b/source/pervasive/cell.rs
@@ -6,88 +6,146 @@ use std::mem::MaybeUninit;
 #[allow(unused_imports)] use crate::pervasive::*;
 #[allow(unused_imports)] use crate::pervasive::modes::*;
 
+
+// TODO implement: borrow_mut, drop
+
 // TODO Identifier should be some opaque type, not necessarily an int
-
-// TODO implement: borrow, borrow_mut, take, swap, read_copy
-
-// TODO figure out how Drop should work
-
 //type Identifier = int;
 
 #[verifier(external_body)]
 pub struct PCell<#[verifier(strictly_positive)] V> {
-  ucell: UnsafeCell<MaybeUninit<V>>,
+    ucell: UnsafeCell<MaybeUninit<V>>,
 }
 
 #[proof]
 #[verifier(unforgeable)]
 pub struct Permission<V> {
-  #[spec] pub pcell: int,
-  #[spec] pub value: option::Option<V>,
-}
-
-pub struct PCellWithToken<V> {
-  pub pcell: PCell<V>,
-  #[proof] pub token: Permission<V>,
+    #[spec] pub pcell: int,
+    #[spec] pub value: option::Option<V>,
 }
 
 impl<V> PCell<V> {
-  #[inline(always)]
-  #[verifier(external_body)]
-  pub fn empty() -> PCellWithToken<V> {
-    ensures(|pt : PCellWithToken<V>|
-      equal(pt.token, Permission{ pcell: pt.pcell.view(), value: option::Option::None })
-    );
+    #[inline(always)]
+    #[verifier(external_body)]
+    pub fn empty() -> (PCell<V>, Proof<Permission<V>>) {
+        ensures(|pt : (PCell<V>, Proof<Permission<V>>)|
+            equal(pt.1, Proof(Permission{ pcell: pt.0.view(), value: option::Option::None }))
+        );
 
-    let p = PCell { ucell: UnsafeCell::new(MaybeUninit::uninit()) };
-    let Proof(t) = exec_proof_from_false();
-    PCellWithToken {pcell: p, token: t}
-  }
-
-  fndecl!(pub fn view(&self) -> int);
-
-  //// Put
-
-  #[inline(always)]
-  #[verifier(external_body)]
-  fn put_external(&self, v: V) {
-    ensures(false);
-    unsafe {
-      *(self.ucell.get()) = MaybeUninit::new(v);
+        let p = PCell { ucell: UnsafeCell::new(MaybeUninit::uninit()) };
+        let Proof(t) = exec_proof_from_false();
+        (p, Proof(t))
     }
-  }
 
-  #[inline(always)]
-  #[verifier(returns(proof))]
-  pub fn put(&self, v: V, #[proof] perm: Permission<V>) -> Permission<V> {
-    requires([
-        equal(self.view(), perm.pcell),
-        equal(perm.value, option::Option::None),
-    ]);
-    ensures(|p: Permission<V>|
-        equal(p.value, option::Option::Some(v))
-    );
+    fndecl!(pub fn view(&self) -> int);
 
-    self.put_external(v);
+    #[inline(always)]
+    #[verifier(external_body)]
+    pub fn put(&self, #[proof] perm: &mut Permission<V>, v: V) {
+        requires([
+            equal(self.view(), old(perm).pcell),
+            equal(old(perm).value, option::Option::None),
+        ]);
+        ensures(
+            equal(perm.pcell, old(perm).pcell) &&
+            equal(perm.value, option::Option::Some(v))
+        );
+        opens_invariants_none();
 
-    perm
-  }
+        unsafe {
+            *(self.ucell.get()) = MaybeUninit::new(v);
+        }
+    }
 
-  /*
-  #[inline(always)]
-  #[verifier(no_verify)]
-  pub fn borrow(&self, perm: &'a Permission<V>) -> &'a V {
-    requires([
-        equal(self.view(), perm.view().pcell),
-        !equal(perm.view().value, None),
-    ]);
-    ensures(|p: Permission<V>|
-        equal(p.view().value, Some(v))
-    );
-    
-    self.write_external(v);
+    #[inline(always)]
+    #[verifier(external_body)]
+    pub fn take(&self, #[proof] perm: &mut Permission<V>) -> V {
+        requires([
+            equal(self.view(), old(perm).pcell),
+            old(perm).value.is_Some(),
+        ]);
+        ensures(|v: V| [
+            equal(perm.pcell, old(perm).pcell),
+            equal(perm.value, option::Option::None),
+            equal(v, old(perm).value.get_Some_0()),
+        ]);
+        opens_invariants_none();
 
-    perm
-  }
-  */
+        unsafe {
+            let mut m = MaybeUninit::uninit();
+            std::mem::swap(&mut m, &mut *self.ucell.get());
+            m.assume_init()
+        }
+    }
+
+    #[inline(always)]
+    #[verifier(external_body)]
+    pub fn replace(&self, #[proof] perm: &mut Permission<V>, in_v: V) -> V {
+        requires([
+            equal(self.view(), old(perm).pcell),
+            old(perm).value.is_Some(),
+        ]);
+        ensures(|out_v: V| [
+            equal(perm.pcell, old(perm).pcell),
+            equal(perm.value, option::Option::Some(in_v)),
+            equal(out_v, old(perm).value.get_Some_0()),
+        ]);
+        opens_invariants_none();
+
+        unsafe {
+            let mut m = MaybeUninit::new(in_v);
+            std::mem::swap(&mut m, &mut *self.ucell.get());
+            m.assume_init()
+        }
+    }
+
+    /// Note that `self` actually contains the data in its interior, so it needs
+    /// to outlive the returned borrow.
+
+    #[inline(always)]
+    #[verifier(external_body)]
+    pub fn as_ref<'a>(&'a self, #[proof] perm: &'a Permission<V>) -> &'a V {
+        requires([
+            equal(self.view(), perm.pcell),
+            perm.value.is_Some(),
+        ]);
+        ensures(|v: V|
+            equal(v, perm.value.get_Some_0())
+        );
+        opens_invariants_none();
+
+        unsafe {
+            (*self.ucell.get()).assume_init_ref()
+        }
+    }
+
+    //////////////////////////////////
+    // Untrusted functions below here
+
+    #[inline(always)]
+    pub fn into_inner(self, #[proof] perm: Permission<V>) -> V {
+        requires([
+            equal(self.view(), perm.pcell),
+            perm.value.is_Some(),
+        ]);
+        ensures(|v|
+            equal(v, perm.value.get_Some_0())
+        );
+        opens_invariants_none();
+
+        #[proof] let mut perm = perm;
+        self.take(&mut perm)
+    }
+
+    #[inline(always)]
+    #[verifier(external_body)]
+    pub fn new(v: V) -> (PCell<V>, Proof<Permission<V>>) {
+        ensures(|pt : (PCell<V>, Proof<Permission<V>>)|
+            equal(pt.1, Proof(Permission{ pcell: pt.0.view(), value: option::Option::Some(v) }))
+        );
+
+        let (p, Proof(mut t)) = Self::empty();
+        p.put(&mut t, v);
+        (p, Proof(t))
+    }
 }

--- a/source/pervasive/cell.rs
+++ b/source/pervasive/cell.rs
@@ -7,7 +7,7 @@ use std::mem::MaybeUninit;
 #[allow(unused_imports)] use crate::pervasive::modes::*;
 
 
-// TODO implement: borrow_mut, drop
+// TODO implement: borrow_mut; figure out Drop, see if we can avoid leaking?
 
 // TODO Identifier should be some opaque type, not necessarily an int
 //type Identifier = int;
@@ -104,7 +104,7 @@ impl<V> PCell<V> {
 
     #[inline(always)]
     #[verifier(external_body)]
-    pub fn as_ref<'a>(&'a self, #[proof] perm: &'a Permission<V>) -> &'a V {
+    pub fn borrow<'a>(&'a self, #[proof] perm: &'a Permission<V>) -> &'a V {
         requires([
             equal(self.view(), perm.pcell),
             perm.value.is_Some(),

--- a/source/pervasive/mod.rs
+++ b/source/pervasive/mod.rs
@@ -7,6 +7,7 @@ pub mod seq_lib;
 pub mod set;
 pub mod set_lib;
 pub mod cell;
+pub mod ptr;
 pub mod invariants;
 pub mod atomic;
 pub mod modes;

--- a/source/pervasive/ptr.rs
+++ b/source/pervasive/ptr.rs
@@ -1,0 +1,188 @@
+use std::ptr::NonNull;
+use std::mem::MaybeUninit;
+use std::alloc::{Layout};
+use std::alloc::{dealloc};
+
+#[allow(unused_imports)] use builtin::*;
+#[allow(unused_imports)] use builtin_macros::*;
+#[allow(unused_imports)] use crate::pervasive::*;
+#[allow(unused_imports)] use crate::pervasive::modes::*;
+
+/// PPtr ("i.e., permissioned pointer").
+///
+/// This is similar to PCell, but has a few key differences:
+///  * In PCell<T>, the type T is placed internally to the PCell, whereas with PPtr,
+///    the type T is placed at some location on the heap.
+///  * Since PPtr is just a pointer (represented by an integer), it can be `Copy`
+///  * The `ptr::Permission` token represents not just the permission to read/write
+///    the contents, but also to deallocate.
+
+
+// TODO implement: borrow_mut, Drop
+
+// TODO Identifier should be some opaque type, not necessarily an int
+//type Identifier = int;
+
+#[verifier(external_body)]
+pub struct PPtr<#[verifier(strictly_positive)] V> {
+    uptr: NonNull<MaybeUninit<V>>,
+}
+
+#[proof]
+#[verifier(unforgeable)]
+pub struct Permission<V> {
+    #[spec] pub pptr: int,
+    #[spec] pub value: option::Option<V>,
+}
+
+impl<V> PPtr<V> {
+    #[inline(always)]
+    #[verifier(external_body)]
+    pub fn empty() -> (PPtr<V>, Proof<Permission<V>>) {
+        ensures(|pt : (PPtr<V>, Proof<Permission<V>>)|
+            equal(pt.1, Proof(Permission{ pptr: pt.0.view(), value: option::Option::None }))
+        );
+        opens_invariants_none();
+
+        let p = PPtr {
+            uptr: Box::leak(box MaybeUninit::uninit()).into(),
+        };
+        let Proof(t) = exec_proof_from_false();
+        (p, Proof(t))
+    }
+
+    fndecl!(pub fn view(&self) -> int);
+
+    #[inline(always)]
+    #[verifier(external_body)]
+    pub fn clone(&self) -> PPtr<V> {
+        ensures(|pt: PPtr<V>| equal(pt.view(), self.view()));
+        opens_invariants_none();
+
+        PPtr { uptr: self.uptr }
+    }
+
+    #[inline(always)]
+    #[verifier(external_body)]
+    pub fn put(&self, #[proof] perm: &mut Permission<V>, v: V) {
+        requires([
+            equal(self.view(), old(perm).pptr),
+            equal(old(perm).value, option::Option::None),
+        ]);
+        ensures([
+            equal(perm.pptr, old(perm).pptr),
+            equal(perm.value, option::Option::Some(v)),
+        ]);
+        opens_invariants_none();
+
+        unsafe {
+            *(self.uptr.as_ptr()) = MaybeUninit::new(v);
+        }
+    }
+
+    #[inline(always)]
+    #[verifier(external_body)]
+    pub fn take(&self, #[proof] perm: &mut Permission<V>) -> V {
+        requires([
+            equal(self.view(), old(perm).pptr),
+            old(perm).value.is_Some(),
+        ]);
+        ensures(|v: V| [
+            equal(perm.pptr, old(perm).pptr),
+            equal(perm.value, option::Option::None),
+            equal(v, old(perm).value.get_Some_0()),
+        ]);
+        opens_invariants_none();
+
+        unsafe {
+            let mut m = MaybeUninit::uninit();
+            std::mem::swap(&mut m, &mut *self.uptr.as_ptr());
+            m.assume_init()
+        }
+    }
+
+    #[inline(always)]
+    #[verifier(external_body)]
+    pub fn replace(&self, #[proof] perm: &mut Permission<V>, in_v: V) -> V {
+        requires([
+            equal(self.view(), old(perm).pptr),
+            old(perm).value.is_Some(),
+        ]);
+        ensures(|out_v: V| [
+            equal(perm.pptr, old(perm).pptr),
+            equal(perm.value, option::Option::Some(in_v)),
+            equal(out_v, old(perm).value.get_Some_0()),
+        ]);
+        opens_invariants_none();
+
+        unsafe {
+            let mut m = MaybeUninit::new(in_v);
+            std::mem::swap(&mut m, &mut *self.uptr.as_ptr());
+            m.assume_init()
+        }
+    }
+
+    /// Note that `self` is just a pointer, so it doesn't need to outlive 
+    /// the returned borrow.
+
+    #[inline(always)]
+    #[verifier(external_body)]
+    pub fn as_ref<'a>(&self, #[proof] perm: &'a Permission<V>) -> &'a V {
+        requires([
+            equal(self.view(), perm.pptr),
+            perm.value.is_Some(),
+        ]);
+        ensures(|v: V|
+            equal(v, perm.value.get_Some_0())
+        );
+        opens_invariants_none();
+        
+        unsafe {
+            self.uptr.as_ref().assume_init_ref()
+        }
+    }
+
+    #[inline(always)]
+    #[verifier(external_body)]
+    pub fn dispose(&self, #[proof] perm: Permission<V>) {
+        requires([
+            equal(self.view(), perm.pptr),
+            equal(perm.value, option::Option::None),
+        ]);
+        opens_invariants_none();
+
+        dealloc(self.uptr.cast().as_ptr(), Layout::for_value(self.uptr.as_ref()));
+    }
+
+    //////////////////////////////////
+    // Untrusted functions below here
+
+    #[inline(always)]
+    pub fn into_inner(self, #[proof] perm: Permission<V>) -> V {
+        requires([
+            equal(self.view(), perm.pptr),
+            perm.value.is_Some(),
+        ]);
+        ensures(|v|
+            equal(v, perm.value.get_Some_0())
+        );
+        opens_invariants_none();
+
+        #[proof] let mut perm = perm;
+        let v = self.take(&mut perm);
+        self.dispose(perm);
+        v
+    }
+
+    #[inline(always)]
+    #[verifier(external_body)]
+    pub fn new(v: V) -> (PPtr<V>, Proof<Permission<V>>) {
+        ensures(|pt : (PPtr<V>, Proof<Permission<V>>)|
+            equal(pt.1, Proof(Permission{ pptr: pt.0.view(), value: option::Option::Some(v) }))
+        );
+
+        let (p, Proof(mut t)) = Self::empty();
+        p.put(&mut t, v);
+        (p, Proof(t))
+    }
+}

--- a/source/pervasive/ptr.rs
+++ b/source/pervasive/ptr.rs
@@ -18,7 +18,7 @@ use std::alloc::{dealloc};
 ///    the contents, but also to deallocate.
 
 
-// TODO implement: borrow_mut, Drop
+// TODO implement: borrow_mut; figure out Drop, see if we can avoid leaking?
 
 // TODO Identifier should be some opaque type, not necessarily an int
 //type Identifier = int;
@@ -127,7 +127,7 @@ impl<V> PPtr<V> {
 
     #[inline(always)]
     #[verifier(external_body)]
-    pub fn as_ref<'a>(&self, #[proof] perm: &'a Permission<V>) -> &'a V {
+    pub fn borrow<'a>(&self, #[proof] perm: &'a Permission<V>) -> &'a V {
         requires([
             equal(self.view(), perm.pptr),
             perm.value.is_Some(),

--- a/source/rust_verify/example/cells.rs
+++ b/source/rust_verify/example/cells.rs
@@ -5,19 +5,18 @@ mod pervasive;
 use crate::pervasive::{*, cell::*};
 #[allow(unused_imports)]
 use crate::cell::*;
+#[allow(unused_imports)] use crate::pervasive::modes::*;
 
 struct X {
-  pub i: u64,
+    pub i: u64,
 }
 
 fn main() {
-  let x = X { i: 5 };
+    let x = X { i: 5 };
 
-  match PCell::empty() {
-    PCellWithToken{pcell, token} => {
-      #[proof] let t1 = pcell.put(x, token);
+    let (pcell, Proof(mut token)) = PCell::empty();
 
-      assert(equal(t1.value, option::Option::Some(X { i : 5 })));
-    }
-  }
+    pcell.put(&mut token, x);
+
+    assert(equal(token.value, option::Option::Some(X { i : 5 })));
 }

--- a/source/rust_verify/tests/cell_lib.rs
+++ b/source/rust_verify/tests/cell_lib.rs
@@ -35,7 +35,7 @@ const CELL_TEST: &str = code_str! {
     assert(equal(token.value, option::Option::Some(7)));
     assert(equal(x, 5));
 
-    let t = cell.as_ref(&token);
+    let t = cell.borrow(&token);
     assert(equal(*t, 7));
 
     let x = cell.take(&mut token);
@@ -66,7 +66,7 @@ const PTR_TEST: &str = code_str! {
     assert(equal(token.value, option::Option::Some(7)));
     assert(equal(x, 5));
 
-    let t = ptr.as_ref(&token);
+    let t = ptr.borrow(&token);
     assert(equal(*t, 7));
 
     let x = ptr.take(&mut token);
@@ -120,13 +120,13 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] cell_mismatch_as_ref IMPORTS.to_string() + code_str! {
+    #[test] cell_mismatch_borrow IMPORTS.to_string() + code_str! {
         pub fn f() {
             let (cell1, Proof(mut token1)) = PCell::<u32>::empty();
             let (cell2, Proof(mut token2)) = PCell::<u32>::empty();
             cell1.put(&mut token1, 5);
             cell2.put(&mut token2, 5);
-            let x = cell1.as_ref(&token2); // FAILS
+            let x = cell1.borrow(&token2); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
 }
@@ -160,10 +160,10 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] cell_none_as_ref IMPORTS.to_string() + code_str! {
+    #[test] cell_none_borrow IMPORTS.to_string() + code_str! {
         pub fn f() {
             let (cell1, Proof(mut token1)) = PCell::<u32>::empty();
-            let x = cell1.as_ref(&token1); // FAILS
+            let x = cell1.borrow(&token1); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
 }
@@ -203,13 +203,13 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] ptr_mismatch_as_ref IMPORTS.to_string() + code_str! {
+    #[test] ptr_mismatch_borrow IMPORTS.to_string() + code_str! {
         pub fn f() {
             let (ptr1, Proof(mut token1)) = PPtr::<u32>::empty();
             let (ptr2, Proof(mut token2)) = PPtr::<u32>::empty();
             ptr1.put(&mut token1, 5);
             ptr2.put(&mut token2, 5);
-            let x = ptr1.as_ref(&token2); // FAILS
+            let x = ptr1.borrow(&token2); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
 }
@@ -253,10 +253,10 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] ptr_none_as_ref IMPORTS.to_string() + code_str! {
+    #[test] ptr_none_borrow IMPORTS.to_string() + code_str! {
         pub fn f() {
             let (ptr1, Proof(mut token1)) = PPtr::<u32>::empty();
-            let x = ptr1.as_ref(&token1); // FAILS
+            let x = ptr1.borrow(&token1); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
 }

--- a/source/rust_verify/tests/cell_lib.rs
+++ b/source/rust_verify/tests/cell_lib.rs
@@ -1,0 +1,272 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+const IMPORTS: &str = code_str! {
+    use crate::pervasive::{cell::*};
+    use crate::pervasive::{ptr::*};
+    use crate::pervasive::{modes::*};
+    use crate::pervasive::{option::*};
+    use crate::pervasive::result::*;
+};
+
+/// With contradiction_smoke_test, add a final `assert(false)` that is expected to fail at the end
+/// of the test, as a cheap way to check that the trusted specs aren't contradictory
+fn test_body(tests: &str, contradiction_smoke_test: bool) -> String {
+    IMPORTS.to_string()
+        + "    fn test() {"
+        + tests
+        + if contradiction_smoke_test { "assert(false); // FAILS\n" } else { "" }
+        + "    }"
+}
+
+const CELL_TEST: &str = code_str! {
+    let (cell, Proof(mut token)) = PCell::<u32>::empty();
+    assert(equal(token.pcell, cell.view()));
+    assert(equal(token.value, option::Option::None));
+
+    cell.put(&mut token, 5);
+    assert(equal(token.pcell, cell.view()));
+    assert(equal(token.value, option::Option::Some(5)));
+
+    let x = cell.replace(&mut token, 7);
+    assert(equal(token.pcell, cell.view()));
+    assert(equal(token.value, option::Option::Some(7)));
+    assert(equal(x, 5));
+
+    let t = cell.as_ref(&token);
+    assert(equal(*t, 7));
+
+    let x = cell.take(&mut token);
+    assert(equal(token.pcell, cell.view()));
+    assert(equal(token.value, option::Option::None));
+    assert(equal(x, 7));
+};
+
+test_verify_one_file! {
+    #[test] test_cell_pass test_body(CELL_TEST, false) => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_cell_smoke test_body(CELL_TEST, true) => Err(e) => assert_one_fails(e)
+}
+
+const PTR_TEST: &str = code_str! {
+    let (ptr, Proof(mut token)) = PPtr::<u32>::empty();
+    assert(equal(token.pptr, ptr.view()));
+    assert(equal(token.value, option::Option::None));
+
+    ptr.put(&mut token, 5);
+    assert(equal(token.pptr, ptr.view()));
+    assert(equal(token.value, option::Option::Some(5)));
+
+    let x = ptr.replace(&mut token, 7);
+    assert(equal(token.pptr, ptr.view()));
+    assert(equal(token.value, option::Option::Some(7)));
+    assert(equal(x, 5));
+
+    let t = ptr.as_ref(&token);
+    assert(equal(*t, 7));
+
+    let x = ptr.take(&mut token);
+    assert(equal(token.pptr, ptr.view()));
+    assert(equal(token.value, option::Option::None));
+    assert(equal(x, 7));
+
+    ptr.dispose(token);
+};
+
+test_verify_one_file! {
+    #[test] test_ptr_pass test_body(PTR_TEST, false) => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_ptr_smoke test_body(PTR_TEST, true) => Err(e) => assert_one_fails(e)
+}
+
+test_verify_one_file! {
+    #[test] cell_mismatch_put IMPORTS.to_string() + code_str! {
+        pub fn f() {
+            let (cell1, Proof(mut token1)) = PCell::<u32>::empty();
+            let (cell2, Proof(mut token2)) = PCell::<u32>::empty();
+            cell1.put(&mut token2, 5); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] cell_mismatch_take IMPORTS.to_string() + code_str! {
+        pub fn f() {
+            let (cell1, Proof(mut token1)) = PCell::<u32>::empty();
+            let (cell2, Proof(mut token2)) = PCell::<u32>::empty();
+            cell1.put(&mut token1, 5);
+            cell2.put(&mut token2, 5);
+            let x = cell1.take(&mut token2); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] cell_mismatch_replace IMPORTS.to_string() + code_str! {
+        pub fn f() {
+            let (cell1, Proof(mut token1)) = PCell::<u32>::empty();
+            let (cell2, Proof(mut token2)) = PCell::<u32>::empty();
+            cell1.put(&mut token1, 5);
+            cell2.put(&mut token2, 5);
+            let x = cell1.replace(&mut token2, 7); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] cell_mismatch_as_ref IMPORTS.to_string() + code_str! {
+        pub fn f() {
+            let (cell1, Proof(mut token1)) = PCell::<u32>::empty();
+            let (cell2, Proof(mut token2)) = PCell::<u32>::empty();
+            cell1.put(&mut token1, 5);
+            cell2.put(&mut token2, 5);
+            let x = cell1.as_ref(&token2); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] cell_some_put IMPORTS.to_string() + code_str! {
+        pub fn f() {
+            let (cell1, Proof(mut token1)) = PCell::<u32>::empty();
+            cell1.put(&mut token1, 7);
+            cell1.put(&mut token1, 5); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] cell_none_take IMPORTS.to_string() + code_str! {
+        pub fn f() {
+            let (cell1, Proof(mut token1)) = PCell::<u32>::empty();
+            let x = cell1.take(&mut token1); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] cell_none_replace IMPORTS.to_string() + code_str! {
+        pub fn f() {
+            let (cell1, Proof(mut token1)) = PCell::<u32>::empty();
+            let x = cell1.replace(&mut token1, 7); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] cell_none_as_ref IMPORTS.to_string() + code_str! {
+        pub fn f() {
+            let (cell1, Proof(mut token1)) = PCell::<u32>::empty();
+            let x = cell1.as_ref(&token1); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] ptr_mismatch_put IMPORTS.to_string() + code_str! {
+        pub fn f() {
+            let (ptr1, Proof(mut token1)) = PPtr::<u32>::empty();
+            let (ptr2, Proof(mut token2)) = PPtr::<u32>::empty();
+            ptr1.put(&mut token2, 5); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] ptr_mismatch_take IMPORTS.to_string() + code_str! {
+        pub fn f() {
+            let (ptr1, Proof(mut token1)) = PPtr::<u32>::empty();
+            let (ptr2, Proof(mut token2)) = PPtr::<u32>::empty();
+            ptr1.put(&mut token1, 5);
+            ptr2.put(&mut token2, 5);
+            let x = ptr1.take(&mut token2); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] ptr_mismatch_replace IMPORTS.to_string() + code_str! {
+        pub fn f() {
+            let (ptr1, Proof(mut token1)) = PPtr::<u32>::empty();
+            let (ptr2, Proof(mut token2)) = PPtr::<u32>::empty();
+            ptr1.put(&mut token1, 5);
+            ptr2.put(&mut token2, 5);
+            let x = ptr1.replace(&mut token2, 7); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] ptr_mismatch_as_ref IMPORTS.to_string() + code_str! {
+        pub fn f() {
+            let (ptr1, Proof(mut token1)) = PPtr::<u32>::empty();
+            let (ptr2, Proof(mut token2)) = PPtr::<u32>::empty();
+            ptr1.put(&mut token1, 5);
+            ptr2.put(&mut token2, 5);
+            let x = ptr1.as_ref(&token2); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] ptr_mismatch_dispose IMPORTS.to_string() + code_str! {
+        pub fn f() {
+            let (ptr1, Proof(mut token1)) = PPtr::<u32>::empty();
+            let (ptr2, Proof(mut token2)) = PPtr::<u32>::empty();
+            ptr1.dispose(token2); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] ptr_some_put IMPORTS.to_string() + code_str! {
+        pub fn f() {
+            let (ptr1, Proof(mut token1)) = PPtr::<u32>::empty();
+            ptr1.put(&mut token1, 7);
+            ptr1.put(&mut token1, 5); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] ptr_none_take IMPORTS.to_string() + code_str! {
+        pub fn f() {
+            let (ptr1, Proof(mut token1)) = PPtr::<u32>::empty();
+            let x = ptr1.take(&mut token1); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] ptr_none_replace IMPORTS.to_string() + code_str! {
+        pub fn f() {
+            let (ptr1, Proof(mut token1)) = PPtr::<u32>::empty();
+            let x = ptr1.replace(&mut token1, 7); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] ptr_none_as_ref IMPORTS.to_string() + code_str! {
+        pub fn f() {
+            let (ptr1, Proof(mut token1)) = PPtr::<u32>::empty();
+            let x = ptr1.as_ref(&token1); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_one_file! {
+    #[test] ptr_some_dispose IMPORTS.to_string() + code_str! {
+        pub fn f() {
+            let (ptr1, Proof(mut token1)) = PPtr::<u32>::empty();
+            ptr1.put(&mut token1, 5);
+            ptr1.dispose(token1); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}


### PR DESCRIPTION
I cleaned up `PCell`, using `&mut` parameters now that they're available. I also added a companion `PPtr`. I'm doing this now, because these were necessary for the `Rc` example over on the state machine branch.

`PPtr` is similar to `PCell`, but has a few key differences:
 * In `PCell<T>`, the type `T` is placed internally to the `PCell`, whereas with `PPtr`, the type `T` is placed at some location on the heap.
 * Since `PPtr` is just a pointer (represented by an integer), it can be `Copy`
 * The `ptr::Permission` token represents not just the permission to read/write the contents, but also to deallocate the memory.

Each has the following trusted methods `empty`, `put`, `take`, `replace`, and `as_ref`. To be complete, we still need `as_mut`, but of course we need the ability to return `&mut` first.

I wasn't sure about the name of `as_ref` (vs. `borrow`). Actually, I'm not really sure if _either_ is appropriate (we can't actually implement the `AsRef` or `Borrow` traits, since the function takes two arguments ...) but I still felt like `as_ref` was more appropriate.
