### PR TITLE
Datatype field updates (including as &mut arguments)

### DIFF
--- a/source/docs/air/call-typing-bug.air
+++ b/source/docs/air/call-typing-bug.air
@@ -1,0 +1,65 @@
+;; ...
+
+ ;; Function-Def crate::foo
+ (check-valid
+  (declare-const s@ S.)
+  (declare-const tmp%1@ Bool)
+  (declare-const tmp%2@ Bool)
+  (declare-const tmp%3@ Bool)
+  (declare-var s$1@ S.)
+  (axiom fuel_defaults)
+  (axiom (has_type (Poly%S. s@) (TYPE%S. (UINT 32))))
+  (block
+   (assume
+    (= s$1@ (S./S (I 5) (%B (B false))))
+   )
+   (block
+    (assert
+     ("precondition not satisfied")
+     (req%add1. (%I (S./S/a (%Poly%S. (Poly%S. s$1@)))))
+    )
+    (snapshot snap%CALL)
+    (havoc s$1@)
+    (assume
+     (and
+      (= (S./S/b (old snap%CALL s$1@)) (S./S/b s$1@))
+    ))
+    (assume
+     (ens%add1. (%I (S./S/a (%Poly%S. (Poly%S. (old snap%CALL s$1@))))) (%I (S./S/a (%Poly%S.
+         (Poly%S. s$1@)
+    )))))
+    (assume (has_type (S./S/a (%Poly%S. (Poly%S. s$1@))) (UINT 32)))
+   )
+   (assume
+    (= tmp%1@ (= (%I (S./S/a (%Poly%S. (Poly%S. s$1@)))) 6))
+   )
+   (block
+    (assert
+     ("assertion failure")
+     (req%pervasive.assert. tmp%1@)
+    )
+    (assume
+     (ens%pervasive.assert. tmp%1@)
+   ))
+   (assume
+    (= tmp%2@ (= (S./S/b (%Poly%S. (Poly%S. s$1@))) false))
+   )
+   (block
+    (assert
+     ("assertion failure")
+     (req%pervasive.assert. tmp%2@)
+    )
+    (assume
+     (ens%pervasive.assert. tmp%2@)
+   ))
+   (assume
+    (= tmp%3@ (= s$1@ (S./S (I 6) (%B (B false)))))
+   )
+   (block
+    (assert
+     ("assertion failure")
+     (req%pervasive.assert. tmp%3@)
+    )
+    (assume
+     (ens%pervasive.assert. tmp%3@)
+ ))))

--- a/source/rust_verify/example/playground.rs
+++ b/source/rust_verify/example/playground.rs
@@ -6,8 +6,31 @@ use pervasive::{*, option::Option, result::Result};
 use pervasive::seq::*;
 use crate::pervasive::vec::*;
 
