### PR TITLE
handle case where conditional returns on one branch but not the other

### DIFF
--- a/source/rust_verify/src/erase.rs
+++ b/source/rust_verify/src/erase.rs
@@ -794,8 +794,13 @@ fn erase_expr_opt(ctxt: &Ctxt, mctxt: &mut MCtxt, expect: Mode, expr: &Expr) -> 
                 }
             }
         }
+        ExprKind::Loop(block, None) => {
+            // The mode checker only allows loops for Mode::Exec
+            let block = erase_block(ctxt, mctxt, Mode::Exec, block);
+            ExprKind::Loop(P(block), None)
+        }
         ExprKind::While(eb, block, None) => {
-            // The mode checker only allows While for Mode::Exec
+            // The mode checker only allows loops for Mode::Exec
             let eb = erase_expr(ctxt, mctxt, Mode::Exec, eb);
             let block = erase_block(ctxt, mctxt, Mode::Exec, block);
             ExprKind::While(P(eb), P(block), None)

--- a/source/rust_verify/tests/control_flow.rs
+++ b/source/rust_verify/tests/control_flow.rs
@@ -477,3 +477,22 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] return_value_in_one_match_arm code! {
+        enum TreeSortedness {
+            Unsorted,
+            Empty,
+        }
+
+        fn moo(left_sortedness: TreeSortedness, b: bool) -> TreeSortedness {
+            let x;
+            match left_sortedness {
+                TreeSortedness::Unsorted => return TreeSortedness::Unsorted,
+                TreeSortedness::Empty => { x = 5; }
+            }
+            assert(x == 5);
+            TreeSortedness::Unsorted
+        }
+    } => Ok(())
+}

