### PR TITLE
handle int/nat literals that don't fit in i32

### DIFF
--- a/source/rust_verify/tests/integers.rs
+++ b/source/rust_verify/tests/integers.rs
@@ -50,6 +50,38 @@ test_verify_one_file! {
             assert(u / 2 <= u);
             assert(u % 10 < 10);
         }
+
+        fn int_literals() {
+            #[spec] let x0 = -5000000000000000000000 as int;
+            #[spec] let x1 = -5000000000000 as int;
+            #[spec] let x2 = -3000000000 as int;
+            #[spec] let x3 = -5 as int;
+            #[spec] let x4 = 0 as int;
+            #[spec] let x5 = 5 as int;
+            #[spec] let x6 = 3000000000 as int;
+            #[spec] let x7 = 5000000000000 as int;
+            #[spec] let x8 = 5000000000000000000000 as int;
+            assert(x0 < x1);
+            assert(x1 < x2);
+            assert(x2 < x3);
+            assert(x3 < x4);
+            assert(x4 < x5);
+            assert(x5 < x6);
+            assert(x6 < x7);
+            assert(x7 < x8);
+        }
+
+        fn nat_literals() {
+            #[spec] let x4 = 0 as nat;
+            #[spec] let x5 = 5 as nat;
+            #[spec] let x6 = 3000000000 as nat;
+            #[spec] let x7 = 5000000000000 as nat;
+            #[spec] let x8 = 5000000000000000000000 as nat;
+            assert(x4 < x5);
+            assert(x5 < x6);
+            assert(x6 < x7);
+            assert(x7 < x8);
+        }
     } => Ok(())
 }
 

--- a/source/rust_verify/tests/integers.rs
+++ b/source/rust_verify/tests/integers.rs
@@ -264,3 +264,13 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_one_fails(err)
 }
+
+test_verify_one_file! {
+    #[test] test_literals_fails7 code! {
+        #[proof]
+        fn f() {
+            #[spec] let x = -5 as nat;
+            assert(x < 0); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}


### PR DESCRIPTION
rust type inference handles an expression like `5 as int` or `5 as nat` by making the value of `5` an `i32`. It does this even for values of `5` that don't fit in `i32`, which was resulting in erroneous clipping. (I found this because I noticed the atomic arithmetic instructions' preconditions still weren't working as they were supposed to.)

This PR special-cases the expression `int_literal as int` or `int_literal as nat` to treat the literal as a `nat` or `int`, regardless of what rustc tells us the type is, and skip the erroneous clipping.

While I was at it, I also slightly changed the way the negative integer literals worked. Previously, `mk_lit_int` would handle `-x` by checking that `-x` was in-bounds, then if not, it would clip x and create the expression `-(clip x)` (instead of `clip (-x)`). Although I'm not sure if this was actually wrong, given how conservative we are about `clip`, it _did_ seem confusing, especially because `-0x8000_0000 : i32` would result in creating an intermediate node of type `i32` with the value `0x8000_0000`, which could potentially cause problems down the line.

Anyway, so I changed `mk_lit_int` to just create a constant with the negative value _inside_ the constant. Then the Clip applies to that, if necessary, and then there's no need to do another negation on the outside.

Another minor technical point: Previously, for the unsigned types, `mk_lit_int`'s bounds-checking didn't ensure `!in_negative_literal` for the unsigned types. This was mostly fine, since rustc doesn't allow that case for its builtin types ... except of course rustc doesn't do that check for Verus's `nat`. And that was fine until now, but only because Rust just assigned the literals to be type `i32`. So since this PR allows for `nat` literals, I had to fix that as well (and for clarity, I just did the check for all the unsigned types).