### PR TITLE
Run borrowck on mode proof and exec before running the verifier

### DIFF
--- a/source/rust_verify/src/driver.rs
+++ b/source/rust_verify/src/driver.rs
@@ -1,6 +1,6 @@
 use crate::erase::CompilerCallbacks;
-use crate::verifier::Verifier;
-use std::sync::{Arc, Mutex};
+use crate::verifier::{Verifier, VerifierCallbacks};
+use std::sync::{Arc, Condvar, Mutex};
 use std::time::{Duration, Instant};
 
 fn mk_compiler<'a, 'b, F>(
@@ -24,10 +24,10 @@ pub struct Stats {
 }
 
 pub fn run<F>(
-    verifier: &mut Verifier,
-    rustc_args: &Vec<String>,
-    file_loader: &F,
-) -> Result<Stats, ()>
+    verifier: Verifier,
+    rustc_args: Vec<String>,
+    file_loader: F,
+) -> (Verifier, Result<Stats, ()>)
 where
     F: 'static + rustc_span::source_map::FileLoader + Send + Sync + Clone,
 {
@@ -35,58 +35,124 @@ where
     let mut time_erasure1 = Duration::new(0, 0);
     let mut time_erasure2 = Duration::new(0, 0);
 
-    // Run verifier callback to build VIR tree and run verifier
-    let status = mk_compiler(rustc_args, verifier, file_loader).run();
-    match status {
-        Ok(_) => {}
-        Err(_) => {
-            return Err(());
+    let vir_ready = Arc::new((Mutex::new(None), Condvar::new()));
+    let now_verify = Arc::new((Mutex::new(None), Condvar::new()));
+    let verifier = Arc::new(Mutex::new(verifier));
+    let compiler_thread = {
+        let mut verifier_callbacks = VerifierCallbacks {
+            verifier: verifier.clone(),
+            vir_ready: vir_ready.clone(),
+            now_verify: now_verify.clone(),
+        };
+        let vir_ready = vir_ready.clone();
+        let rustc_args = rustc_args.clone();
+        let file_loader = file_loader.clone();
+        // Run verifier callback to build VIR tree and run verifier
+        std::thread::spawn(move || {
+            let verifier_compiler = mk_compiler(&rustc_args, &mut verifier_callbacks, &file_loader);
+            let status = verifier_compiler.run();
+            match status {
+                Ok(_) => Ok(()),
+                Err(_) => {
+                    let (vir_ready, cvar) = &*vir_ready;
+                    *vir_ready.lock().expect("vir_ready mutex") = Some(true);
+                    cvar.notify_one();
+                    Err(())
+                }
+            }
+        })
+    };
+
+    let compiler_err = {
+        let (lock, cvar) = &*vir_ready;
+        let mut vir_ready = lock.lock().expect("vir_ready mutex");
+        while vir_ready.is_none() {
+            vir_ready = cvar.wait(vir_ready).expect("cvar wait");
         }
-    }
+        vir_ready.unwrap()
+    };
 
     let time1 = Instant::now();
 
-    // Run borrow checker with both #[exec] and #[proof]
-    if !verifier.args.no_lifetime {
-        let erasure_hints = verifier.erasure_hints.clone().expect("erasure_hints");
-        let mut callbacks = CompilerCallbacks {
-            erasure_hints,
-            lifetimes_only: true,
-            print: verifier.args.print_erased_spec,
-            time_erasure: Arc::new(Mutex::new(Duration::new(0, 0))),
-        };
-        let status = mk_compiler(&rustc_args, &mut callbacks, file_loader).run();
-        time_erasure1 = *callbacks.time_erasure.lock().unwrap();
-        match status {
-            Ok(_) => {}
-            Err(_) => {
-                return Err(());
-            }
+    if let Err(()) = {
+        let verifier = verifier.lock().unwrap();
+        if compiler_err {
+            Err(())
+        } else if !verifier.args.no_lifetime {
+            // Run borrow checker with both #[exec] and #[proof]
+            let erasure_hints = verifier.erasure_hints.clone().expect("erasure_hints");
+            let mut callbacks = CompilerCallbacks {
+                erasure_hints,
+                lifetimes_only: true,
+                print: verifier.args.print_erased_spec,
+                time_erasure: Arc::new(Mutex::new(Duration::new(0, 0))),
+            };
+            let status = mk_compiler(&rustc_args, &mut callbacks, &file_loader).run();
+            time_erasure1 = *callbacks.time_erasure.lock().unwrap();
+            status.map_err(|_| ())
+        } else {
+            Ok(())
         }
+    } {
+        {
+            let (now_verify, cvar) = &*now_verify;
+            *now_verify.lock().expect("now_verify mutex") = Some(true);
+            cvar.notify_one();
+        }
+        let _status = compiler_thread.join().expect("join compiler thread");
+        let verifier = Arc::try_unwrap(verifier)
+            .map_err(|_| ())
+            .expect("only one reference to the verifier expected")
+            .into_inner()
+            .expect("valid Mutex for verifier");
+        return (verifier, Err(()));
     }
 
     let time2 = Instant::now();
 
+    {
+        let (now_verify, cvar) = &*now_verify;
+        *now_verify.lock().expect("now_verify mutex") = Some(false);
+        cvar.notify_one();
+    }
+    let status = compiler_thread.join().expect("join compiler thread");
+
+    let time3 = Instant::now();
+
+    let verifier = Arc::try_unwrap(verifier)
+        .map_err(|_| ())
+        .expect("only one Arc reference to the verifier")
+        .into_inner()
+        .expect("valid Mutex for verifier");
+
+    if let Err(()) = status {
+        return (verifier, Err(()));
+    }
+
     // Run borrow checker and compiler on #[exec] (if enabled)
     if verifier.args.compile {
-        let erasure_hints = verifier.erasure_hints.clone().expect("erasure_hints").clone();
+        let erasure_hints =
+            verifier.erasure_hints.clone().expect("erasure_hints should be initialized").clone();
         let mut callbacks = CompilerCallbacks {
             erasure_hints,
             lifetimes_only: false,
             print: verifier.args.print_erased,
             time_erasure: Arc::new(Mutex::new(Duration::new(0, 0))),
         };
-        mk_compiler(&rustc_args, &mut callbacks, file_loader)
+        mk_compiler(&rustc_args, &mut callbacks, &file_loader)
             .run()
             .expect("RunCompiler.run() failed");
         time_erasure2 = *callbacks.time_erasure.lock().unwrap();
     }
 
-    let time3 = Instant::now();
-    Ok(Stats {
-        time_verify: time1 - time0,
-        time_lifetime: time2 - time1 - time_erasure1,
-        time_compile: time3 - time2 - time_erasure2,
-        time_erasure: time_erasure1 + time_erasure2,
-    })
+    let time4 = Instant::now();
+    (
+        verifier,
+        Ok(Stats {
+            time_verify: (time1 - time0) + (time3 - time2),
+            time_lifetime: time2 - time1 - time_erasure1,
+            time_compile: time4 - time3 - time_erasure2,
+            time_erasure: time_erasure1 + time_erasure2,
+        }),
+    )
 }

--- a/source/rust_verify/src/main.rs
+++ b/source/rust_verify/src/main.rs
@@ -41,9 +41,10 @@ pub fn main() {
     let pervasive_path = our_args.pervasive_path.clone();
 
     let file_loader = rust_verify::file_loader::PervasiveFileLoader::new(pervasive_path);
-    let mut verifier = rust_verify::verifier::Verifier::new(our_args);
+    let verifier = rust_verify::verifier::Verifier::new(our_args);
 
-    let status = rust_verify::driver::run(&mut verifier, &rustc_args, &file_loader);
+    let (verifier, status) = rust_verify::driver::run(verifier, rustc_args, file_loader);
+
     if !verifier.encountered_vir_error {
         println!(
             "Verification results:: verified: {} errors: {}",

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -8,17 +8,25 @@ use air::context::ValidityResult;
 use air::errors::{Error, ErrorLabel};
 use rustc_hir::OwnerNode;
 use rustc_interface::interface::Compiler;
+
 use rustc_middle::ty::TyCtxt;
 use rustc_span::source_map::SourceMap;
 use rustc_span::{CharPos, FileName, MultiSpan, Span};
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::Write;
-use std::sync::Arc;
+use std::sync::{Arc, Condvar, Mutex};
 use std::time::{Duration, Instant};
+
 use vir::ast::{Fun, Function, Krate, VirErr, Visibility};
 use vir::ast_util::{fun_as_rust_dbg, is_visible_to};
 use vir::def::SnapPos;
+
+pub struct VerifierCallbacks {
+    pub verifier: Arc<Mutex<Verifier>>,
+    pub vir_ready: Arc<(Mutex<Option<bool>>, Condvar)>,
+    pub now_verify: Arc<(Mutex<Option<bool>>, Condvar)>,
+}
 
 pub struct Verifier {
     pub encountered_vir_error: bool,
@@ -34,6 +42,9 @@ pub struct Verifier {
     pub time_air: Duration,
     pub time_smt_init: Duration,
     pub time_smt_run: Duration,
+
+    pub vir_crate: Option<Krate>,
+    pub air_no_span: Option<air::ast::Span>,
 }
 
 #[derive(Debug)]
@@ -110,7 +121,7 @@ impl Verifier {
             count_verified: 0,
             count_errors: 0,
             errors: Vec::new(),
-            args: args,
+            args,
             test_capture_output: None,
             erasure_hints: None,
             time_vir: Duration::new(0, 0),
@@ -119,6 +130,9 @@ impl Verifier {
             time_air: Duration::new(0, 0),
             time_smt_init: Duration::new(0, 0),
             time_smt_run: Duration::new(0, 0),
+
+            vir_crate: None,
+            air_no_span: None,
         }
     }
 
@@ -372,12 +386,10 @@ impl Verifier {
     }
 
     // Verify one or more modules in a crate
-    fn verify_crate(
-        &mut self,
-        compiler: &Compiler,
-        krate: &Krate,
-        no_span: Span,
-    ) -> Result<(), VirErr> {
+    fn verify_crate(&mut self, compiler: &Compiler) -> Result<(), VirErr> {
+        let krate = self.vir_crate.as_ref().expect("vir_crate should be initialized");
+        let air_no_span = self.air_no_span.as_ref().expect("air_no_span should be initialized");
+
         #[cfg(debug_assertions)]
         vir::check_ast_flavor::check_krate(&krate);
 
@@ -405,11 +417,7 @@ impl Verifier {
             air_context.set_z3_param(&option, &value);
         }
 
-        let air_no_span = air::ast::Span {
-            raw_span: crate::util::to_raw_span(no_span),
-            as_string: "no location".to_string(),
-        };
-        let mut global_ctx = vir::context::GlobalCtx::new(&krate, air_no_span);
+        let mut global_ctx = vir::context::GlobalCtx::new(&krate, air_no_span.clone());
         let krate = vir::ast_simplify::simplify_krate(&mut global_ctx, &krate)?;
 
         if let Some(filename) = &self.args.log_vir_simple {
@@ -498,7 +506,7 @@ impl Verifier {
         Ok(())
     }
 
-    fn run<'tcx>(&mut self, compiler: &Compiler, tcx: TyCtxt<'tcx>) -> Result<bool, VirErr> {
+    fn vir<'tcx>(&mut self, tcx: TyCtxt<'tcx>) -> Result<bool, VirErr> {
         let autoviewed_call_typs = Arc::new(std::sync::Mutex::new(HashMap::new()));
         let _ = tcx.formal_verifier_callback.replace(Some(Box::new(crate::typecheck::Typecheck {
             int_ty_id: None,
@@ -543,10 +551,9 @@ impl Verifier {
         vir::well_formed::check_crate(&vir_crate)?;
         let erasure_modes = vir::modes::check_crate(&vir_crate)?;
 
-        // Verify crate
-        let time3 = Instant::now();
-        if !self.args.external_body {
-            let span = hir
+        self.vir_crate = Some(vir_crate.clone());
+        self.air_no_span = (!self.args.external_body).then(|| {
+            let no_span = hir
                 .krate()
                 .owners
                 .iter()
@@ -557,9 +564,11 @@ impl Verifier {
                 })
                 .next()
                 .expect("OwnerNode::Crate missing");
-            self.verify_crate(&compiler, &vir_crate, span)?;
-        }
-        let time4 = Instant::now();
+            air::ast::Span {
+                raw_span: crate::util::to_raw_span(no_span),
+                as_string: "no location".to_string(),
+            }
+        });
 
         let erasure_info = ctxt.erasure_info.borrow();
         let resolved_calls = erasure_info.resolved_calls.clone();
@@ -578,11 +587,23 @@ impl Verifier {
         };
         self.erasure_hints = Some(erasure_hints);
 
-        let time5 = Instant::now();
-        self.time_vir = time5 - time0;
+        let time4 = Instant::now();
+        self.time_vir = time4 - time0;
         self.time_vir_rust_to_vir = time2 - time1;
-        self.time_vir_verify = time4 - time3;
 
+        Ok(true)
+    }
+
+    pub fn verify<'tcx>(&mut self, compiler: &Compiler) -> Result<bool, VirErr> {
+        // Verify crate
+        let time3 = Instant::now();
+        if !self.args.external_body {
+            self.verify_crate(&compiler)?;
+        }
+        let time4 = Instant::now();
+
+        self.time_vir_verify = time4 - time3;
+        self.time_vir += self.time_vir_verify;
         Ok(true)
     }
 }
@@ -616,9 +637,9 @@ impl rustc_lint::FormalVerifierRewrite for Rewrite {
     }
 }
 
-impl rustc_driver::Callbacks for Verifier {
+impl rustc_driver::Callbacks for VerifierCallbacks {
     fn config(&mut self, config: &mut rustc_interface::interface::Config) {
-        if let Some(target) = &self.test_capture_output {
+        if let Some(target) = &self.verifier.lock().unwrap().test_capture_output {
             config.diagnostic_output =
                 rustc_session::DiagnosticOutput::Raw(Box::new(DiagnosticOutputBuffer {
                     output: target.clone(),
@@ -646,17 +667,50 @@ impl rustc_driver::Callbacks for Verifier {
         compiler: &Compiler,
         queries: &'tcx rustc_interface::Queries<'tcx>,
     ) -> rustc_driver::Compilation {
-        let _result =
-            queries.global_ctxt().expect("global_ctxt").peek_mut().enter(|tcx| {
-                match self.run(compiler, tcx) {
-                    Ok(true) => {}
-                    Ok(false) => {}
+        let _result = queries.global_ctxt().expect("global_ctxt").peek_mut().enter(|tcx| {
+            {
+                let mut verifier = self.verifier.lock().expect("verifier mutex");
+                if let Err(err) = verifier.vir(tcx) {
+                    report_error(compiler, &err);
+                    verifier.encountered_vir_error = true;
+                    return;
+                }
+            }
+
+            if !compiler.session().compile_status().is_ok() {
+                return;
+            }
+
+            {
+                let (vir_ready, cvar) = &*self.vir_ready;
+                *vir_ready.lock().expect("vir_ready mutex") = Some(false);
+                cvar.notify_one();
+            }
+
+            let verifier_err = {
+                let (now_verify, cvar) = &*self.now_verify;
+                let mut now_verify = now_verify.lock().expect("now_verify mutex");
+                while now_verify.is_none() {
+                    now_verify = cvar.wait(now_verify).expect("cvar wait");
+                }
+                now_verify.unwrap()
+            };
+
+            if verifier_err {
+                return;
+            }
+
+            {
+                let mut verifier = self.verifier.lock().expect("verifier mutex");
+                match verifier.verify(compiler) {
+                    Ok(_) => {}
                     Err(err) => {
                         report_error(compiler, &err);
-                        self.encountered_vir_error = true;
+                        verifier.encountered_vir_error = true;
                     }
                 }
-            });
+            }
+        });
         rustc_driver::Compilation::Stop
     }
 }

--- a/source/rust_verify/tests/adts_generics.rs
+++ b/source/rust_verify/tests/adts_generics.rs
@@ -43,11 +43,11 @@ test_verify_one_file! {
             a: A,
         }
 
-        fn one(v: int) {
+        fn one(v: u64) {
             let t1 = Thing { a: v };
             let t2 = Thing { a: v };
-            let a1: int = t1.a;
-            let a2: int = t2.a;
+            let a1: u64 = t1.a;
+            let a2: u64 = t2.a;
             assert(a1 == a2);
             assert(a1 != a2); // FAILS
         }

--- a/source/rust_verify/tests/basic.rs
+++ b/source/rust_verify/tests/basic.rs
@@ -116,6 +116,7 @@ test_verify_one_file! {
 }
 
 const TEST_REQUIRES1: &str = code_str! {
+    #[proof]
     fn test_requires1(a: int, b: int, c: int) {
         requires([a <= b, b <= c]);
 
@@ -125,6 +126,7 @@ const TEST_REQUIRES1: &str = code_str! {
 
 test_verify_one_file! {
     #[test] test_requires2 TEST_REQUIRES1.to_string() + code_str! {
+        #[proof]
         fn test_requires2(a: int, b: int, c: int) {
             assume(a <= b);
             assume(b <= c);
@@ -146,6 +148,7 @@ test_verify_one_file! {
 }
 
 const TEST_RET: &str = code_str! {
+    #[proof]
     fn test_ret(a: int, b: int) -> int {
         requires(a <= b);
         ensures(|ret: int| [
@@ -164,6 +167,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_ret2 TEST_RET.to_string() + code_str! {
+        #[proof]
         fn test_ret2(a: int, b: int) -> int {
             requires(a <= b);
             ensures(|ret: int| [

--- a/source/rust_verify/tests/common/mod.rs
+++ b/source/rust_verify/tests/common/mod.rs
@@ -142,7 +142,7 @@ pub fn verify_files_and_pervasive(
         let mut verifier = Verifier::new(our_args);
         verifier.test_capture_output = Some(captured_output_1);
         let file_loader: TestFileLoader = TestFileLoader { files };
-        let status = rust_verify::driver::run(&mut verifier, &rustc_args, &file_loader);
+        let (verifier, status) = rust_verify::driver::run(verifier, rustc_args, file_loader);
         status.map(|_| ()).map_err(|_| TestErr {
             errors: verifier.errors,
             has_vir_error: verifier.encountered_vir_error,

--- a/source/rust_verify/tests/erase.rs
+++ b/source/rust_verify/tests/erase.rs
@@ -19,3 +19,14 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] test_regression_70 code! {
+        fn m(v: &mut u64) { }
+
+        fn main() {
+            let v = 6;
+            m(&mut v);
+        }
+    } => Err(e) => assert_eq!(e.errors.len(), 0)
+}

--- a/source/rust_verify/tests/structural.rs
+++ b/source/rust_verify/tests/structural.rs
@@ -7,7 +7,7 @@ const STRUCTS: &str = code_str! {
     #[derive(PartialEq, Eq, Structural)]
     struct Car {
         four_doors: bool,
-        passengers: int,
+        passengers: u64,
     }
 
     #[derive(PartialEq, Eq, Structural)]
@@ -19,7 +19,7 @@ const STRUCTS: &str = code_str! {
 
 test_verify_one_file! {
     #[test] test_structural_eq STRUCTS.to_string() + code_str! {
-        fn test_structural_eq(passengers: int) {
+        fn test_structural_eq(passengers: u64) {
             let c1 = Car { passengers, four_doors: true };
             let c2 = Car { passengers, four_doors: false };
             let c3 = Car { passengers, four_doors: true };
@@ -43,7 +43,7 @@ test_verify_one_file! {
             v: bool,
         }
 
-        fn test_not_structural(passengers: int) {
+        fn test_not_structural(passengers: u64) {
             let v1 = Thing { v: true };
             let v2 = Thing { v: true };
             assert(v1 == v2);
@@ -65,7 +65,7 @@ test_verify_one_file! {
             fn eq(&self, _: &Self) -> bool { todo!() }
         }
 
-        fn test_not_structural(passengers: int) {
+        fn test_not_structural(passengers: u64) {
             let v1 = Thing { v: true };
             let v2 = Thing { v: true };
             assert(v1 == v2);


### PR DESCRIPTION
In order to run borrowck on proof and exec code _before_ lowering to AIR and running Z3, we start the first instance of rustc, pause it after expansion to generate VIR, then keep the rustc thread waiting to maintain its state for VIR->AIR and to report errors from Z3.

Fixes #70