--- a/source/rust_verify/tests/control_flow.rs
+++ b/source/rust_verify/tests/control_flow.rs
@@ -1,0 +1,479 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+test_verify_one_file! {
+    #[test] returns_and_implict_units_in_branches code! {
+        fn test_return_from_else(b: bool) {
+            let x = if b {
+                1
+            } else {
+                return;
+            };
+            assert(b);
+            assert(x == 1);
+        }
+
+        fn test_return_from_if(b: bool) {
+            let x = if b {
+                return;
+            } else {
+                1
+            };
+            assert(!b);
+            assert(x == 1);
+        }
+
+        pub enum Foo { A, B }
+
+        fn test_return_from_match(foo: Foo) {
+            let x = match foo {
+                Foo::A => { return; }
+                Foo::B => { 7 }
+            };
+            assert(x == 7);
+            assert(match foo { Foo::A => false, Foo::B => true });
+        }
+
+        fn test_return_from_both(b: bool) {
+            let x = if b { return; } else { return; };
+            assert(false); // can't get here
+        }
+
+        fn test_return_from_both2(b: bool) {
+            let x;
+            x = if b { return; } else { return; };
+            assert(false); // can't get here
+        }
+
+        // make sure we correctly distinguish the 'return' cases from implicit unit cases
+
+        fn test_implicit_unit_block(b: bool) {
+            let x = { };
+            assert(equal(x, ()));
+        }
+
+        fn test_implicit_unit_block2(b: bool) {
+            let x;
+            x = { };
+            assert(equal(x, ()));
+        }
+
+        fn test_implicit_unit_from_both(b: bool) {
+            let x = if b { } else { };
+            assert(equal(x, ()));
+        }
+
+        fn test_implicit_unit_from_both2(b: bool) {
+            let x;
+            x = if b { } else { };
+            assert(equal(x, ()));
+        }
+
+        fn test_implicit_unit_from_left(b: bool) {
+            let x = if b { () } else { };
+            assert(equal(x, ()));
+        }
+
+        fn test_implicit_unit_from_left2(b: bool) {
+            let x;
+            x = if b { () } else { };
+            assert(equal(x, ()));
+        }
+
+        fn test_implicit_unit_from_right(b: bool) {
+            let x = if b { } else { () };
+            assert(equal(x, ()));
+        }
+
+        fn test_implicit_unit_from_right2(b: bool) {
+            let x;
+            x = if b { } else { () };
+            assert(equal(x, ()));
+        }
+
+        fn test_add_u32_and_never() -> u32 {
+            ensures(|r: u32| r < 3);
+            let x: u32 = {return 1; 3};
+            let y: u32 = {return 2;};
+            x + y
+        }
+
+        fn test_final_stmt_return() -> u8 {
+            ensures(|y: u8| y == 5);
+            return 5;
+        }
+
+        fn never_short_circuit_left() {
+            let x = { return; } || true;
+            assert(false);
+        }
+
+        fn never_short_circuit_right(b: bool) {
+            let x = b || { return; };
+            assert(b);
+        }
+
+        fn never_binop_left(b: bool) {
+            let x = { return; 7 } + 5;
+            assert(false);
+        }
+
+        fn never_binop_left2(b: bool) {
+            let x = { return; 7 } + { assert(false); 5 };
+        }
+
+        fn never_binop_right(b: bool) {
+            let x = 5 + { return; 7 };
+            assert(false);
+        }
+
+        fn never_in_conditional(b: bool) {
+            if { return; true } {
+                assert(false);
+            } else {
+                assert(false);
+            }
+        }
+
+        fn never_in_return() -> u8 {
+            ensures(|i: u8| i == 3);
+            return { return 3; 5 };
+        }
+
+        fn return_return() -> u8 {
+            ensures(|i: u8| i == 3);
+            return 3;
+            return 5;
+        }
+
+        fn return_return2() -> u8 {
+            ensures(|i: u8| i == 3);
+            return 3;
+            5
+        }
+
+        fn if_unit_no_else() {
+            let x = if true { () };
+            assert(equal(x, ()));
+        }
+
+        fn if_let(b: bool) {
+            let r = if b { let mut x = 5; x = 7; x } else { return; };
+            assert(r == 7);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] returns_and_implict_units_in_branches_fail code! {
+        fn postcondition_fail_if(b: bool) {
+            ensures(false);
+
+            let x = if b {
+                5
+            } else {
+                return; // FAILS
+            };
+            assume(false);
+        }
+
+        fn postcondition_fail_else(b: bool) {
+            ensures(false);
+
+            let x = if b {
+                return; // FAILS
+            } else {
+                5
+            };
+            assume(false);
+        }
+
+        fn postcondition_fail_if_value(b: bool) -> u8 {
+            ensures(|i: u8| i == 4);
+
+            let x = if b {
+                return 7; // FAILS
+            } else {
+                5
+            };
+            4
+        }
+
+        fn postcondition_fail_else_value(b: bool) -> u8 {
+            ensures(|i: u8| i == 4);
+
+            let x = if b {
+                5
+            } else {
+                return 7; // FAILS
+            };
+            4
+        }
+
+        fn test_return_from_else(b: bool) {
+            let x = if b {
+                1
+            } else {
+                return;
+            };
+            assert(b);
+            assert(x == 1);
+            assert(false); // FAILS
+        }
+
+        fn test_return_from_if(b: bool) {
+            let x = if b {
+                return;
+            } else {
+                1
+            };
+            assert(!b);
+            assert(x == 1);
+            assert(false); // FAILS
+        }
+
+        pub enum Foo { A, B }
+
+        fn test_return_from_match(foo: Foo) {
+            let x = match foo {
+                Foo::A => { return; }
+                Foo::B => { 7 }
+            };
+            assert(x == 7);
+            assert(match foo { Foo::A => false, Foo::B => true });
+            assert(false); // FAILS
+        }
+
+        fn test_implicit_unit_block(b: bool) {
+            let x = { };
+            assert(equal(x, ()));
+            assert(false); // FAILS
+        }
+
+        fn test_implicit_unit_block2(b: bool) {
+            let x;
+            x = { };
+            assert(equal(x, ()));
+            assert(false); // FAILS
+        }
+
+        fn test_implicit_unit_from_both(b: bool) {
+            let x = if b { } else { };
+            assert(equal(x, ()));
+            assert(false); // FAILS
+        }
+
+        fn test_implicit_unit_from_both2(b: bool) {
+            let x;
+            x = if b { } else { };
+            assert(equal(x, ()));
+            assert(false); // FAILS
+        }
+
+        fn test_implicit_unit_from_left(b: bool) {
+            let x = if b { () } else { };
+            assert(equal(x, ()));
+            assert(false); // FAILS
+        }
+
+        fn test_implicit_unit_from_left2(b: bool) {
+            let x;
+            x = if b { () } else { };
+            assert(equal(x, ()));
+            assert(false); // FAILS
+        }
+
+        fn test_implicit_unit_from_right(b: bool) {
+            let x = if b { } else { () };
+            assert(equal(x, ()));
+            assert(false); // FAILS
+        }
+
+        fn test_implicit_unit_from_right2(b: bool) {
+            let x;
+            x = if b { } else { () };
+            assert(equal(x, ()));
+            assert(false); // FAILS
+        }
+
+        fn test_add_u32_and_never() -> u32 {
+            ensures(|r: u32| r > 3);
+            let x: u32 = {
+              return 1; // FAILS
+              3
+            };
+            let y: u32 = {return 2;};
+            x + y
+        }
+
+        fn test_final_stmt_return() -> u8 {
+            ensures(|y: u8| y == 6);
+            return 5; // FAILS
+        }
+
+        fn never_short_circuit_left() {
+            let x = {
+                assert(false); // FAILS
+                return;
+            } || true;
+        }
+
+        fn never_short_circuit_right(b: bool) {
+            let x = b || { return; };
+            assert(false); // FAILS
+        }
+
+        fn never_binop_left(b: bool) {
+            let x = {
+                assert(false); // FAILS
+                return;
+                7
+            } + 5;
+        }
+
+        fn never_binop_left2(b: bool) {
+            let x = {
+                assert(false); // FAILS
+                return;
+                7
+            } + { assert(false); 5 };
+        }
+
+        fn never_binop_right(b: bool) {
+            let x = {
+                assert(false); // FAILS
+                5
+            } + { return; 7 };
+        }
+
+        fn never_in_conditional(b: bool) -> u8 {
+            ensures(|y: u8| y == 7);
+
+            let mut x = 7;
+            if {
+              x = 5;
+              return x; // FAILS
+              true
+            } {
+                assert(false);
+            } else {
+                assert(false);
+            }
+
+            return 1243;
+        }
+
+        fn never_in_return() -> u8 {
+            ensures(|i: u8| i == 5);
+            return {
+              return 3; // FAILS
+              5
+            };
+        }
+
+        fn return_return() -> u8 {
+            ensures(|i: u8| i == 5);
+            return 3; // FAILS
+            return 5;
+        }
+
+        fn return_return2() -> u8 {
+            ensures(|i: u8| i == 5);
+            return 3; // FAILS
+            5
+        }
+
+        fn if_unit_no_else() {
+            let x = if true { () };
+            assert(false); // FAILS
+        }
+
+        fn if_let(b: bool) {
+            let r = if b { let mut x = 5; x = 7; x } else { return; };
+            assert(r == 5); // FAILS
+        }
+    } => Err(err) => assert_fails(err, 28)
+}
+
+test_verify_one_file! {
+    #[test] block_with_no_return_as_arg code! {
+        fn foo(x: u8) {
+
+        }
+
+        fn main() {
+            foo({ return; });
+            assert(false);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] block_with_no_return_as_arg2 code! {
+        fn foo(x: ()) {
+
+        }
+
+        fn x() {
+            foo({ return; });
+            assert(false);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] block_with_no_return_as_arg3 code! {
+        fn foo(x: u8) {
+        }
+
+        fn bar() { }
+
+        fn main() {
+            foo({ return; bar(); });
+            assert(false);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] conditional_with_infinite_loop code! {
+        fn main(b: bool) {
+            let x = if b {
+                1
+            } else {
+                loop { }
+            };
+            assert(x == 1);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] conditional_with_infinite_while_loop code! {
+        fn foo(b: bool) {
+            let x = if b {
+                1
+            } else {
+                while true { }
+                5
+            };
+            assert(x == 1);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] return_inside_while code! {
+        fn foo(b: bool) {
+            let mut x = 5;
+            while b {
+                invariant(x == 5);
+
+                x = 6;
+                return;
+            }
+        }
+    } => Ok(())
+}

--- a/source/rust_verify/tests/control_flow.rs
+++ b/source/rust_verify/tests/control_flow.rs
@@ -4,7 +4,7 @@ mod common;
 use common::*;
 
 test_verify_one_file! {
-    #[test] returns_and_implict_units_in_branches code! {
+    #[test] distinguish_returns_and_implict_units code! {
         fn test_return_from_else(b: bool) {
             let x = if b {
                 1
@@ -167,7 +167,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] returns_and_implict_units_in_branches_fail code! {
+    #[test] postconditions_fail_in_returns_in_conditional code! {
         fn postcondition_fail_if(b: bool) {
             ensures(false);
 
@@ -211,7 +211,11 @@ test_verify_one_file! {
             };
             4
         }
+    } => Err(err) => assert_fails(err, 4)
+}
 
+test_verify_one_file! {
+    #[test] return_from_if_else_fail code! {
         fn test_return_from_else(b: bool) {
             let x = if b {
                 1
@@ -233,7 +237,11 @@ test_verify_one_file! {
             assert(x == 1);
             assert(false); // FAILS
         }
+    } => Err(err) => assert_fails(err, 2)
+}
 
+test_verify_one_file! {
+    #[test] return_from_match_fail code! {
         pub enum Foo { A, B }
 
         fn test_return_from_match(foo: Foo) {
@@ -245,7 +253,11 @@ test_verify_one_file! {
             assert(match foo { Foo::A => false, Foo::B => true });
             assert(false); // FAILS
         }
+    } => Err(err) => assert_fails(err, 1)
+}
 
+test_verify_one_file! {
+    #[test] implicit_unit_block_fail code! {
         fn test_implicit_unit_block(b: bool) {
             let x = { };
             assert(equal(x, ()));
@@ -271,7 +283,11 @@ test_verify_one_file! {
             assert(equal(x, ()));
             assert(false); // FAILS
         }
+    } => Err(err) => assert_fails(err, 4)
+}
 
+test_verify_one_file! {
+    #[test] implicit_unit_conditional_fail code! {
         fn test_implicit_unit_from_left(b: bool) {
             let x = if b { () } else { };
             assert(equal(x, ()));
@@ -297,7 +313,11 @@ test_verify_one_file! {
             assert(equal(x, ()));
             assert(false); // FAILS
         }
+    } => Err(err) => assert_fails(err, 4)
+}
 
+test_verify_one_file! {
+    #[test] return_in_let_fail code! {
         fn test_add_u32_and_never() -> u32 {
             ensures(|r: u32| r > 3);
             let x: u32 = {
@@ -307,12 +327,20 @@ test_verify_one_file! {
             let y: u32 = {return 2;};
             x + y
         }
+    } => Err(err) => assert_fails(err, 1)
+}
 
+test_verify_one_file! {
+    #[test] final_stmt_return_fail code! {
         fn test_final_stmt_return() -> u8 {
             ensures(|y: u8| y == 6);
             return 5; // FAILS
         }
+    } => Err(err) => assert_fails(err, 1)
+}
 
+test_verify_one_file! {
+    #[test] short_circuit_returns_fail code! {
         fn never_short_circuit_left() {
             let x = {
                 assert(false); // FAILS
@@ -347,7 +375,11 @@ test_verify_one_file! {
                 5
             } + { return; 7 };
         }
+    } => Err(err) => assert_fails(err, 5)
+}
 
+test_verify_one_file! {
+    #[test] misc_never_returns_fail code! {
         fn never_in_conditional(b: bool) -> u8 {
             ensures(|y: u8| y == 7);
 
@@ -362,7 +394,7 @@ test_verify_one_file! {
                 assert(false);
             }
 
-            return 1243;
+            return 9;
         }
 
         fn never_in_return() -> u8 {
@@ -384,7 +416,11 @@ test_verify_one_file! {
             return 3; // FAILS
             5
         }
+    } => Err(err) => assert_fails(err, 4)
+}
 
+test_verify_one_file! {
+    #[test] conditionals_units_return_fail code! {
         fn if_unit_no_else() {
             let x = if true { () };
             assert(false); // FAILS
@@ -394,7 +430,7 @@ test_verify_one_file! {
             let r = if b { let mut x = 5; x = 7; x } else { return; };
             assert(r == 5); // FAILS
         }
-    } => Err(err) => assert_fails(err, 28)
+    } => Err(err) => assert_fails(err, 2)
 }
 
 test_verify_one_file! {

--- a/source/rust_verify/tests/loops.rs
+++ b/source/rust_verify/tests/loops.rs
@@ -249,3 +249,27 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] basic_loop code! {
+        fn test() {
+            #[spec] let mut a: int = 5;
+            loop {
+                invariant(a > 0);
+                a = a + 1;
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] basic_loop_fail code! {
+        fn test() {
+            #[spec] let mut a: int = 5;
+            loop {
+                invariant(a > 0); // FAILS
+                a = a - 1;
+            }
+        }
+    } => Err(err) => assert_one_fails(err)
+}

--- a/source/rust_verify/tests/open_invariant.rs
+++ b/source/rust_verify/tests/open_invariant.rs
@@ -398,7 +398,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] never_terminate_in_invariant code! {
-        use crate::pervasive::invariants::*;
+        use crate::pervasive::invariant::*;
 
         pub fn X(#[proof] i: LocalInvariant<u8>) {
             open_local_invariant!(&i => inner => {

--- a/source/rust_verify/tests/open_invariant.rs
+++ b/source/rust_verify/tests/open_invariant.rs
@@ -395,3 +395,16 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_one_fails(err)
 }
+
+test_verify_one_file! {
+    #[test] never_terminate_in_invariant code! {
+        use crate::pervasive::invariants::*;
+
+        pub fn X(#[proof] i: LocalInvariant<u8>) {
+            open_local_invariant!(&i => inner => {
+                inner = 7;
+                loop { }
+            });
+        }
+    } => Ok(())
+}

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -562,6 +562,10 @@ fn mk_fun_decl(
 pub fn simplify_krate(ctx: &mut GlobalCtx, krate: &Krate) -> Result<Krate, VirErr> {
     let KrateX { functions, datatypes, traits, module_ids } = &**krate;
     let mut state = State::new();
+
+    // Pre-emptively add this because unit values might be added later.
+    state.tuple_type_name(0);
+
     let functions = vec_map_result(functions, |f| simplify_function(ctx, &mut state, f))?;
     let mut datatypes = vec_map_result(&datatypes, |d| simplify_datatype(&mut state, d))?;
 

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -687,6 +687,8 @@ fn expr_to_stm_opt(
             // If e1 evaluates to `proceed_on`, then evaluate and
             // return e2; otherwise, return the value `other`
             // (without evaluating `e2`).
+            // Also note: if `e2` is a pure expression, we don't need to do the
+            // special handling.
             let short_circuit = match op {
                 BinaryOp::And => Some((true, false)),
                 BinaryOp::Implies => Some((true, true)),
@@ -716,7 +718,7 @@ fn expr_to_stm_opt(
                     let e1 = unwrap_or_return_never!(e1, stms1);
                     stms1.append(&mut stms2);
                     let e2 = unwrap_or_return_never!(e2, stms1);
-                    let bin = mk_exp(ExpX::Binary(*op, e1, e2));
+                    let bin = mk_exp(ExpX::Binary(*op, e1, e2.clone()));
 
                     if let BinaryOp::Arith(arith, inferred_mode) = op {
                         // Insert bounds check

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -533,13 +533,12 @@ fn if_to_stm(
             } else {
                 // We have `if ( stms0; e0 ) { stms1; e1 } else { stms2; e2 }`.
                 // We turn this into:
-                //  stms0; if e0 { stms1 } else { stms2 };
-                //  if e0 { e1 } else { e2 }
+                //  stms0;
+                //  if e0 { stms1; temp = e1; } else { stms2; temp = e2; };
+                //  temp
 
-                // If statement, put results from e1/e2 in a temp variable, return temp variable
                 let (temp, temp_var) = state.next_temp(&expr.span, &expr.typ);
                 let temp_id = state.declare_new_var(&temp, &expr.typ, false, false);
-                // if e0 { stms1; temp = e1; } else { stms2; temp = e2; }
                 stms1.push(init_var(&expr.span, &temp_id, &e1));
                 stms2.push(init_var(&expr.span, &temp_id, &e2));
                 let stm1 = stms_to_one_stm(&expr.span, stms1);

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -2,7 +2,7 @@ use crate::ast::{
     ArithOp, BinaryOp, CallTarget, Constant, Expr, ExprX, Fun, Function, Ident, IntRange, Mode,
     PatternX, SpannedTyped, Stmt, StmtX, Typ, TypX, Typs, UnaryOp, UnaryOpr, VarAt, VirErr,
 };
-use crate::ast_util::{err_str, err_string};
+use crate::ast_util::{err_str, err_string, types_equal};
 use crate::context::Ctx;
 use crate::def::Spanned;
 use crate::sst::{
@@ -39,6 +39,41 @@ pub(crate) struct State {
     dont_rename: HashSet<UniqueIdent>,
     // If we allow return expressions, this is the return variable and ensures clauses:
     pub(crate) ret_post: Option<(Option<UniqueIdent>, Exps)>,
+}
+
+#[derive(Clone)]
+enum ReturnValue {
+    Some(Exp),
+    ImplicitUnit(Span),
+    Never,
+}
+
+impl ReturnValue {
+    /// Turn implicit unit into an "explicit unit", i.e., an
+    /// sst Exp representing the unit value; meanwhile, return None for Never.
+    fn to_value(self) -> Option<Exp> {
+        match self {
+            ReturnValue::Some(e) => Some(e),
+            ReturnValue::ImplicitUnit(span) => Some(lowered_unit_value(&span)),
+            ReturnValue::Never => None,
+        }
+    }
+}
+
+/// Macro to help while processing an expression.
+/// Many expressions have a form where we process subexpressions, and if one
+/// of the subexpressions returns Never, then we want to return immediately,
+/// returning only the statements we have collected so far and passing the Never
+/// up to the next level. This macro makes it a bit more convenient.
+macro_rules! unwrap_or_return_never {
+    ($e:expr, $stms:expr) => {
+        match $e.to_value() {
+            Some(e) => e,
+            None => {
+                return Ok(($stms, ReturnValue::Never));
+            }
+        }
+    };
 }
 
 impl State {
@@ -165,11 +200,54 @@ fn function_can_be_exp(ctx: &Ctx, expr: &Expr, path: &Fun) -> Result<bool, VirEr
     }
 }
 
+pub fn assume_false(span: &Span) -> Stm {
+    let expx = ExpX::Const(Constant::Bool(false));
+    let exp = SpannedTyped::new(&span, &Arc::new(TypX::Bool), expx);
+    Spanned::new(span.clone(), StmX::Assume(exp))
+}
+
+/// Determine if it's possible for control flow to reach the statement after the loop exit.
+/// Naturally, we need to be conservative and answer 'yes' if we can't tell.
+/// However, this analysis is also relevant to the typing of the program: in particular,
+/// we ALSO need to return 'no' if any case where rustc's typechecker
+/// might have said 'no'.
+///
+/// The reason is that: if rustc determines that the loop can't exit, then
+/// the code after this will be unreachable, which means the user might be allowed
+/// to leave off a return expression. We need to detect that case, or else we might
+/// wrongly determine that it returns a 'unit' and we'll create malformed AIR code.
+///
+/// So when does Rust do this? As far as I can tell, it only does this if:
+///
+///   (i) it's a 'loop' statement, and
+///   (ii) it doesn't have ANY 'break' statement in it
+///        (It is possible that a 'break' statement in a while loop might itself be
+///        unreachable, but Rust doesn't seem to take that into account for this purpose.)
+///
+/// (TODO update this check when we support 'break' statements.)
+
+pub fn can_control_flow_reach_after_loop(expr: &Expr) -> bool {
+    match &expr.x {
+        ExprX::While { cond, body: _, invs: _ } => match &cond.x {
+            ExprX::Const(Constant::Bool(true)) => false,
+            _ => true,
+        },
+        _ => {
+            panic!("expected while loop");
+        }
+    }
+}
+
+enum ReturnedCall {
+    Call { fun: Fun, typs: Typs, has_return: bool, args: Args },
+    Never,
+}
+
 fn expr_get_call(
     ctx: &Ctx,
     state: &mut State,
     expr: &Expr,
-) -> Result<Option<(Vec<Stm>, Fun, Typs, bool, Args)>, VirErr> {
+) -> Result<Option<(Vec<Stm>, ReturnedCall)>, VirErr> {
     match &expr.x {
         ExprX::Call(CallTarget::FnSpec(..), _) => {
             panic!("internal error: CallTarget::FnSpec")
@@ -178,12 +256,26 @@ fn expr_get_call(
             let mut stms: Vec<Stm> = Vec::new();
             let mut exps: Vec<Arg> = Vec::new();
             for arg in args.iter() {
-                let (mut stms0, e0) = expr_to_stm(ctx, state, arg)?;
+                let (mut stms0, e0) = expr_to_stm_opt(ctx, state, arg)?;
                 stms.append(&mut stms0);
+                let e0 = match e0.to_value() {
+                    Some(e) => e,
+                    None => {
+                        return Ok(Some((stms, ReturnedCall::Never)));
+                    }
+                };
                 exps.push((e0, arg.typ.clone()));
             }
             let has_ret = get_function(ctx, expr, x)?.x.has_return();
-            Ok(Some((stms, x.clone(), typs.clone(), has_ret, Arc::new(exps))))
+            Ok(Some((
+                stms,
+                ReturnedCall::Call {
+                    fun: x.clone(),
+                    typs: typs.clone(),
+                    has_return: has_ret,
+                    args: Arc::new(exps),
+                },
+            )))
         }
         _ => Ok(None),
     }
@@ -194,7 +286,7 @@ fn expr_must_be_call_stm(
     ctx: &Ctx,
     state: &mut State,
     expr: &Expr,
-) -> Result<Option<(Vec<Stm>, Fun, Typs, bool, Args)>, VirErr> {
+) -> Result<Option<(Vec<Stm>, ReturnedCall)>, VirErr> {
     match &expr.x {
         ExprX::Call(CallTarget::Static(x, _), _) if !function_can_be_exp(ctx, expr, x)? => {
             expr_get_call(ctx, state, expr)
@@ -203,8 +295,8 @@ fn expr_must_be_call_stm(
     }
 }
 
-pub(crate) fn expr_to_exp_state(ctx: &Ctx, state: &mut State, expr: &Expr) -> Result<Exp, VirErr> {
-    let (stms, exp) = expr_to_stm(ctx, state, expr)?;
+pub(crate) fn expr_to_pure_exp(ctx: &Ctx, state: &mut State, expr: &Expr) -> Result<Exp, VirErr> {
+    let (stms, exp) = expr_to_stm_or_error(ctx, state, expr)?;
     if stms.len() == 0 {
         Ok(exp)
     } else {
@@ -225,7 +317,7 @@ pub(crate) fn expr_to_decls_exp(
             state.declare_new_var(&param.x.name, &param.x.typ, false, false);
         }
     }
-    let exp = expr_to_exp_state(ctx, &mut state, expr)?;
+    let exp = expr_to_pure_exp(ctx, &mut state, expr)?;
     let exp = state.finalize_exp(&exp);
     state.finalize();
     Ok((state.local_decls, exp))
@@ -237,7 +329,7 @@ pub(crate) fn expr_to_bind_decls_exp(ctx: &Ctx, params: &Pars, expr: &Expr) -> R
         let id = state.declare_new_var(&param.x.name, &param.x.typ, false, false);
         state.dont_rename.insert(id);
     }
-    let exp = expr_to_exp_state(ctx, &mut state, expr)?;
+    let exp = expr_to_pure_exp(ctx, &mut state, expr)?;
     let exp = state.finalize_exp(&exp);
     state.finalize();
     Ok(exp)
@@ -251,17 +343,34 @@ pub(crate) fn expr_to_exp_as_spec(ctx: &Ctx, params: &Pars, expr: &Expr) -> Resu
     Ok(expr_to_decls_exp(ctx, true, params, expr)?.1)
 }
 
-pub(crate) fn expr_to_stm(
+/// Convert an expr to (Vec<Stm>, Exp).
+/// Errors if the given expression is one that never returns a value.
+/// (This should only be used in contexts where that should never happen, like spec
+/// contexts. Otherwise, call `expr_to_stm_opt` and handle the Never case).
+
+pub(crate) fn expr_to_stm_or_error(
     ctx: &Ctx,
     state: &mut State,
     expr: &Expr,
 ) -> Result<(Vec<Stm>, Exp), VirErr> {
     let (stms, exp_opt) = expr_to_stm_opt(ctx, state, expr)?;
-    if let Some(exp) = exp_opt {
-        Ok((stms, exp))
-    } else {
-        err_str(&expr.span, "expression must produce a value")
+    match exp_opt.to_value() {
+        Some(e) => Ok((stms, e)),
+        None => err_str(&expr.span, "expression must produce a value"),
     }
+}
+
+/// Unit type, in the lowered form that ast_simplify produces
+fn lowered_unit_typ() -> Typ {
+    let path = crate::def::prefix_tuple_type(0);
+    Arc::new(TypX::Datatype(path, Arc::new(vec![])))
+}
+
+/// Unit value, in the lowered form that ast_simplify produces
+fn lowered_unit_value(span: &Span) -> Exp {
+    let datatype = crate::def::prefix_tuple_type(0);
+    let variant = crate::def::prefix_tuple_variant(0);
+    SpannedTyped::new(span, &lowered_unit_typ(), ExpX::Ctor(datatype, variant, Arc::new(vec![])))
 }
 
 pub(crate) fn stms_to_one_stm(span: &Span, stms: Vec<Stm>) -> Stm {
@@ -272,10 +381,15 @@ pub(crate) fn stms_to_one_stm(span: &Span, stms: Vec<Stm>) -> Stm {
     }
 }
 
-fn check_no_exp(exp: &Option<Exp>) -> Result<(), VirErr> {
+pub(crate) fn stms_to_one_stm_opt(span: &Span, stms: Vec<Stm>) -> Option<Stm> {
+    if stms.len() == 0 { None } else { Some(stms_to_one_stm(span, stms)) }
+}
+
+fn check_unit_or_never(exp: &ReturnValue) -> Result<(), VirErr> {
     match exp {
-        None => Ok(()),
-        Some(exp) => match &exp.x {
+        ReturnValue::ImplicitUnit(_) => Ok(()),
+        ReturnValue::Never => Ok(()),
+        ReturnValue::Some(exp) => match &exp.x {
             ExpX::Var((x, _)) if crate::def::is_temp_var(x) => Ok(()),
             // REVIEW: we could lift this restriction by putting exp into a dummy VIR node:
             // (we can't just drop it; the erasure depends on information from VIR)
@@ -284,24 +398,47 @@ fn check_no_exp(exp: &Option<Exp>) -> Result<(), VirErr> {
     }
 }
 
-pub(crate) fn expr_to_one_stm(ctx: &Ctx, state: &mut State, expr: &Expr) -> Result<Stm, VirErr> {
-    let (stms, exp) = expr_to_stm_opt(ctx, state, expr)?;
-    check_no_exp(&exp)?;
-    Ok(stms_to_one_stm(&expr.span, stms))
-}
-
 pub(crate) fn expr_to_one_stm_dest(
     ctx: &Ctx,
     state: &mut State,
     expr: &Expr,
     dest: &Option<UniqueIdent>,
+    enss: &Vec<Exp>,
 ) -> Result<Stm, VirErr> {
     let (mut stms, exp) = expr_to_stm_opt(ctx, state, expr)?;
-    match (dest, exp) {
-        (None, _) => {}
-        (Some(_), None) => return err_str(&expr.span, "expression must produce a value"),
-        (Some(dest), Some(exp)) => {
-            stms.push(init_var(&expr.span, &dest, &exp));
+    match exp.to_value() {
+        Some(e) => {
+            // Add assertions for the post-conditions.
+            if let Some(dest) = dest {
+                stms.push(init_var(&expr.span, &dest, &e));
+            }
+            for ens in enss {
+                let error = error_with_label(
+                    "postcondition not satisfied".to_string(),
+                    &expr.span,
+                    "at the end of the function body".to_string(),
+                )
+                .secondary_label(&ens.span, "failed this postcondition".to_string());
+
+                stms.push(Spanned::new(expr.span.clone(), StmX::Assert(Some(error), ens.clone())));
+            }
+        }
+        None => {
+            // Program execution never gets to this point, so we don't need to check
+            // any postconditions.
+            // This might happen, for example, if the user writes their code in this style:
+            //
+            //    fn foo() {
+            //        ...
+            //        return x;
+            //    }
+            //
+            // Here, we will always process the post-conditions when we get to the `return`
+            // statement, but technically, the return statement is still an "early return"
+            // and we never actually get to "the end" of the function.
+            // Anyway, the point is, we don't need to check the postconditions again
+            // in that case, or in any other case where we never reach the end of the
+            // function.
         }
     }
     Ok(stms_to_one_stm(&expr.span, stms))
@@ -349,42 +486,104 @@ fn stm_call(
 fn if_to_stm(
     state: &mut State,
     expr: &Expr,
-    stms0: &mut Vec<Stm>,
-    e0: Exp,
+    mut stms0: Vec<Stm>,
+    e0: &ReturnValue,
     mut stms1: Vec<Stm>,
-    e1: &Exp,
+    e1: &ReturnValue,
     mut stms2: Vec<Stm>,
-    e2: &Exp,
-) -> Exp {
-    // If statement, put results from e1/e2 in a temp variable, return temp variable
-    let (temp, temp_var) = state.next_temp(&expr.span, &expr.typ);
-    let temp_id = state.declare_new_var(&temp, &expr.typ, false, false);
-    // if e0 { stms1; temp = e1; } else { stms2; temp = e2; }
-    stms1.push(init_var(&expr.span, &temp_id, &e1));
-    stms2.push(init_var(&expr.span, &temp_id, &e2));
-    let stm1 = stms_to_one_stm(&expr.span, stms1);
-    let stm2 = stms_to_one_stm(&expr.span, stms2);
-    let if_stmt = StmX::If(e0, stm1, Some(stm2));
-    stms0.push(Spanned::new(expr.span.clone(), if_stmt));
-    // temp
-    temp_var
+    e2: &ReturnValue,
+) -> (Vec<Stm>, ReturnValue) {
+    let e0 = match e0.clone().to_value() {
+        Some(e) => e,
+        None => {
+            return (stms0, ReturnValue::Never);
+        }
+    };
+
+    match (e1, e2) {
+        (ReturnValue::ImplicitUnit(_), _) | (_, ReturnValue::ImplicitUnit(_)) => {
+            // If one branch returned an implicit unit, then the other branch
+            // must also return a unit (either implicit or explicit).
+            // If this sanity check fails, then it's likely we screwed up and
+            // the alleged implicit unit branch was actually a never-return.
+            assert!(types_equal(&expr.typ, &lowered_unit_typ()));
+
+            let stm1 = stms_to_one_stm(&expr.span, stms1);
+            let stm2 = stms_to_one_stm_opt(&expr.span, stms2);
+            let if_stmt = StmX::If(e0, stm1, stm2);
+            stms0.push(Spanned::new(expr.span.clone(), if_stmt));
+            (stms0, ReturnValue::ImplicitUnit(expr.span.clone()))
+        }
+        (ReturnValue::Never, other) | (other, ReturnValue::Never) => {
+            // Suppose one side never returns; the return value of the conditional
+            // (assuming it DOES return) will always be the one from the other branch.
+            // (Of course, the other branch might be 'Never' too, in which case the
+            // return value of the whole expression is Never.)
+            //
+            // For example, if we have:
+            //    let t = if cond { 5 } else { return; };
+            // Then we get Some(5) from the left branch, and Never from the right branch.
+            // Furthermore, for the purposes of assigning to `t`, we can assume the return
+            // value of the branch is _always_ 5.
+
+            let stm1 = stms_to_one_stm(&expr.span, stms1);
+            let stm2 = stms_to_one_stm_opt(&expr.span, stms2);
+            let if_stmt = StmX::If(e0, stm1, stm2);
+            stms0.push(Spanned::new(expr.span.clone(), if_stmt));
+            (stms0, other.clone())
+        }
+        (ReturnValue::Some(e1), ReturnValue::Some(e2)) => {
+            if stms1.len() == 0 && stms2.len() == 0 {
+                // In this case, we can construct a pure expression.
+                let expx = ExpX::If(e0.clone(), e1.clone(), e2.clone());
+                let exp = SpannedTyped::new(&expr.span, &expr.typ, expx);
+                (vec![], ReturnValue::Some(exp))
+            } else {
+                // We have `if ( stms0; e0 ) { stms1; e1 } else { stms2; e2 }`.
+                // We turn this into:
+                //  stms0; if e0 { stms1 } else { stms2 };
+                //  if e0 { e1 } else { e2 }
+
+                // If statement, put results from e1/e2 in a temp variable, return temp variable
+                let (temp, temp_var) = state.next_temp(&expr.span, &expr.typ);
+                let temp_id = state.declare_new_var(&temp, &expr.typ, false, false);
+                // if e0 { stms1; temp = e1; } else { stms2; temp = e2; }
+                stms1.push(init_var(&expr.span, &temp_id, &e1));
+                stms2.push(init_var(&expr.span, &temp_id, &e2));
+                let stm1 = stms_to_one_stm(&expr.span, stms1);
+                let stm2 = stms_to_one_stm_opt(&expr.span, stms2);
+                let if_stmt = StmX::If(e0, stm1, stm2);
+                stms0.push(Spanned::new(expr.span.clone(), if_stmt));
+                // temp
+                (stms0, ReturnValue::Some(temp_var))
+            }
+        }
+    }
 }
 
-pub(crate) fn expr_to_stm_opt(
+/// Convert a VIR Expr to a SST (Vec<Stm>, ReturnValue), i.e., instructions of the form,
+/// "run these statements, then return this side-effect-free expression".
+///
+/// Note the 'ReturnValue' can be one of three things:
+///  * Some(e) - means the expression e was returned
+///  * Unit - for the implicit unit case
+///  * Never - the expression can never return (e.g., after a return value or break)
+
+fn expr_to_stm_opt(
     ctx: &Ctx,
     state: &mut State,
     expr: &Expr,
-) -> Result<(Vec<Stm>, Option<Exp>), VirErr> {
+) -> Result<(Vec<Stm>, ReturnValue), VirErr> {
     let mk_exp = |expx: ExpX| SpannedTyped::new(&expr.span, &expr.typ, expx);
     match &expr.x {
-        ExprX::Const(c) => Ok((vec![], Some(mk_exp(ExpX::Const(c.clone()))))),
+        ExprX::Const(c) => Ok((vec![], ReturnValue::Some(mk_exp(ExpX::Const(c.clone()))))),
         ExprX::Var(x) => {
             let unique_id = state.get_var_unique_id(&x);
-            Ok((vec![], Some(mk_exp(ExpX::Var(unique_id)))))
+            Ok((vec![], ReturnValue::Some(mk_exp(ExpX::Var(unique_id)))))
         }
         ExprX::VarLoc(x) => {
             let unique_id = state.get_var_unique_id(&x);
-            Ok((vec![], Some(mk_exp(ExpX::VarLoc(unique_id)))))
+            Ok((vec![], ReturnValue::Some(mk_exp(ExpX::VarLoc(unique_id)))))
         }
         ExprX::VarAt(x, VarAt::Pre) => {
             if let Some((scope, _)) = state.rename_map.scope_and_index_of_key(x) {
@@ -392,12 +591,16 @@ pub(crate) fn expr_to_stm_opt(
                     err_str(&expr.span, "the parameter is shadowed here")?;
                 }
             }
-            Ok((vec![], Some(mk_exp(ExpX::VarAt(state.get_var_unique_id(&x), VarAt::Pre)))))
+            Ok((
+                vec![],
+                ReturnValue::Some(mk_exp(ExpX::VarAt(state.get_var_unique_id(&x), VarAt::Pre))),
+            ))
         }
         ExprX::ConstVar(..) => panic!("ConstVar should already be removed"),
         ExprX::Loc(expr1) => {
-            let (stms, e0) = expr_to_stm(ctx, state, expr1)?;
-            Ok((stms, Some(mk_exp(ExpX::Loc(e0)))))
+            let (stms, e0) = expr_to_stm_opt(ctx, state, expr1)?;
+            let e0 = unwrap_or_return_never!(e0, stms);
+            Ok((stms, ReturnValue::Some(mk_exp(ExpX::Loc(e0)))))
         }
         ExprX::Assign { init_not_mut, lhs: expr1, rhs: expr2 } => {
             let dest_x = match &expr1.x {
@@ -405,46 +608,59 @@ pub(crate) fn expr_to_stm_opt(
                 _ => err_str(&expr1.span, "complex assignments not yet supported"),
             };
             match expr_must_be_call_stm(ctx, state, expr2)? {
-                Some((mut stms2, func_path, typs, _, args)) => {
+                Some((stms2, ReturnedCall::Never)) => Ok((stms2, ReturnValue::Never)),
+                Some((mut stms2, ReturnedCall::Call { fun, typs, has_return: _, args })) => {
                     // make a Call
                     let dest = Dest { var: dest_x?.clone(), is_init: *init_not_mut };
-                    stms2.push(stm_call(state, &expr.span, func_path, typs, args, Some(dest)));
-                    Ok((stms2, None))
+                    stms2.push(stm_call(state, &expr.span, fun, typs, args, Some(dest)));
+                    Ok((stms2, ReturnValue::ImplicitUnit(expr.span.clone())))
                 }
                 None => {
                     // make an Assign
-                    let (mut stms2, e2) = expr_to_stm(ctx, state, expr2)?;
+                    let (mut stms2, e2) = expr_to_stm_opt(ctx, state, expr2)?;
+                    let e2 = unwrap_or_return_never!(e2, stms2);
                     let assign = StmX::Assign { lhs: dest_x?, rhs: e2, is_init: *init_not_mut };
                     stms2.push(Spanned::new(expr.span.clone(), assign));
-                    Ok((stms2, None))
+                    Ok((stms2, ReturnValue::ImplicitUnit(expr.span.clone())))
                 }
             }
         }
         ExprX::Call(CallTarget::FnSpec(e0), args) => {
-            let e0 = expr_to_exp_state(ctx, state, e0)?;
-            let args = Arc::new(vec_map_result(args, |e| expr_to_exp_state(ctx, state, e))?);
+            let e0 = expr_to_pure_exp(ctx, state, e0)?;
+            let args = Arc::new(vec_map_result(args, |e| expr_to_pure_exp(ctx, state, e))?);
             let call = ExpX::CallLambda(expr.typ.clone(), e0, args);
-            Ok((vec![], Some(mk_exp(call))))
+            Ok((vec![], ReturnValue::Some(mk_exp(call))))
         }
         ExprX::Call(CallTarget::Static(..), _) => {
-            let (mut stms, x, typs, ret, args) = expr_get_call(ctx, state, expr)?.expect("Call");
-            if function_can_be_exp(ctx, expr, &x)? {
-                // ExpX::Call
-                let args = Arc::new(vec_map(&args, |(a, _)| a.clone()));
-                let call = ExpX::Call(x.clone(), typs.clone(), args);
-                Ok((stms, Some(mk_exp(call))))
-            } else if ret {
-                let (temp, temp_var) = state.next_temp(&expr.span, &expr.typ);
-                state.declare_new_var(&temp, &expr.typ, false, false);
-                // tmp = StmX::Call;
-                let dest = Dest { var: (temp.clone(), Some(0)), is_init: true };
-                stms.push(stm_call(state, &expr.span, x.clone(), typs.clone(), args, Some(dest)));
-                // tmp
-                Ok((stms, Some(temp_var)))
-            } else {
-                // StmX::Call
-                stms.push(stm_call(state, &expr.span, x.clone(), typs.clone(), args, None));
-                Ok((stms, None))
+            match expr_get_call(ctx, state, expr)?.expect("Call") {
+                (stms, ReturnedCall::Never) => Ok((stms, ReturnValue::Never)),
+                (mut stms, ReturnedCall::Call { fun: x, typs, has_return: ret, args }) => {
+                    if function_can_be_exp(ctx, expr, &x)? {
+                        // ExpX::Call
+                        let args = Arc::new(vec_map(&args, |(a, _)| a.clone()));
+                        let call = ExpX::Call(x.clone(), typs.clone(), args);
+                        Ok((stms, ReturnValue::Some(mk_exp(call))))
+                    } else if ret {
+                        let (temp, temp_var) = state.next_temp(&expr.span, &expr.typ);
+                        state.declare_new_var(&temp, &expr.typ, false, false);
+                        // tmp = StmX::Call;
+                        let dest = Dest { var: (temp.clone(), Some(0)), is_init: true };
+                        stms.push(stm_call(
+                            state,
+                            &expr.span,
+                            x.clone(),
+                            typs.clone(),
+                            args,
+                            Some(dest),
+                        ));
+                        // tmp
+                        Ok((stms, ReturnValue::Some(temp_var)))
+                    } else {
+                        // StmX::Call
+                        stms.push(stm_call(state, &expr.span, x.clone(), typs.clone(), args, None));
+                        Ok((stms, ReturnValue::ImplicitUnit(expr.span.clone())))
+                    }
+                }
             }
         }
         ExprX::Tuple(_) => {
@@ -455,32 +671,40 @@ pub(crate) fn expr_to_stm_opt(
             let mut stms: Vec<Stm> = Vec::new();
             let mut args: Vec<Binder<Exp>> = Vec::new();
             for binder in binders.iter() {
-                let (mut stms1, e1) = expr_to_stm(ctx, state, &binder.a)?;
+                let (mut stms1, e1) = expr_to_stm_opt(ctx, state, &binder.a)?;
                 stms.append(&mut stms1);
+                let e1 = unwrap_or_return_never!(e1, stms);
                 let arg = BinderX { name: binder.name.clone(), a: e1 };
                 args.push(Arc::new(arg));
             }
             let ctor = ExpX::Ctor(p.clone(), i.clone(), Arc::new(args));
-            Ok((stms, Some(mk_exp(ctor))))
+            Ok((stms, ReturnValue::Some(mk_exp(ctor))))
         }
         ExprX::Unary(op, expr) => {
-            let (stms, exp) = expr_to_stm(ctx, state, expr)?;
-            Ok((stms, Some(mk_exp(ExpX::Unary(*op, exp)))))
+            let (stms, exp) = expr_to_stm_opt(ctx, state, expr)?;
+            let exp = unwrap_or_return_never!(exp, stms);
+            Ok((stms, ReturnValue::Some(mk_exp(ExpX::Unary(*op, exp)))))
         }
         ExprX::UnaryOpr(op, expr) => {
-            let (stms, exp) = expr_to_stm(ctx, state, expr)?;
-            Ok((stms, Some(mk_exp(ExpX::UnaryOpr(op.clone(), exp)))))
+            let (stms, exp) = expr_to_stm_opt(ctx, state, expr)?;
+            let exp = unwrap_or_return_never!(exp, stms);
+            Ok((stms, ReturnValue::Some(mk_exp(ExpX::UnaryOpr(op.clone(), exp)))))
         }
         ExprX::Binary(op, e1, e2) => {
+            // Handle short-circuiting, when applicable.
+            // The pair (proceed_on, other) means:
+            // If e1 evaluates to `proceed_on`, then evaluate and
+            // return e2; otherwise, return the value `other`
+            // (without evaluating `e2`).
             let short_circuit = match op {
                 BinaryOp::And => Some((true, false)),
                 BinaryOp::Implies => Some((true, true)),
                 BinaryOp::Or => Some((false, true)),
                 _ => None,
             };
-            let (mut stms1, e1) = expr_to_stm(ctx, state, e1)?;
-            let (mut stms2, e2) = expr_to_stm(ctx, state, e2)?;
-            let bin = match (short_circuit, stms2.len()) {
+            let (mut stms1, e1) = expr_to_stm_opt(ctx, state, e1)?;
+            let (mut stms2, e2) = expr_to_stm_opt(ctx, state, e2)?;
+            match (short_circuit, stms2.len()) {
                 (Some((proceed_on, other)), n) if n > 0 => {
                     // and:
                     //   if e1 { stmts2; e2 } else { false }
@@ -490,56 +714,57 @@ pub(crate) fn expr_to_stm_opt(
                     //   if e1 { true } else { stmts2; e2 }
                     let bx = ExpX::Const(Constant::Bool(other));
                     let b = SpannedTyped::new(&expr.span, &Arc::new(TypX::Bool), bx);
+                    let b = ReturnValue::Some(b);
                     if proceed_on {
-                        let temp_var =
-                            if_to_stm(state, expr, &mut stms1, e1, stms2, &e2, vec![], &b);
-                        temp_var
+                        Ok(if_to_stm(state, expr, stms1, &e1, stms2, &e2, vec![], &b))
                     } else {
-                        let temp_var =
-                            if_to_stm(state, expr, &mut stms1, e1, vec![], &b, stms2, &e2);
-                        temp_var
+                        Ok(if_to_stm(state, expr, stms1, &e1, vec![], &b, stms2, &e2))
                     }
                 }
                 _ => {
+                    let e1 = unwrap_or_return_never!(e1, stms1);
                     stms1.append(&mut stms2);
-                    mk_exp(ExpX::Binary(*op, e1, e2.clone()))
-                }
-            };
-            if let BinaryOp::Arith(arith, inferred_mode) = op {
-                // Insert bounds check
-                match (state.view_as_spec, ctx.global.inferred_modes[inferred_mode], &*expr.typ) {
-                    (true, _, _) => {}
-                    (_, Mode::Spec, _) => {}
-                    (_, _, TypX::Int(IntRange::U(_) | IntRange::I(_))) => {
-                        let (assert_exp, msg) = match arith {
-                            ArithOp::Add | ArithOp::Sub | ArithOp::Mul => {
-                                let unary = UnaryOpr::HasType(expr.typ.clone());
-                                let has_type = ExpX::UnaryOpr(unary, bin.clone());
-                                let has_type =
-                                    SpannedTyped::new(&expr.span, &Arc::new(TypX::Bool), has_type);
-                                (has_type, "possible arithmetic underflow/overflow")
+                    let e2 = unwrap_or_return_never!(e2, stms1);
+                    let bin = mk_exp(ExpX::Binary(*op, e1, e2));
+
+                    if let BinaryOp::Arith(arith, inferred_mode) = op {
+                        // Insert bounds check
+                        match (state.view_as_spec, ctx.global.inferred_modes[inferred_mode], &*expr.typ) {
+                            (true, _, _) => {}
+                            (_, Mode::Spec, _) => {}
+                            (_, _, TypX::Int(IntRange::U(_) | IntRange::I(_))) => {
+                                let (assert_exp, msg) = match arith {
+                                    ArithOp::Add | ArithOp::Sub | ArithOp::Mul => {
+                                        let unary = UnaryOpr::HasType(expr.typ.clone());
+                                        let has_type = ExpX::UnaryOpr(unary, bin.clone());
+                                        let has_type =
+                                            SpannedTyped::new(&expr.span, &Arc::new(TypX::Bool), has_type);
+                                        (has_type, "possible arithmetic underflow/overflow")
+                                    }
+                                    ArithOp::EuclideanDiv | ArithOp::EuclideanMod => {
+                                        let zero = ExpX::Const(Constant::Nat(Arc::new("0".to_string())));
+                                        let ne = ExpX::Binary(BinaryOp::Ne, e2.clone(), e2.new_x(zero));
+                                        let ne = SpannedTyped::new(&expr.span, &Arc::new(TypX::Bool), ne);
+                                        (ne, "possible division by zero")
+                                    }
+                                };
+                                let error = air::errors::error(msg, &expr.span);
+                                let assert = StmX::Assert(Some(error), assert_exp);
+                                let assert = Spanned::new(expr.span.clone(), assert);
+                                stms1.push(assert);
                             }
-                            ArithOp::EuclideanDiv | ArithOp::EuclideanMod => {
-                                let zero = ExpX::Const(Constant::Nat(Arc::new("0".to_string())));
-                                let ne = ExpX::Binary(BinaryOp::Ne, e2.clone(), e2.new_x(zero));
-                                let ne = SpannedTyped::new(&expr.span, &Arc::new(TypX::Bool), ne);
-                                (ne, "possible division by zero")
-                            }
-                        };
-                        let error = air::errors::error(msg, &expr.span);
-                        let assert = StmX::Assert(Some(error), assert_exp);
-                        let assert = Spanned::new(expr.span.clone(), assert);
-                        stms1.push(assert);
+                            _ => {}
+                        }
                     }
-                    _ => {}
+
+                    Ok((stms1, ReturnValue::Some(bin)))
                 }
             }
-            Ok((stms1, Some(bin)))
         }
         ExprX::Quant(quant, binders, body) => {
             state.push_scope();
             state.declare_binders(binders);
-            let exp = expr_to_exp_state(ctx, state, body)?;
+            let exp = expr_to_pure_exp(ctx, state, body)?;
             state.pop_scope();
             let mut vars: Vec<Ident> = Vec::new();
             for b in binders.iter() {
@@ -550,12 +775,12 @@ pub(crate) fn expr_to_stm_opt(
             }
             let trigs = crate::triggers::build_triggers(ctx, &expr.span, &vars, &exp)?;
             let bnd = Spanned::new(body.span.clone(), BndX::Quant(*quant, binders.clone(), trigs));
-            Ok((vec![], Some(mk_exp(ExpX::Bind(bnd, exp)))))
+            Ok((vec![], ReturnValue::Some(mk_exp(ExpX::Bind(bnd, exp)))))
         }
         ExprX::Closure(params, body) => {
             state.push_scope();
             state.declare_binders(params);
-            let mut exp = expr_to_exp_state(ctx, state, body)?;
+            let mut exp = expr_to_pure_exp(ctx, state, body)?;
             state.pop_scope();
 
             // Parameters and return types must be boxed, so insert necessary box/unboxing
@@ -591,32 +816,30 @@ pub(crate) fn expr_to_stm_opt(
             }
 
             let bnd = Spanned::new(body.span.clone(), BndX::Lambda(Arc::new(boxed_params)));
-            Ok((vec![], Some(mk_exp(ExpX::Bind(bnd, exp)))))
+            Ok((vec![], ReturnValue::Some(mk_exp(ExpX::Bind(bnd, exp)))))
         }
         ExprX::Choose { params, cond, body } => {
             state.push_scope();
             state.declare_binders(&params);
-            let cond_exp = expr_to_exp_state(ctx, state, cond)?;
-            let body_exp = expr_to_exp_state(ctx, state, body)?;
+            let cond_exp = expr_to_pure_exp(ctx, state, cond)?;
+            let body_exp = expr_to_pure_exp(ctx, state, body)?;
             state.pop_scope();
             let vars = vec_map(params, |p| p.name.clone());
             let trigs = crate::triggers::build_triggers(ctx, &expr.span, &vars, &cond_exp)?;
             let bnd =
                 Spanned::new(body.span.clone(), BndX::Choose(params.clone(), trigs, cond_exp));
-            Ok((vec![], Some(mk_exp(ExpX::Bind(bnd, body_exp)))))
+            Ok((vec![], ReturnValue::Some(mk_exp(ExpX::Bind(bnd, body_exp)))))
         }
         ExprX::Fuel(x, fuel) => {
             let stm = Spanned::new(expr.span.clone(), StmX::Fuel(x.clone(), *fuel));
-            Ok((vec![stm], None))
+            Ok((vec![stm], ReturnValue::ImplicitUnit(expr.span.clone())))
         }
         ExprX::Header(_) => {
             return err_str(&expr.span, "header expression not allowed here");
         }
         ExprX::Admit => {
-            let expx = ExpX::Const(Constant::Bool(false));
-            let exp = SpannedTyped::new(&expr.span, &Arc::new(TypX::Bool), expx);
-            let stm = Spanned::new(expr.span.clone(), StmX::Assume(exp));
-            Ok((vec![stm], None))
+            let stm = assume_false(&expr.span);
+            Ok((vec![stm], ReturnValue::ImplicitUnit(expr.span.clone())))
         }
         ExprX::Forall { vars, require, ensure, proof } => {
             // deadend {
@@ -640,14 +863,14 @@ pub(crate) fn expr_to_stm_opt(
                 body.push(assume);
             }
             let (mut proof_stms, e) = expr_to_stm_opt(ctx, state, proof)?;
-            if let Some(_) = e {
+            if let ReturnValue::Some(_) = e {
                 return err_str(&expr.span, "forall/assert-by cannot end with an expression");
             }
-            let require_exp = expr_to_exp_state(ctx, state, &require)?;
+            let require_exp = expr_to_pure_exp(ctx, state, &require)?;
             let assume = Spanned::new(require.span.clone(), StmX::Assume(require_exp));
             body.push(assume);
             body.append(&mut proof_stms);
-            let ensure_exp = expr_to_exp_state(ctx, state, &ensure)?;
+            let ensure_exp = expr_to_pure_exp(ctx, state, &ensure)?;
             let assert = Spanned::new(ensure.span.clone(), StmX::Assert(None, ensure_exp));
             body.push(assert);
             let block = Spanned::new(expr.span.clone(), StmX::Block(Arc::new(body)));
@@ -660,57 +883,50 @@ pub(crate) fn expr_to_stm_opt(
             let imply = SpannedTyped::new(&ensure.span, &Arc::new(TypX::Bool), implyx);
             let forallx = ExprX::Quant(Quant::Forall, vars.clone(), imply);
             let forall = SpannedTyped::new(&ensure.span, &Arc::new(TypX::Bool), forallx);
-            let forall_exp = expr_to_exp_state(ctx, state, &forall)?;
+            let forall_exp = expr_to_pure_exp(ctx, state, &forall)?;
             let assume = Spanned::new(ensure.span.clone(), StmX::Assume(forall_exp));
             stms.push(assume);
-            Ok((stms, None))
+            Ok((stms, ReturnValue::ImplicitUnit(expr.span.clone())))
         }
         ExprX::AssertBV(e) => {
-            let expr = expr_to_exp_state(ctx, state, &e)?;
+            let expr = expr_to_pure_exp(ctx, state, &e)?;
+            let ret = ReturnValue::ImplicitUnit(expr.span.clone());
             let assert = Spanned::new(e.span.clone(), StmX::AssertBV(expr));
-            Ok((vec![assert], None))
+            Ok((vec![assert], ret))
         }
-        ExprX::If(e0, e1, None) => {
-            let (mut stms0, e0) = expr_to_stm(ctx, state, e0)?;
-            let stms1 = expr_to_one_stm(ctx, state, e1)?;
-            stms0.push(Spanned::new(expr.span.clone(), StmX::If(e0, stms1, None)));
-            Ok((stms0, None))
+        ExprX::If(expr0, expr1, None) => {
+            let (stms0, e0) = expr_to_stm_opt(ctx, state, expr0)?;
+            let (stms1, e1) = expr_to_stm_opt(ctx, state, expr1)?;
+            let stms2 = vec![];
+            let e2 = ReturnValue::ImplicitUnit(expr.span.clone());
+            Ok(if_to_stm(state, expr, stms0, &e0, stms1, &e1, stms2, &e2))
         }
         ExprX::If(expr0, expr1, Some(expr2)) => {
-            let (mut stms0, e0) = expr_to_stm(ctx, state, expr0)?;
+            let (stms0, e0) = expr_to_stm_opt(ctx, state, expr0)?;
             let (stms1, e1) = expr_to_stm_opt(ctx, state, expr1)?;
             let (stms2, e2) = expr_to_stm_opt(ctx, state, expr2)?;
-            match (e1, e2) {
-                (Some(e1), Some(e2)) if stms1.len() == 0 && stms2.len() == 0 => {
-                    // If expression
-                    Ok((stms0, Some(mk_exp(ExpX::If(e0, e1, e2)))))
-                }
-                (Some(e1), Some(e2)) => {
-                    // If statement, put results from e1/e2 in a temp variable, return temp variable
-                    let temp_var = if_to_stm(state, expr, &mut stms0, e0, stms1, &e1, stms2, &e2);
-                    Ok((stms0, Some(temp_var)))
-                }
-                (None, None) => {
-                    // If statement, let expression be None
-                    let stm1 = stms_to_one_stm(&expr1.span, stms1);
-                    let stm2 = stms_to_one_stm(&expr2.span, stms2);
-                    stms0.push(Spanned::new(expr.span.clone(), StmX::If(e0, stm1, Some(stm2))));
-                    Ok((stms0, None))
-                }
-                _ => err_str(
-                    &expr.span,
-                    "if any if/match arm returns a value, all arms must return a value",
-                ),
-            }
+            Ok(if_to_stm(state, expr, stms0, &e0, stms1, &e1, stms2, &e2))
         }
         ExprX::Match(..) => {
             panic!("internal error: Match should have been simplified by ast_simplify")
         }
         ExprX::While { cond, body, invs } => {
-            let (stms0, e0) = expr_to_stm(ctx, state, cond)?;
+            let (stms0, e0) = expr_to_stm_opt(ctx, state, cond)?;
+            let e0 = match e0 {
+                ReturnValue::Some(e0) => e0,
+                ReturnValue::ImplicitUnit(_) => {
+                    panic!("while loop condition doesn't return a bool expression");
+                }
+                ReturnValue::Never => {
+                    // If the condition never returns (which would be odd, but it
+                    // could happen) then the body of the while loop never gets to go at all.
+                    return Ok((stms0, ReturnValue::Never));
+                }
+            };
+
             let (stms1, e1) = expr_to_stm_opt(ctx, state, body)?;
-            check_no_exp(&e1)?;
-            let invs = Arc::new(vec_map_result(invs, |e| expr_to_exp_state(ctx, state, e))?);
+            check_unit_or_never(&e1)?;
+            let invs = Arc::new(vec_map_result(invs, |e| expr_to_pure_exp(ctx, state, e))?);
             let while_stm = Spanned::new(
                 expr.span.clone(),
                 StmX::While {
@@ -722,11 +938,18 @@ pub(crate) fn expr_to_stm_opt(
                     modified_vars: Arc::new(vec![]),
                 },
             );
-            Ok((vec![while_stm], None))
+            if can_control_flow_reach_after_loop(expr) {
+                let ret = ReturnValue::ImplicitUnit(expr.span.clone());
+                Ok((vec![while_stm], ret))
+            } else {
+                let stms = vec![while_stm, assume_false(&expr.span)];
+                Ok((stms, ReturnValue::Never))
+            }
         }
         ExprX::OpenInvariant(inv, binder, body, atomicity) => {
             // Evaluate `inv`
-            let (mut stms0, big_inv_exp) = expr_to_stm(ctx, state, inv)?;
+            let (mut stms0, big_inv_exp) = expr_to_stm_opt(ctx, state, inv)?;
+            let big_inv_exp = unwrap_or_return_never!(big_inv_exp, stms0);
 
             // Assign it to a constant temp variable to ensure it is constant
             // across the entire block.
@@ -743,15 +966,19 @@ pub(crate) fn expr_to_stm_opt(
                 /* mutable */ true,
                 /* maybe_need_rename */ true,
             );
-            let body_stm = expr_to_one_stm(ctx, state, body)?;
+            let (body_stms, body_e) = expr_to_stm_opt(ctx, state, body)?;
             state.pop_scope();
 
+            check_unit_or_never(&body_e)?;
+
+            let body_stm = stms_to_one_stm(&expr.span, body_stms);
             stms0.push(Spanned::new(
                 expr.span.clone(),
                 StmX::OpenInvariant(temp_var, ident, binder.a.clone(), body_stm, *atomicity),
             ));
 
-            return Ok((stms0, None));
+            let _body_e = unwrap_or_return_never!(body_e, stms0);
+            return Ok((stms0, ReturnValue::ImplicitUnit(expr.span.clone())));
         }
         ExprX::Return(e1) => {
             if let Some((ret_dest, enss)) = state.ret_post.clone() {
@@ -761,7 +988,8 @@ pub(crate) fn expr_to_stm_opt(
                     (None, Some(e)) => return err_str(&e.span, "return value not allowed here"),
                     (_, None) => panic!("internal error: return value expected"),
                     (Some(dest), Some(e1)) => {
-                        let (mut ret_stms, exp) = expr_to_stm(ctx, state, e1)?;
+                        let (mut ret_stms, exp) = expr_to_stm_opt(ctx, state, e1)?;
+                        let exp = unwrap_or_return_never!(exp, ret_stms);
                         stms.append(&mut ret_stms);
                         stms.push(init_var(&expr.span, &dest, &exp));
                     }
@@ -778,10 +1006,8 @@ pub(crate) fn expr_to_stm_opt(
                         StmX::Assert(Some(error), ens.clone()),
                     ));
                 }
-                let expx = ExpX::Const(Constant::Bool(false));
-                let exp = SpannedTyped::new(&expr.span, &Arc::new(TypX::Bool), expx);
-                stms.push(Spanned::new(expr.span.clone(), StmX::Assume(exp)));
-                Ok((stms, None))
+                stms.push(assume_false(&expr.span));
+                Ok((stms, ReturnValue::Never))
             } else {
                 err_str(&expr.span, "return expression not allowed here")
             }
@@ -791,6 +1017,7 @@ pub(crate) fn expr_to_stm_opt(
             let mut local_decls: Vec<LocalDecl> = Vec::new();
             let mut binds: Vec<Bnd> = Vec::new();
             let mut is_pure_exp = true;
+            let mut never_return = false;
             for stmt in stmts.iter() {
                 let (mut stms0, e0, decl_bnd_opt) = stmt_to_stm(ctx, state, stmt)?;
                 match decl_bnd_opt {
@@ -807,14 +1034,26 @@ pub(crate) fn expr_to_stm_opt(
                             }
                         }
                     }
-                    _ => {
+                    None => {
+                        // the statement wasn't a Decl; it could have been anything
                         is_pure_exp = false;
                     }
                 }
-                check_no_exp(&e0)?;
+                check_unit_or_never(&e0)?;
                 stms.append(&mut stms0);
+                match e0 {
+                    ReturnValue::Never => {
+                        is_pure_exp = false;
+                        never_return = true;
+                        // Don't process any of the later statements: they are unreachable.
+                        break;
+                    }
+                    _ => {}
+                }
             }
-            let exp = if let Some(expr) = body_opt {
+            let exp = if never_return {
+                ReturnValue::Never
+            } else if let Some(expr) = body_opt {
                 let (mut stms1, exp) = expr_to_stm_opt(ctx, state, expr)?;
                 if stms1.len() > 0 {
                     is_pure_exp = false;
@@ -822,13 +1061,13 @@ pub(crate) fn expr_to_stm_opt(
                 stms.append(&mut stms1);
                 exp
             } else {
-                None
+                ReturnValue::ImplicitUnit(expr.span.clone())
             };
             for _ in local_decls.iter() {
                 state.pop_scope();
             }
             match exp {
-                Some(mut exp) if is_pure_exp => {
+                ReturnValue::Some(mut exp) if is_pure_exp => {
                     // Pure expression: fold decls into Let bindings and return a single expression
                     for bnd in binds.iter().rev() {
                         exp = SpannedTyped::new(
@@ -841,10 +1080,12 @@ pub(crate) fn expr_to_stm_opt(
                     for decl in local_decls {
                         state.dont_rename.insert(decl.ident.clone());
                     }
-                    return Ok((vec![], Some(exp)));
+
+                    assert!(!never_return);
+                    return Ok((vec![], ReturnValue::Some(exp)));
                 }
                 _ => {
-                    // Not pure: return statements
+                    // Not pure: return statements + an expression
                     for decl in local_decls {
                         state.local_decls.push(decl);
                     }
@@ -856,11 +1097,22 @@ pub(crate) fn expr_to_stm_opt(
     }
 }
 
-pub(crate) fn stmt_to_stm(
+/// In the case that this stmt is a Decl, we also return the following information:
+///
+///    * An SST LocalDecl for the declaration
+///    * Optionally, An SST Bnd for the declaration (only if the right-hand side is pure)
+///
+/// Thus, when the Bnd is available, the caller of this fn has the option of whether
+/// to use the LocalDecl or the Bnd; they can use the Bnds in order to construct a pure
+/// expression or LocalDecls to construct an impure one.
+/// (Note: a declaration by itself being marked 'mutable' doesn't matter for determining
+/// purity; it only matters if there are assignments later.)
+
+fn stmt_to_stm(
     ctx: &Ctx,
     state: &mut State,
     stmt: &Stmt,
-) -> Result<(Vec<Stm>, Option<Exp>, Option<(LocalDecl, Option<Bnd>)>), VirErr> {
+) -> Result<(Vec<Stm>, ReturnValue, Option<(LocalDecl, Option<Bnd>)>), VirErr> {
     match &stmt.x {
         StmtX::Expr(expr) => {
             let (stms, exp) = expr_to_stm_opt(ctx, state, expr)?;
@@ -876,24 +1128,42 @@ pub(crate) fn stmt_to_stm(
             let typ = pattern.typ.clone();
             let decl = Arc::new(LocalDeclX { ident, typ, mutable: *mutable });
 
+            // First check if the initializer needs to be translate to a Call instead
+            // of an Exp. If so, translate it that way.
             if let Some(init) = init {
                 match expr_must_be_call_stm(ctx, state, init)? {
-                    Some((mut stms, func_name, typs, _, args)) => {
+                    Some((stms, ReturnedCall::Never)) => {
+                        return Ok((stms, ReturnValue::Never, None));
+                    }
+                    Some((mut stms, ReturnedCall::Call { fun, typs, has_return: _, args })) => {
                         // Special case: convert to a Call
+                        // It can't be pure in this case, so don't return a Bnd.
                         let dest = Dest { var: decl.ident.clone(), is_init: true };
-                        stms.push(stm_call(state, &init.span, func_name, typs, args, Some(dest)));
-                        return Ok((stms, None, Some((decl, None))));
+                        stms.push(stm_call(state, &init.span, fun, typs, args, Some(dest)));
+                        let ret = ReturnValue::ImplicitUnit(stmt.span.clone());
+                        return Ok((stms, ret, Some((decl, None))));
                     }
                     None => {}
                 }
             }
 
+            // Otherwise, translate the initializer to an Exp.
+
             let (mut stms, exp) = match init {
                 None => (vec![], None),
-                Some(init) => expr_to_stm_opt(ctx, state, init)?,
+                Some(init) => {
+                    let (stms, exp) = expr_to_stm_opt(ctx, state, init)?;
+                    let exp = match exp.to_value() {
+                        Some(exp) => exp,
+                        None => {
+                            return Ok((stms, ReturnValue::Never, None));
+                        }
+                    };
+                    (stms, Some(exp))
+                }
             };
 
-            // For a pure expression, return a binder
+            // For a pure expression (i.e., one with no SST statements), return a binder
             let bnd = match &exp {
                 Some(exp) if stms.len() == 0 => {
                     let binder = BinderX { name: name.clone(), a: exp.clone() };
@@ -911,7 +1181,8 @@ pub(crate) fn stmt_to_stm(
                 }
             }
 
-            Ok((stms, None, Some((decl, bnd))))
+            let ret = ReturnValue::ImplicitUnit(stmt.span.clone());
+            Ok((stms, ret, Some((decl, bnd))))
         }
     }
 }

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -572,8 +572,8 @@ pub fn func_def_to_air(
 
             // AST --> SST
             state.ret_post = Some((dest.clone(), enss.clone()));
-            let stm =
-                crate::ast_to_sst::expr_to_one_stm_dest(&ctx, &mut state, &body, &dest, &*enss)?;
+            let (stm, skip_ensures) =
+                crate::ast_to_sst::expr_to_one_stm_dest(&ctx, &mut state, &body, &dest)?;
             let stm = state.finalize_stm(&stm);
             state.ret_post = None;
 
@@ -594,10 +594,12 @@ pub fn func_def_to_air(
                 &state.local_decls,
                 &function.x.attrs.hidden,
                 &reqs,
+                &enss,
                 &function.x.mask_spec,
                 function.x.mode,
                 &stm,
                 function.x.attrs.bit_vector,
+                skip_ensures,
             );
 
             state.finalize();

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -572,7 +572,8 @@ pub fn func_def_to_air(
 
             // AST --> SST
             state.ret_post = Some((dest.clone(), enss.clone()));
-            let stm = crate::ast_to_sst::expr_to_one_stm_dest(&ctx, &mut state, &body, &dest)?;
+            let stm =
+                crate::ast_to_sst::expr_to_one_stm_dest(&ctx, &mut state, &body, &dest, &*enss)?;
             let stm = state.finalize_stm(&stm);
             state.ret_post = None;
 
@@ -593,7 +594,6 @@ pub fn func_def_to_air(
                 &state.local_decls,
                 &function.x.attrs.hidden,
                 &reqs,
-                &*enss,
                 &function.x.mask_spec,
                 function.x.mode,
                 &stm,

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -93,6 +93,7 @@ pub enum MonoTypX {
 
 struct State {
     types: ScopeMap<Ident, Typ>,
+    is_trait: bool,
 }
 
 pub(crate) fn typ_as_mono(typ: &Typ) -> Option<MonoTyp> {
@@ -442,7 +443,11 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
         }
         ExprX::Return(None) => expr.clone(),
         ExprX::Return(Some(e1)) => {
-            let e1 = coerce_expr_to_native(ctx, &poly_expr(ctx, state, e1));
+            let e1 = if state.is_trait {
+                coerce_expr_to_poly(ctx, &poly_expr(ctx, state, e1))
+            } else {
+                coerce_expr_to_native(ctx, &poly_expr(ctx, state, e1))
+            };
             mk_expr_typ(&e1.typ, ExprX::Return(Some(e1.clone())))
         }
         ExprX::Block(ss, e1) => {
@@ -545,7 +550,7 @@ fn poly_function(ctx: &Ctx, function: &Function) -> Function {
     }
     let params = Arc::new(new_params);
 
-    let mut state = State { types };
+    let mut state = State { types, is_trait };
 
     let native_exprs = |state: &mut State, es: &Exprs| {
         let mut exprs: Vec<Expr> = Vec::new();

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -448,7 +448,7 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
             } else {
                 coerce_expr_to_native(ctx, &poly_expr(ctx, state, e1))
             };
-            mk_expr_typ(&e1.typ, ExprX::Return(Some(e1.clone())))
+            mk_expr(ExprX::Return(Some(e1.clone())))
         }
         ExprX::Block(ss, e1) => {
             let mut stmts: Vec<Stmt> = Vec::new();

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -358,7 +358,6 @@ pub(crate) fn check_termination_exp(
         &Arc::new(local_decls),
         &Arc::new(vec![]),
         &Arc::new(vec![]),
-        &Arc::new(vec![]),
         &MaskSpec::NoSpec,
         function.x.mode,
         &stm_block,

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -358,9 +358,11 @@ pub(crate) fn check_termination_exp(
         &Arc::new(local_decls),
         &Arc::new(vec![]),
         &Arc::new(vec![]),
+        &Arc::new(vec![]),
         &MaskSpec::NoSpec,
         function.x.mode,
         &stm_block,
+        false,
         false,
     );
 

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1238,7 +1238,6 @@ pub fn body_stm_to_air(
     local_decls: &Vec<LocalDecl>,
     hidden: &Vec<Fun>,
     reqs: &Vec<Exp>,
-    enss: &Vec<Exp>,
     mask_spec: &MaskSpec,
     mode: Mode,
     stm: &Stm,
@@ -1330,19 +1329,6 @@ pub fn body_stm_to_air(
         state.local_bv_shared.clone()
     };
 
-    for ens in enss {
-        let error = error_with_label(
-            "postcondition not satisfied".to_string(),
-            &stm.span,
-            "at the end of the function body".to_string(),
-        )
-        .secondary_label(&ens.span, "failed this postcondition".to_string());
-
-        let expr_ctxt = ExprCtxt { mode: ExprMode::Body, is_bit_vector: is_bit_vector_mode };
-        let e = mk_let(&trait_typ_bind, &exp_to_expr(ctx, ens, expr_ctxt));
-        let ens_stmt = StmtX::Assert(error, e);
-        stmts.push(Arc::new(ens_stmt));
-    }
     let assertion = one_stmt(stmts);
 
     if !is_bit_vector_mode {


### PR DESCRIPTION
Add support for the Rust idiom,

```rust
let x = if { expr } else { return; }
```

and similarly for match statements (which we internally lower into if-else).

Also: handle code that makes use of blocks implicitly returning units. Not that I expect that to be very common, but the two cases look similarly syntactically, so I wanted to make sure handling one case didn't screw up the other one. The fact that it's hard to tell them apart made some of the corner cases a little weird, but I documented the assumptions in `ast_to_sst` and wrote tests.