-fn add1(v: &mut Vec<u64>) {
-    requires(forall(|i: nat| i < old(v).len() >>= old(v).index(i) < 10));
+
+#[derive(PartialEq, Eq, Structural)]
+struct S<A> {
+    a: A,
+    b: bool,
 }
 
-fn main() { }
+fn add1(a: &mut u32) {
+    requires([
+        *old(a) < 10,
+    ]);
+    ensures([
+        *a == *old(a) + 1,
+    ]);
+    *a = *a + 1;
+}
+
+fn foo(s: S<u32>) {
+    // let mut s = s;
+    let mut s = S { a: 5, b: false };
+    add1(&mut s.a);
+    assert(s.a == 6);
+    assert(s.b == false);
+    assert(s == S { a: 6, b: false });
+}
+
+fn main() {}
+

--- a/source/rust_verify/src/erase.rs
+++ b/source/rust_verify/src/erase.rs
@@ -69,7 +69,8 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use vir::ast::{
-    Datatype, ExprX, Fun, Function, GenericBoundX, Krate, Mode, Path, Pattern, PatternX, UnaryOpr,
+    Datatype, ExprX, FieldOpr, Fun, Function, GenericBoundX, Krate, Mode, Path, Pattern, PatternX,
+    UnaryOpr,
 };
 use vir::ast_util::get_field;
 use vir::modes::{mode_join, ErasureModes};
@@ -674,7 +675,7 @@ fn erase_expr_opt(ctxt: &Ctxt, mctxt: &mut MCtxt, expect: Mode, expr: &Expr) -> 
         }
         ExprKind::Field(e1, field) => {
             let field_mode = match &mctxt.find_span(&ctxt.resolved_exprs, expr.span).x {
-                ExprX::UnaryOpr(UnaryOpr::Field { datatype, variant, field }, _) => {
+                ExprX::UnaryOpr(UnaryOpr::Field(FieldOpr { datatype, variant, field }), _) => {
                     let datatype = &ctxt.datatypes[datatype];
                     let variant = datatype.x.get_variant(variant);
                     get_field(&variant.a, field).a.1

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -26,8 +26,8 @@ use rustc_span::def_id::DefId;
 use rustc_span::Span;
 use std::sync::Arc;
 use vir::ast::{
-    ArithOp, ArmX, BinaryOp, CallTarget, Constant, ExprX, FunX, HeaderExpr, HeaderExprX, Ident,
-    IntRange, InvAtomicity, Mode, PatternX, SpannedTyped, StmtX, Stmts, Typ, TypX, UnaryOp,
+    ArithOp, ArmX, BinaryOp, CallTarget, Constant, ExprX, FieldOpr, FunX, HeaderExpr, HeaderExprX,
+    Ident, IntRange, InvAtomicity, Mode, PatternX, SpannedTyped, StmtX, Stmts, Typ, TypX, UnaryOp,
     UnaryOpr, VarAt, VirErr,
 };
 use vir::ast_util::{ident_binder, path_as_rust_name};
@@ -688,14 +688,14 @@ fn fn_call_to_vir<'tcx>(
             use crate::def::FieldName;
             let variant_name_ident = str_ident(&variant_name);
             return Ok(mk_expr(ExprX::UnaryOpr(
-                UnaryOpr::Field {
+                UnaryOpr::Field(FieldOpr {
                     datatype: self_path.clone(),
                     variant: variant_name_ident.clone(),
                     field: match variant_field {
                         FieldName::Unnamed(i) => positional_field_ident(i),
                         FieldName::Named(f) => str_ident(&f),
                     },
-                },
+                }),
                 vir_args.into_iter().next().expect("missing arg for is_variant"),
             )));
         }
@@ -1628,7 +1628,11 @@ pub(crate) fn expr_to_vir_inner<'tcx>(
                 expr.span,
                 &field_type,
                 ExprX::UnaryOpr(
-                    UnaryOpr::Field { datatype, variant: variant_name, field: field_name },
+                    UnaryOpr::Field(FieldOpr {
+                        datatype,
+                        variant: variant_name,
+                        field: field_name,
+                    }),
                     vir_lhs,
                 ),
             );

--- a/source/rust_verify/tests/adts.rs
+++ b/source/rust_verify/tests/adts.rs
@@ -567,6 +567,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_field_update_param_1_pass FIELD_UPDATE.to_string() + FIELD_UPDATE_2 + code_str! {
         fn test(t: &mut T) {
+            requires(old(t).s.b < 30);
             ensures(*t == T { s: S { a: old(t).s.a + 1, b: old(t).s.b + 1 }, ..*old(t) });
             t.s.a = t.s.a + 1;
             t.s.b = t.s.b + 1;
@@ -577,6 +578,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_field_update_param_1_fail FIELD_UPDATE.to_string() + FIELD_UPDATE_2 + code_str! {
         fn test(t: &mut T) {
+            requires(old(t).s.b < 30);
             ensures(*t == T { s: S { a: old(t).s.a + 1, b: old(t).s.b + 1 }, ..*old(t) });
             t.s.a = t.s.a + 1;
             t.s.b = t.s.b + 1;
@@ -595,8 +597,7 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    // TODO support complex arguments to &mut params
-    #[test] #[ignore] test_field_update_param_mut_ref_pass FIELD_UPDATE.to_string() + FIELD_UPDATE_2 + code_str! {
+    #[test] test_field_update_param_mut_ref_pass FIELD_UPDATE.to_string() + FIELD_UPDATE_2 + code_str! {
         fn foo(s: &mut S, v: usize) {
             ensures(*s == S { a: old(s).a + v, ..*old(s) });
             s.a = s.a + v;

--- a/source/rust_verify/tests/adts.rs
+++ b/source/rust_verify/tests/adts.rs
@@ -533,6 +533,41 @@ test_verify_one_file! {
     } => Err(e) => assert_one_fails(e)
 }
 
+test_verify_one_file! {
+    #[test] test_field_update_1_call_pass FIELD_UPDATE.to_string() + code_str! {
+        fn add1(a: i32) -> i32 {
+            requires(a < 30);
+            ensures(|ret: i32| ret == a + 1);
+            a + 1
+        }
+
+        fn test() {
+            let mut s = S { a: 10, b: -10 };
+            s.a = s.a + 1;
+            s.b = add1(s.b);
+            assert(s.a == 11);
+            assert(s.b == -9);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_field_update_poly_pass code! {
+        #[derive(PartialEq, Eq, Structural)]
+        struct S<A> {
+            a: A,
+            b: i32,
+        }
+
+        fn test() {
+            let mut s: S<usize> = S { a: 10, b: -10 };
+            s.a = s.a + 1;
+            s.b = s.b + 1;
+            assert(s.a == 11 && s.b == -9);
+        }
+    } => Ok(())
+}
+
 const FIELD_UPDATE_2: &str = code_str! {
     #[derive(PartialEq, Eq, Structural)]
     struct T {

--- a/source/rust_verify/tests/adts.rs
+++ b/source/rust_verify/tests/adts.rs
@@ -624,3 +624,25 @@ test_verify_one_file! {
         }
     } => Err(e) => assert_vir_error(e)
 }
+
+const FIELD_UPDATE_MODES: &str = code_str! {
+    #[derive(PartialEq, Eq, Structural)]
+    struct S {
+        #[spec] a: nat,
+        b: i32,
+    }
+
+    #[derive(PartialEq, Eq, Structural)]
+    struct T {
+        #[proof] s: S,
+        c: bool,
+    }
+};
+
+test_verify_one_file! {
+    #[test] test_field_update_field_mode_pass_1 FIELD_UPDATE_MODES.to_string() + code_str! {
+        fn test(t: T) {
+            t.s.a = t.s.a + 1;
+        }
+    } => Err(e) => assert_vir_error(e)
+}

--- a/source/rust_verify/tests/basic.rs
+++ b/source/rust_verify/tests/basic.rs
@@ -360,3 +360,20 @@ test_verify_one_file! {
         }
     } => Err(e) => assert_fails(e, 4)
 }
+
+test_verify_one_file! {
+    #[test] test_init_spec_param_fail_1 code! {
+        fn test1(#[spec] x: u64) {
+            x = 5;
+        }
+    } => Err(e) => assert_vir_error(e)
+}
+
+test_verify_one_file! {
+    #[test] test_init_spec_param_fail_2 code! {
+        #[spec]
+        fn test1(x: u64) {
+            x = 5;
+        }
+    } => Err(e) => assert_vir_error(e)
+}

--- a/source/rust_verify/tests/modes.rs
+++ b/source/rust_verify/tests/modes.rs
@@ -263,3 +263,36 @@ test_verify_one_file! {
         }
     } => Err(e) => assert_vir_error(e)
 }
