### PR TITLE
implement a trait for spawning and joining threads

### DIFF
--- a/source/pervasive/cell.rs
+++ b/source/pervasive/cell.rs
@@ -138,7 +138,6 @@ impl<V> PCell<V> {
     }
 
     #[inline(always)]
-    #[verifier(external_body)]
     pub fn new(v: V) -> (PCell<V>, Proof<Permission<V>>) {
         ensures(|pt : (PCell<V>, Proof<Permission<V>>)|
             equal(pt.1, Proof(Permission{ pcell: pt.0.view(), value: option::Option::Some(v) }))

--- a/source/pervasive/mod.rs
+++ b/source/pervasive/mod.rs
@@ -13,6 +13,7 @@ pub mod atomic;
 pub mod modes;
 pub mod multiset;
 pub mod state_machine_internal;
+pub mod thread;
 
 #[allow(unused_imports)]
 use builtin::*;

--- a/source/pervasive/ptr.rs
+++ b/source/pervasive/ptr.rs
@@ -151,7 +151,9 @@ impl<V> PPtr<V> {
         ]);
         opens_invariants_none();
 
-        dealloc(self.uptr.cast().as_ptr(), Layout::for_value(self.uptr.as_ref()));
+        unsafe {
+            dealloc(self.uptr.cast().as_ptr(), Layout::for_value(self.uptr.as_ref()));
+        }
     }
 
     //////////////////////////////////
@@ -175,7 +177,6 @@ impl<V> PPtr<V> {
     }
 
     #[inline(always)]
