### PR TITLE
add another span in postcondition error messages

### DIFF
--- a/source/rust_verify/example/assertions.rs
+++ b/source/rust_verify/example/assertions.rs
@@ -17,3 +17,10 @@ fn has_expectations(b:bool) {
 fn fails_expectations() {
     has_expectations(false);
 }
+
+fn fails_post() {
+    ensures(false);
+
+    let x = 5;
+    let y = 7;
+}

--- a/source/rust_verify/tests/traits.rs
+++ b/source/rust_verify/tests/traits.rs
@@ -584,13 +584,13 @@ test_verify_one_file! {
     #[test] test_verify_2 code! {
         trait T {
             fn f(&self) {
-                ensures(false); // FAILS
+                ensures(false);
                 no_method_body()
             }
         }
         struct S {}
         impl T for S {
-            fn f(&self) {}
+            fn f(&self) {} // FAILS
         }
     } => Err(err) => assert_one_fails(err)
 }
@@ -624,7 +624,7 @@ test_verify_one_file! {
             #[spec]
             fn ens(&self) -> bool { no_method_body() }
             fn f(&self) {
-                ensures(self.ens()); // FAILS
+                ensures(self.ens());
                 no_method_body()
             }
         }
@@ -632,7 +632,7 @@ test_verify_one_file! {
         impl T for S {
             #[spec]
             fn ens(&self) -> bool { false }
-            fn f(&self) {}
+            fn f(&self) {} // FAILS
         }
     } => Err(err) => assert_one_fails(err)
 }
@@ -673,7 +673,7 @@ test_verify_one_file! {
 
             fn f(&self, a: &A) -> A {
                 requires(self.req(*a));
-                ensures(|ra: A| self.ens(*a, ra)); // FAILS
+                ensures(|ra: A| self.ens(*a, ra));
                 no_method_body()
             }
         }
@@ -715,7 +715,7 @@ test_verify_one_file! {
 
             fn f(&self, a: &u64) -> u64 {
                 self.x / 2 + a
-            }
+            } // FAILS
         }
 
         fn p<A, Z: T<A>>(a: &A, z: &Z) -> A {
@@ -962,7 +962,7 @@ test_verify_one_file! {
             fn f<'a>(&'a self, x: &'a Self, b: bool) -> &'a Self {
                 ensures(|r: &'a Self| [
                     b >>= equal(r, self),
-                    !b >>= equal(r, x), // FAILS
+                    !b >>= equal(r, x),
                 ]);
                 no_method_body()
             }
@@ -978,7 +978,7 @@ test_verify_one_file! {
         impl T for S {
             fn f<'a>(&'a self, x: &'a Self, b: bool) -> &'a Self {
                 if b { self } else { self }
-            }
+            } // FAILS
         }
 
         fn test() {

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1243,7 +1243,12 @@ pub fn body_stm_to_air(
     let mut local = state.local_shared.clone();
 
     for ens in enss {
-        let error = error("postcondition not satisfied", &ens.span);
+        let error = error_with_label(
+            "postcondition not satisfied".to_string(),
+            &stm.span,
+            "at the end of the function body".to_string(),
+        )
+        .secondary_label(&ens.span, "failed this postcondition".to_string());
         let e = mk_let(&trait_typ_bind, &exp_to_expr(ctx, ens, ExprCtxt::Body));
         let ens_stmt = StmtX::Assert(error, e);
         stmts.push(Arc::new(ens_stmt));


### PR DESCRIPTION
now that traits exist, the previous postcondition error message was unsuitable, because it only pointed to the postcondition, which might be in a different function than the actual error! This PR makes it more specific.

Now it looks like this, for a normal function:

```
error: postcondition not satisfied
  --> rust_verify/example/assertions.rs:21:17
   |
21 |   fn fails_post() {
   |  _________________^
22 | |     ensures(false);
   | |             ----- failed this postcondition
23 | |
24 | |     let x = 5;
25 | |     let y = 7;
26 | | }
   | |_^ at the end of the function body
```

or like this, for a trait function:

```
error: postcondition not satisfied
   --> rust_verify/example/og_counter.rs:210:36
    |
24  |           ensures(|r: Ret| self.post(r));
    |                            ------------ failed this postcondition
...
210 |       fn run(self) -> Proof<X_inc_a> {
    |  ____________________________________^
211 | |         let Thread1Data { globals: globals, mut token } = self;
212 | |         let globals = globals.borrow();
213 | |
...   |
225 | |         Proof(token)
226 | |     }
    | |_____^ at the end of the function body
```