+
+const FIELD_UPDATE: &str = code_str! {
+    #[derive(PartialEq, Eq, Structural)]
+    struct S {
+        #[spec] a: u64,
+        b: bool,
+    }
+};
+
+test_verify_one_file! {
+    #[test] test_field_update_fail FIELD_UPDATE.to_string() + code_str! {
+        fn test() {
+            let mut s = S { a: 5, b: false };
+            #[spec] let b = true;
+            s.b = b;
+        }
+    } => Err(e) => assert_vir_error(e)
+}
+
+test_verify_one_file! {
+    #[test] test_mut_ref_field_fail FIELD_UPDATE.to_string() + code_str! {
+        fn muts_exec(a: &mut u64) {
+            requires(*old(a) < 30);
+            ensures(*a == *old(a) + 1);
+            *a = *a + 1;
+        }
+
+        fn test() {
+            let mut s = S { a: 5, b: false };
+            muts_exec(&mut s.a);
+        }
+    } => Err(e) => assert_vir_error(e)
+}

--- a/source/rust_verify/tests/refs.rs
+++ b/source/rust_verify/tests/refs.rs
@@ -433,8 +433,6 @@ test_verify_one_file! {
         fn main() {
             let mut s = S { a: 5, b: false };
             add1(&mut s.a);
-            assume(s.a == 6);
-            assume(s.b == false);
             assert(s == S { a: 6, b: false });
         }
     } => Ok(())