-    #[verifier(external_body)]
     pub fn new(v: V) -> (PPtr<V>, Proof<Permission<V>>) {
         ensures(|pt : (PPtr<V>, Proof<Permission<V>>)|
             equal(pt.1, Proof(Permission{ pptr: pt.0.view(), value: option::Option::Some(v) }))

--- a/source/pervasive/thread.rs
+++ b/source/pervasive/thread.rs
@@ -25,7 +25,7 @@ pub struct JoinHandle<#[verifier(maybe_negative)] Ret>
 
 impl<Ret> JoinHandle<Ret>
 {
-    fndecl!(fn predicate(&self, ret: Ret) -> bool);
+    fndecl!(pub fn predicate(&self, ret: Ret) -> bool);
 
     // TODO note that std::thread::JoinHandle::join is allowed to panic
     #[verifier(external_body)]

--- a/source/pervasive/thread.rs
+++ b/source/pervasive/thread.rs
@@ -3,7 +3,8 @@
 #[allow(unused_imports)] use crate::pervasive::*;
 #[allow(unused_imports)] use crate::pervasive::result::*;
 
-trait Spawnable<Ret: Sized> : Sized {
+/*
+pub trait Spawnable<Ret: Sized> : Sized {
     #[spec]
     fn pre(self) -> bool { no_method_body() }
 
@@ -51,3 +52,4 @@ pub fn spawn<Param: Spawnable<Ret> + Send + 'static, Ret: Send + 'static>(p: Par
     let handle = std::thread::spawn(move || p.run());
     JoinHandle { handle }
 }
+*/

--- a/source/pervasive/thread.rs
+++ b/source/pervasive/thread.rs
@@ -1,0 +1,55 @@
+#[allow(unused_imports)] use builtin::*;
+#[allow(unused_imports)] use builtin_macros::*;
+#[allow(unused_imports)] use crate::pervasive::*;
+#[allow(unused_imports)] use crate::pervasive::result::*;
+
+trait Spawnable<Ret> {
+    #[spec]
+    fn pre(&self) -> bool { no_method_body() }
+
+    #[spec]
+    fn post(&self, ret: Ret) -> bool { no_method_body() }
+    
+    // TODO: we use Boxes because the values would otherwise have to be Sized,
+    // and right now, adding a `Sized` bound is unsupported.
+    fn run(self) -> Ret {
+        requires(self.pre());
+        ensures(|r: Ret| self.post(r));
+        no_method_body()
+    }
+}
+
+#[verifier(external_body)]
+pub struct JoinHandle<#[verifier(maybe_negative)] Ret>
+{
+    handle: std::thread::JoinHandle<Box<Ret>>,
+}
+
+impl<Ret> JoinHandle<Ret>
+{
+    fndecl!(fn predicate(&self, ret: Ret) -> bool);
+
+    // TODO note that std::thread::JoinHandle::join is allowed to panic
+    #[verifier(external_body)]
+    fn join(self) -> Result<Ret, ()>
+    {
+        ensures(|r: Result<Ret, ()>|
+            r.is_Ok() >>= self.predicate(r.get_Ok_0()));
+
+        match self.handle.join() {
+            Ok(box r) => Result::Ok(r),
+            Err(_) => Result::Err(()),
+        }
+    }
+}
+
+#[verifier(external_body)]
+pub fn spawn<Param: Spawnable<Ret> + Send + 'static, Ret: Send + 'static>(p: Param) -> JoinHandle<Ret> 
+{
+    requires(p.pre());
+    ensures(|handle: JoinHandle<Ret>|
+        forall(|ret: Ret| handle.predicate(ret) >>= p.post(ret)));
+
+    let handle = std::thread::spawn(move || p.run());
+    JoinHandle { handle }
+}

--- a/source/pervasive/thread.rs
+++ b/source/pervasive/thread.rs
@@ -3,7 +3,6 @@
 #[allow(unused_imports)] use crate::pervasive::*;
 #[allow(unused_imports)] use crate::pervasive::result::*;
 
-/*
 pub trait Spawnable<Ret: Sized> : Sized {
     #[spec]
     fn pre(self) -> bool { no_method_body() }
@@ -30,7 +29,7 @@ impl<Ret> JoinHandle<Ret>
 
     // TODO note that std::thread::JoinHandle::join is allowed to panic
     #[verifier(external_body)]
-    fn join(self) -> Result<Ret, ()>
+    pub fn join(self) -> Result<Ret, ()>
     {
         ensures(|r: Result<Ret, ()>|
             r.is_Ok() >>= self.predicate(r.get_Ok_0()));
@@ -52,4 +51,4 @@ pub fn spawn<Param: Spawnable<Ret> + Send + 'static, Ret: Send + 'static>(p: Par
     let handle = std::thread::spawn(move || p.run());
     JoinHandle { handle }
 }
-*/
+

--- a/source/rust_verify/example/og_counter.rs
+++ b/source/rust_verify/example/og_counter.rs
@@ -5,6 +5,7 @@ use pervasive::*;
 use crate::pervasive::{invariants::*};
 use crate::pervasive::{atomic::*};
 use crate::pervasive::{modes::*};
+use crate::pervasive::{thread::*};
 use state_machines_macros::tokenized_state_machine;
 
 tokenized_state_machine!(
@@ -85,6 +86,31 @@ impl G {
     equal(self.perm.patomic, patomic.view()) && equal(self.perm.value as int, self.counter.value)
     && equal(self.counter.instance, inst)
   }
+}
+
+//// thread 1
+
+pub struct Thread1Data {
+    #[proof] pub instance: X_Instance,
+    #[proof] pub token: X_inc_a,
+}
+
+impl Thread1Data for Spawnable<Thread1Data> {
+    #[spec]
+    fn pre(&self) -> bool {
+        equal(self.token.instance, self.instance)
+        && !self.token.value
+    }
+
+    #[spec]
+    fn post(&self, new: Thread1Data) -> bool {
+        equal(new.token.instance, self.instance)
+        && new.token.value
+    }
+
+    fn run(&self) {
+
+    }
 }
 
 fn main() {

--- a/source/rust_verify/example/og_counter.rs
+++ b/source/rust_verify/example/og_counter.rs
@@ -90,7 +90,7 @@ impl G {
 
 //// thread 1
 
-pub struct Thread1Data {
+/*pub struct Thread1Data {
     #[proof] pub instance: X_Instance,
     #[proof] pub token: X_inc_a,
 }
@@ -111,7 +111,7 @@ impl Thread1Data for Spawnable<Thread1Data> {
     fn run(&self) {
 
     }
-}
+}*/
 
 fn main() {
   // Initialize protocol 

--- a/source/rust_verify/example/og_counter.rs
+++ b/source/rust_verify/example/og_counter.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use builtin::*;
+use builtin_macros::*;
 mod pervasive;
 use pervasive::*;
 use crate::pervasive::{invariants::*};
@@ -7,6 +8,88 @@ use crate::pervasive::{atomic::*};
 use crate::pervasive::{modes::*};
 use crate::pervasive::{thread::*};
 use state_machines_macros::tokenized_state_machine;
+use crate::pervasive::result::*;
+
+// Thread lib
+
+pub trait Spawnable<Ret: Sized> : Sized {
+    #[spec]
+    fn pre(self) -> bool { no_method_body() }
+
+    #[spec]
+    fn post(self, ret: Ret) -> bool { no_method_body() }
+    
+    fn run(self) -> Ret {
+        requires(self.pre());
+        ensures(|r: Ret| self.post(r));
+        no_method_body()
+    }
+}
+
+#[verifier(external_body)]
+pub struct JoinHandle<#[verifier(maybe_negative)] Ret>
+{
+    handle: std::thread::JoinHandle<Ret>,
+}
+
+impl<Ret> JoinHandle<Ret>
+{
+    fndecl!(fn predicate(&self, ret: Ret) -> bool);
+
+    // TODO note that std::thread::JoinHandle::join is allowed to panic
+    #[verifier(external_body)]
+    fn join(self) -> Result<Ret, ()>
+    {
+        ensures(|r: Result<Ret, ()>|
+            r.is_Ok() >>= self.predicate(r.get_Ok_0()));
+
+        match self.handle.join() {
+            Ok(r) => Result::Ok(r),
+            Err(_) => Result::Err(()),
+        }
+    }
+}
+
+#[verifier(external_body)]
+pub fn spawn<Param: Spawnable<Ret> + Send + 'static, Ret: Send + 'static>(p: Param) -> JoinHandle<Ret> 
+{
+    requires(p.pre());
+    ensures(|handle: JoinHandle<Ret>|
+        forall(|ret: Ret| handle.predicate(ret) >>= p.post(ret)));
+
+    let handle = std::thread::spawn(move || p.run());
+    JoinHandle { handle }
+}
+
+// Arc lib (stub)
+// TODO support Rust's std::sync::Arc instead
+
+#[verifier(external_body)]
+struct Arc<#[verifier(strictly_positive)] T> {
+    dummy: std::marker::PhantomData<T>,
+}
+
+impl<T> Arc<T> {
+    fndecl!(pub fn view(&self) -> T);
+
+    #[verifier(external_body)]
+    pub fn borrow(&self) -> &T {
+        ensures(|t: T| equal(t, self.view()));
+        unimplemented!();
+    }
+
+    #[verifier(external_body)]
+    pub fn new(t: T) -> Arc<T> {
+        ensures(|a: Arc<T>| equal(t, a.view()));
+        unimplemented!();
+    }
+
+    #[verifier(external_body)]
+    pub fn clone(&self) -> Arc<T> {
+        ensures(|a: Arc<T>| equal(a, *self));
+        unimplemented!();
+    }
+}
 
 tokenized_state_machine!(
     X {
@@ -76,104 +159,166 @@ tokenized_state_machine!(
 
 #[proof]
 pub struct G {
-  #[proof] pub counter: X_counter,
-  #[proof] pub perm: PermissionU32,
+    #[proof] pub counter: X_counter,
+    #[proof] pub perm: PermissionU32,
 }
 
 impl G {
-  #[spec]
-  pub fn wf(self, inst: X_Instance, patomic: PAtomicU32) -> bool {
-    equal(self.perm.patomic, patomic.view()) && equal(self.perm.value as int, self.counter.value)
-    && equal(self.counter.instance, inst)
-  }
+    #[spec]
+    pub fn wf(self, instance: X_Instance, patomic: PAtomicU32) -> bool {
+        equal(self.perm.patomic, patomic.view())
+        && equal(self.perm.value as int, self.counter.value)
+        && equal(self.counter.instance, instance)
+    }
+}
+
+pub struct Global {
+    pub atomic: PAtomicU32,
+    #[proof] pub instance: X_Instance,
+    #[proof] pub inv: Invariant<G>,
+}
+
+impl Global {
+    #[spec]
+    pub fn wf(self) -> bool {
+        forall(|g: G| self.inv.inv(g) == g.wf(self.instance, self.atomic))
+    }
 }
 
 //// thread 1
 
-/*pub struct Thread1Data {
-    #[proof] pub instance: X_Instance,
+pub struct Thread1Data {
+    pub globals: Arc<Global>,
+
     #[proof] pub token: X_inc_a,
 }
 
-impl Thread1Data for Spawnable<Thread1Data> {
+impl Spawnable<Proof<X_inc_a>> for Thread1Data {
     #[spec]
-    fn pre(&self) -> bool {
-        equal(self.token.instance, self.instance)
+    fn pre(self) -> bool {
+        self.globals.view().wf()
+        && equal(self.token.instance, self.globals.view().instance)
         && !self.token.value
     }
 
     #[spec]
-    fn post(&self, new: Thread1Data) -> bool {
-        equal(new.token.instance, self.instance)
-        && new.token.value
+    fn post(self, new_token: Proof<X_inc_a>) -> bool {
+        equal(new_token.0.instance, self.globals.view().instance)
+        && new_token.0.value
     }
 
-    fn run(&self) {
+    fn run(self) -> Proof<X_inc_a> {
+        let Thread1Data { globals: globals, mut token } = self;
+        let globals = globals.borrow();
 
+        open_invariant!(&globals.inv => g => {
+            #[proof] let G { counter: mut c, perm: mut p } = g;
+
+            #[spec] let now_c = c;
+
+            globals.instance.tr_inc_a(&mut c, &mut token); // atomic increment
+            globals.atomic.fetch_add(&mut p, 1);
+
+            g = G { counter: c, perm: p };
+        });
+
+        Proof(token)
     }
-}*/
+}
+
+//// thread 2
+
+pub struct Thread2Data {
+    pub globals: Arc<Global>,
+
+    #[proof] pub token: X_inc_b,
+}
+
+impl Spawnable<Proof<X_inc_b>> for Thread2Data {
+    #[spec]
+    fn pre(self) -> bool {
+        self.globals.view().wf()
+        && equal(self.token.instance, self.globals.view().instance)
+        && !self.token.value
+    }
+
+    #[spec]
+    fn post(self, new_token: Proof<X_inc_b>) -> bool {
+        equal(new_token.0.instance, self.globals.view().instance)
+        && new_token.0.value
+    }
+
+    fn run(self) -> Proof<X_inc_b> {
+        let Thread2Data { globals: globals, mut token } = self;
+        let globals = globals.borrow();
+
+        open_invariant!(&globals.inv => g => {
+            #[proof] let G { counter: mut c, perm: mut p } = g;
+
+            #[spec] let now_c = c;
+
+            globals.instance.tr_inc_b(&mut c, &mut token); // atomic increment
+            globals.atomic.fetch_add(&mut p, 1);
+
+        
+            g = G { counter: c, perm: p };
+        });
+
+        Proof(token)
+    }
+}
 
 fn main() {
   // Initialize protocol 
 
-  #[proof] let (inst,
+  #[proof] let (instance,
       counter_token,
       mut inc_a_token,
       mut inc_b_token) = X_Instance::initialize();
 
   // Initialize the counter
 
-  let (at, Proof(perm_token)) = PAtomicU32::new(0);
+  let (atomic, Proof(perm_token)) = PAtomicU32::new(0);
 
   #[proof] let at_inv: Invariant<G> = Invariant::new(
       G { counter: counter_token, perm: perm_token },
-      |g: G| g.wf(inst, at),
+      |g: G| g.wf(instance, atomic),
       0);
 
-  // TODO actually run these on separate threads
+  let global = Global { atomic, instance: instance.clone(), inv: at_inv };
+  let global_arc = Arc::new(global);
 
-  // Thread 1 (gets access to inc_a_token)
+  // Spawn threads
 
-  open_invariant!(&at_inv => g => {
-    #[proof] let G { counter: mut c, perm: mut p } = g;
+  let thread1_data = Thread1Data { globals: global_arc.clone(), token: inc_a_token };
+  let join_handle1 = spawn(thread1_data);
 
-    #[spec] let now_c = c;
+  let thread2_data = Thread2Data { globals: global_arc.clone(), token: inc_b_token };
+  let join_handle2 = spawn(thread2_data);
 
-    inst.tr_inc_a(&mut c, &mut inc_a_token); // atomic increment
-    assert(now_c.value == p.value);
-    assert(c.value <= 3);
-    assert(now_c.value <= 2);
-    assert(0 <= now_c.value);
-    assert(p.value <= 2);
-    assert(0 <= p.value);
-    assert(p.value as int + 1 <= 3);
-    at.fetch_add(&mut p, 1);
+  // Join threads
 
-    g = G { counter: c, perm: p };
-  });
+  #[proof] let inc_a_token;
+  match join_handle1.join() {
+      Result::Ok(Proof(token)) => { inc_a_token = token; }
+      _ => { return; }
+  };
 
-  // Thread 2 (gets access to inc_b_token)
-
-  open_invariant!(&at_inv => g => {
-    #[proof] let G { counter: mut c2, perm: mut p2 } = g;
-
-    inst.tr_inc_b(&mut c2, &mut inc_b_token); // atomic increment
-    at.fetch_add(&mut p2, 1);
-
-    g = G { counter: c2, perm: p2 };
-  });
+  #[proof] let inc_b_token;
+  match join_handle2.join() {
+      Result::Ok(Proof(token)) => { inc_b_token = token; }
+      _ => { return; }
+  };
 
   // Join threads, load the atomic again
 
-  // Since we recovered exclusive control of the invariant, we could destruct it
-  // if we want to. Or we can just open the invariant block like normal.
-
+  let global = global_arc.borrow();
   let x;
-  open_invariant!(&at_inv => g => {
+  open_invariant!(&global.inv => g => {
     #[proof] let G { counter: c3, perm: p3 } = g;
 
-    x = at.load(&p3);
-    inst.finalize(&c3, &inc_a_token, &inc_b_token);
+    x = global.atomic.load(&p3);
+    instance.finalize(&c3, &inc_a_token, &inc_b_token);
 
     g = G { counter: c3, perm: p3 };
   });

--- a/source/rust_verify/example/og_counter.rs
+++ b/source/rust_verify/example/og_counter.rs
@@ -10,57 +10,6 @@ use crate::pervasive::{thread::*};
 use state_machines_macros::tokenized_state_machine;
 use crate::pervasive::result::*;
 
-// Thread lib
-
-pub trait Spawnable<Ret: Sized> : Sized {
-    #[spec]
-    fn pre(self) -> bool { no_method_body() }
-
-    #[spec]
-    fn post(self, ret: Ret) -> bool { no_method_body() }
-    
-    fn run(self) -> Ret {
-        requires(self.pre());
-        ensures(|r: Ret| self.post(r));
-        no_method_body()
-    }
-}
-
-#[verifier(external_body)]
-pub struct JoinHandle<#[verifier(maybe_negative)] Ret>
-{
-    handle: std::thread::JoinHandle<Ret>,
-}
-
-impl<Ret> JoinHandle<Ret>
-{
-    fndecl!(fn predicate(&self, ret: Ret) -> bool);
-
-    // TODO note that std::thread::JoinHandle::join is allowed to panic
-    #[verifier(external_body)]
-    fn join(self) -> Result<Ret, ()>
-    {
-        ensures(|r: Result<Ret, ()>|
-            r.is_Ok() >>= self.predicate(r.get_Ok_0()));
-
-        match self.handle.join() {
-            Ok(r) => Result::Ok(r),
-            Err(_) => Result::Err(()),
-        }
-    }
-}
-
-#[verifier(external_body)]
-pub fn spawn<Param: Spawnable<Ret> + Send + 'static, Ret: Send + 'static>(p: Param) -> JoinHandle<Ret> 
-{
-    requires(p.pre());
-    ensures(|handle: JoinHandle<Ret>|
-        forall(|ret: Ret| handle.predicate(ret) >>= p.post(ret)));
-
-    let handle = std::thread::spawn(move || p.run());
-    JoinHandle { handle }
-}
-
 // Arc lib (stub)
 // TODO support Rust's std::sync::Arc instead
 

--- a/source/rust_verify/example/og_counter.rs
+++ b/source/rust_verify/example/og_counter.rs
@@ -14,7 +14,7 @@ use crate::pervasive::result::*;
 // TODO support Rust's std::sync::Arc instead
 
 #[verifier(external_body)]
-struct Arc<#[verifier(strictly_positive)] T> {
+pub struct Arc<#[verifier(strictly_positive)] T> {
     dummy: std::marker::PhantomData<T>,
 }
 


### PR DESCRIPTION
 * depends on Chris's patch for ignoring marking traits (https://github.com/secure-foundations/verus/pull/93)
 * trusted thread library for spawn & join based on std::thread::spawn
 * integrate it into the 'og_counter' example

I ran into a bug where the traits didn't work if declared in a separate module, though.