--- a/source/rust_verify/tests/refs.rs
+++ b/source/rust_verify/tests/refs.rs
@@ -437,3 +437,29 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] test_mut_ref_field_and_update_pass code! {
+        #[derive(PartialEq, Eq, Structural)]
+        struct S<A> {
+            a: A,
+            b: bool,
+        }
+
+        fn add1(a: &mut u32) -> u32 {
+            requires(*old(a) < 10);
+            ensures(|ret: u32| [
+                *a == *old(a) + 1,
+                ret == *old(a)
+            ]);
+            *a = *a + 1;
+            *a - 1
+        }
+
+        fn main() {
+            let mut s = S { a: 5, b: false };
+            s.a = add1(&mut s.a);
+            assert(s == S { a: 5, b: false });
+        }
+    } => Ok(())
+}

--- a/source/rust_verify/tests/refs.rs
+++ b/source/rust_verify/tests/refs.rs
@@ -182,20 +182,19 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_mut_ref_arg_self_fail_complex MUT_REF_ARG_SELF_COMMON.to_string() + code_str! {
+    #[test] test_mut_ref_arg_self_complex_pass MUT_REF_ARG_SELF_COMMON.to_string() + code_str! {
         pub struct Wrap {
             pub w: Value,
         }
 
         impl Wrap {
             fn outer(&mut self) {
-                requires(old(self).w.v < 10);
-                // currently disallowing this
+                requires(old(self).w.v == 2);
                 self.w.add1();
                 assert(self.w.v == 3);
             }
         }
-    } => Err(e) => assert_vir_error(e)
+    } => Ok(())
 }
 
 test_verify_one_file! {
@@ -385,4 +384,58 @@ test_verify_one_file! {
             assert(bar.a == 11); // FAILS
         }
     } => Err(e) => assert_one_fails(e)
+}
+
+test_verify_one_file! {
+    #[test] test_mut_ref_field_pass_1 code! {
+        #[derive(PartialEq, Eq, Structural)]
+        struct S {
+            a: u32,
+            b: i32,
+            c: bool,
+        }
+
+        fn add1(a: &mut u32, b: &mut i32) {
+            requires([
+                *old(a) < 10,
+                *old(b) < 10,
+            ]);
+            ensures([
+                *a == *old(a) + 1,
+                *b == *old(b) + 1,
+            ]);
+            *a = *a + 1;
+            *b = *b + 1;
+        }
+
+        fn main() {
+            let mut s = S { a: 5, b: -5, c: false };
+            add1(&mut s.a, &mut s.b);
+            assert(s == S { a: 6, b: -4, c: false });
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_mut_ref_field_pass_2 code! {
+        #[derive(PartialEq, Eq, Structural)]
+        struct S<A> {
+            a: A,
+            b: bool,
+        }
+
+        fn add1(a: &mut u32) {
+            requires(*old(a) < 10);
+            ensures(*a == *old(a) + 1);
+            *a = *a + 1;
+        }
+
+        fn main() {
+            let mut s = S { a: 5, b: false };
+            add1(&mut s.a);
+            assume(s.a == 6);
+            assume(s.b == false);
+            assert(s == S { a: 6, b: false });
+        }
+    } => Ok(())
 }

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -113,6 +113,13 @@ pub enum UnaryOp {
     Clip(IntRange),
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct FieldOpr {
+    pub datatype: Path,
+    pub variant: Ident,
+    pub field: Ident,
+}
+
 /// More complex unary operations (requires Clone rather than Copy)
 /// (Below, "boxed" refers to boxing types in the SMT encoding, not the Rust Box type)
 #[derive(Clone, Debug)]
@@ -129,7 +136,7 @@ pub enum UnaryOpr {
     /// Read .0, .1, etc. from tuple (Note: ast_simplify replaces this with Field)
     TupleField { tuple_arity: usize, field: usize },
     /// Read field from variant of datatype
-    Field { datatype: Path, variant: Ident, field: Ident },
+    Field(FieldOpr),
 }
 
 /// Arithmetic operation that might fail (overflow or divide by zero)

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -155,6 +155,50 @@ fn pattern_to_exprs(
     }
 }
 
+fn simplify_assign_lhs(
+    ctx: &GlobalCtx,
+    state: &mut State,
+    datatype_path: &Path,
+    variant: &Ident,
+    field: &Ident,
+    base: &Expr,
+    rhs: &Expr,
+) -> Result<(Expr, Expr), VirErr> {
+    let datatype = &ctx.datatypes[datatype_path];
+    assert_eq!(datatype.len(), 1);
+    let fields = &datatype[0].a;
+    let binders = fields
+        .iter()
+        .map(|f| {
+            let field_op;
+            ident_binder(
+                &f.name,
+                if f.name == *field {
+                    rhs
+                } else {
+                    let op = UnaryOpr::Field {
+                        datatype: datatype_path.clone(),
+                        variant: variant.clone(),
+                        field: f.name.clone(),
+                    };
+                    let exprx = ExprX::UnaryOpr(op, base.clone());
+                    field_op = SpannedTyped::new(&base.span, &f.a.0, exprx);
+                    &field_op
+                },
+            )
+        })
+        .collect();
+    let ctorx = ExprX::Ctor(datatype_path.clone(), variant.clone(), Arc::new(binders), None);
+    let ctor = SpannedTyped::new(&base.span, &base.typ, ctorx);
+    match &base.x {
+        ExprX::VarLoc(_) => Ok((base.clone(), ctor)),
+        ExprX::UnaryOpr(UnaryOpr::Field { datatype, variant, field }, base) => {
+            Ok(simplify_assign_lhs(ctx, state, datatype, variant, field, base, &ctor)?)
+        }
+        _ => err_str(&base.span, "complex assignments not yet supported"),
+    }
+}
+
 fn simplify_one_expr(ctx: &GlobalCtx, state: &mut State, expr: &Expr) -> Result<Expr, VirErr> {
     match &expr.x {
         ExprX::ConstVar(x) => {
@@ -187,6 +231,29 @@ fn simplify_one_expr(ctx: &GlobalCtx, state: &mut State, expr: &Expr) -> Result<
             let exprx = ExprX::Ctor(datatype, variant, binders, None);
             Ok(SpannedTyped::new(&expr.span, &expr.typ, exprx))
         }
+        ExprX::Assign { init_not_mut, lhs, rhs } => match &lhs.x {
+            ExprX::VarLoc(_) => Ok(expr.clone()),
+            ExprX::UnaryOpr(UnaryOpr::Field { datatype, variant, field }, rcvr) => {
+                let (temp_decls, rhs) = small_or_temp(state, rhs);
+                if *init_not_mut {
+                    panic!("unexpected init_not_mut here");
+                }
+                let (simplified_lhs, simplified_rhs) =
+                    simplify_assign_lhs(ctx, state, datatype, variant, field, rcvr, &rhs)?;
+                let assign = SpannedTyped::new(
+                    &expr.span,
+                    &expr.typ,
+                    ExprX::Assign { init_not_mut: false, lhs: simplified_lhs, rhs: simplified_rhs },
+                );
+                if temp_decls.len() == 0 {
+                    Ok(assign)
+                } else {
+                    let block = ExprX::Block(Arc::new(temp_decls), Some(assign));
+                    Ok(SpannedTyped::new(&expr.span, &expr.typ, block))
+                }
+            }
+            _ => err_str(&expr.span, "complex assignments not yet supported"),
+        },
         ExprX::Ctor(path, variant, partial_binders, Some(update)) => {
             let (temp_decl, update) = small_or_temp(state, update);
             let mut decls: Vec<Stmt> = Vec::new();

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -598,14 +598,14 @@ fn expr_to_stm_opt(
         }
         ExprX::Assign { init_not_mut, lhs: expr1, rhs: expr2 } => {
             let dest_x = match &expr1.x {
-                ExprX::VarLoc(x) => Ok(state.get_var_unique_id(&x)),
-                _ => err_str(&expr1.span, "complex assignments not yet supported"),
+                ExprX::VarLoc(x) => state.get_var_unique_id(&x),
+                _ => panic!("complex Assign should have been simplified"),
             };
             match expr_must_be_call_stm(ctx, state, expr2)? {
                 Some((stms2, ReturnedCall::Never)) => Ok((stms2, ReturnValue::Never)),
                 Some((mut stms2, ReturnedCall::Call { fun, typs, has_return: _, args })) => {
                     // make a Call
-                    let dest = Dest { var: dest_x?.clone(), is_init: *init_not_mut };
+                    let dest = Dest { var: dest_x.clone(), is_init: *init_not_mut };
                     stms2.push(stm_call(state, &expr.span, fun, typs, args, Some(dest)));
                     Ok((stms2, ReturnValue::ImplicitUnit(expr.span.clone())))
                 }
@@ -613,7 +613,7 @@ fn expr_to_stm_opt(
                     // make an Assign
                     let (mut stms2, e2) = expr_to_stm_opt(ctx, state, expr2)?;
                     let e2 = unwrap_or_return_never!(e2, stms2);
-                    let assign = StmX::Assign { lhs: dest_x?, rhs: e2, is_init: *init_not_mut };
+                    let assign = StmX::Assign { lhs: dest_x, rhs: e2, is_init: *init_not_mut };
                     stms2.push(Spanned::new(expr.span.clone(), assign));
                     Ok((stms2, ReturnValue::ImplicitUnit(expr.span.clone())))
                 }

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -94,6 +94,7 @@ pub const I_INV: &str = "iInv";
 pub const ARCH_SIZE: &str = "SZ";
 pub const SNAPSHOT_CALL: &str = "CALL";
 pub const SNAPSHOT_PRE: &str = "PRE";
+pub const SNAPSHOT_ASSIGN: &str = "ASSIGN";
 pub const POLY: &str = "Poly";
 pub const BOX_INT: &str = "I";
 pub const BOX_BOOL: &str = "B";

--- a/source/vir/src/lib.rs
+++ b/source/vir/src/lib.rs
@@ -26,6 +26,8 @@
 //!
 //! To ensure that VIR stays simple and easy to use, the vir crate does not depend on rustc.
 
+#![feature(let_else)]
+
 pub mod ast;
 pub mod ast_simplify;
 mod ast_to_sst;

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -237,12 +237,6 @@ fn get_var_loc_mode(typing: &mut Typing, expr: &Expr, init_not_mut: bool) -> Res
     let x_mode = match &expr.x {
         ExprX::VarLoc(x) => {
             let (_, x_mode) = typing.get(x);
-            if x_mode == Mode::Spec && init_not_mut {
-                return err_str(
-                    &expr.span,
-                    "delayed assignment to non-mut let not allowed for spec variables",
-                );
-            }
             x_mode
         }
         ExprX::UnaryOpr(UnaryOpr::Field { datatype, variant: _, field }, rcvr) => {
@@ -264,6 +258,12 @@ fn get_var_loc_mode(typing: &mut Typing, expr: &Expr, init_not_mut: bool) -> Res
             panic!("unexpected loc {:?}", expr);
         }
     };
+    if x_mode == Mode::Spec && init_not_mut {
+        return err_str(
+            &expr.span,
+            "delayed assignment to non-mut let not allowed for spec variables",
+        );
+    }
     typing.erasure_modes.var_modes.push((expr.span.clone(), x_mode));
     Ok(x_mode)
 }

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -326,7 +326,6 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
                     } else {
                         coerce_typ_to_native(ctx, &expr.typ)
                     };
-                    // dbg!(&field, &typ, &exprx);
                     mk_expr_typ(&typ, exprx)
                 }
             }
@@ -394,7 +393,11 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
         }
         ExprX::Assign { init_not_mut, lhs: e1, rhs: e2 } => {
             let e1 = poly_expr(ctx, state, e1);
-            let e2 = coerce_expr_to_native(ctx, &poly_expr(ctx, state, e2));
+            let e2 = if typ_is_poly(ctx, &e1.typ) {
+                coerce_expr_to_poly(ctx, &poly_expr(ctx, state, e2))
+            } else {
+                coerce_expr_to_native(ctx, &poly_expr(ctx, state, e2))
+            };
             mk_expr(ExprX::Assign { init_not_mut: *init_not_mut, lhs: e1, rhs: e2 })
         }
         ExprX::AssertBV(e) => mk_expr(ExprX::AssertBV(poly_expr(ctx, state, e))),

--- a/source/vir/src/printer.rs
+++ b/source/vir/src/printer.rs
@@ -243,7 +243,7 @@ fn expr_to_node(expr: &Expr) -> Node {
                 UnaryOpr::TupleField { tuple_arity, field } => {
                     nodes_vec!(tuplefield {str_to_node(":arity")} {str_to_node(&format!("{}", tuple_arity))} {str_to_node(&format!("{}", field))})
                 }
-                UnaryOpr::Field { datatype, variant, field } => {
+                UnaryOpr::Field(FieldOpr { datatype, variant, field }) => {
                     nodes_vec!(field {path_to_node(datatype)} {str_to_node(variant)} {str_to_node(field)})
                 }
             };

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -11,7 +11,7 @@ use crate::def::{
 };
 use crate::func_to_air::params_to_pars;
 use crate::scc::Graph;
-use crate::sst::{BndX, Exp, ExpX, Exps, LocalDecl, LocalDeclX, Stm, StmX, UniqueIdent};
+use crate::sst::{BndX, Dest, Exp, ExpX, Exps, LocalDecl, LocalDeclX, Stm, StmX, UniqueIdent};
 use crate::sst_visitor::{
     exp_rename_vars, exp_visitor_check, exp_visitor_dfs, map_exp_visitor, map_stm_visitor,
     stm_visitor_dfs, VisitorControlFlow,
@@ -289,17 +289,21 @@ fn mk_decreases_at_entry(ctxt: &Ctxt, span: &Span, exps: &Vec<Exp>) -> (Vec<Loca
     let mut decls: Vec<LocalDecl> = Vec::new();
     let mut stm_assigns: Vec<Stm> = Vec::new();
     for (i, exp) in exps.iter().enumerate() {
+        let typ = Arc::new(TypX::Int(IntRange::Int));
         let decl = Arc::new(LocalDeclX {
             ident: (decrease_at_entry(i), Some(0)),
-            typ: Arc::new(TypX::Int(IntRange::Int)),
+            typ: typ.clone(),
             mutable: false,
         });
+        let uniq_ident = (decrease_at_entry(i), Some(0));
         let stm_assign = Spanned::new(
             span.clone(),
             StmX::Assign {
-                lhs: (decrease_at_entry(i), Some(0)),
+                lhs: Dest {
+                    dest: crate::ast_to_sst::var_loc_exp(&span, &typ, uniq_ident),
+                    is_init: true,
+                },
                 rhs: height_of_exp(ctxt, exp),
-                is_init: true,
             },
         );
         decls.push(decl);

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -72,12 +72,13 @@ pub struct ParX {
 
 #[derive(Clone, Debug)]
 pub struct Dest {
-    pub var: UniqueIdent,
+    pub dest: Exp,
     pub is_init: bool,
 }
 
 pub type Stm = Arc<Spanned<StmX>>;
 pub type Stms = Arc<Vec<Stm>>;
+
 #[derive(Debug)]
 pub enum StmX {
     // call to exec/proof function
@@ -87,9 +88,8 @@ pub enum StmX {
     AssertBV(Exp),
     Assume(Exp),
     Assign {
-        lhs: UniqueIdent,
+        lhs: Dest,
         rhs: Exp,
-        is_init: bool,
     },
     Fuel(Fun, u32),
     DeadEnd(Stm),

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -1,5 +1,5 @@
 use crate::ast::{
-    BinaryOp, Constant, Fun, Ident, Path, Typ, TypX, UnaryOp, UnaryOpr, VarAt, VirErr,
+    BinaryOp, Constant, FieldOpr, Fun, Ident, Path, Typ, TypX, UnaryOp, UnaryOpr, VarAt, VirErr,
 };
 use crate::ast_util::{err_str, path_as_rust_name};
 use crate::context::Ctx;
@@ -300,7 +300,7 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
         ExpX::UnaryOpr(UnaryOpr::TupleField { .. }, _) => {
             panic!("internal error: TupleField should have been removed before here")
         }
-        ExpX::UnaryOpr(UnaryOpr::Field { datatype, variant, field }, lhs) => {
+        ExpX::UnaryOpr(UnaryOpr::Field(FieldOpr { datatype, variant, field }), lhs) => {
             let (is_pure, arg) = gather_terms(ctxt, ctx, lhs, depth + 1);
             (
                 is_pure,


### PR DESCRIPTION
This adds support for `a.b.c = 3;` and `call(&mut a.b.c)` using the same strategy of havoc-ing the base variable (`a`), and assuming all the unchanged fields are the same before and after a snapshot.

I'd like to add more tests for this, but I'd also like to land it as it touches a few critical places and would prefer it doesn't diverge too much. Some of this logic may have to change with a proper fix to https://github.com/secure-foundations/verus/issues/115 (which is next up for me).