### PR TITLE
add some well-formedness checks in pub / requires / ensures

### DIFF
--- a/source/pervasive/atomic.rs
+++ b/source/pervasive/atomic.rs
@@ -100,12 +100,12 @@ macro_rules! atomic_types {
 
         impl $p_ident {
             #[spec] #[verifier(publish)]
-            fn is_for(&self, patomic: $at_ident) -> bool {
+            pub fn is_for(&self, patomic: $at_ident) -> bool {
                 self.patomic == patomic.view()
             }
 
             #[spec] #[verifier(publish)]
-            fn points_to(&self, v: $value_ty) -> bool {
+            pub fn points_to(&self, v: $value_ty) -> bool {
                 self.value == v
             }
         }

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -245,6 +245,14 @@ fn check_function(ctxt: &Ctxt, function: &Function) -> Result<(), VirErr> {
             );
         }
     }
+
+    if function.x.publish.is_some() && function.x.visibility.is_private {
+        return err_str(
+            &function.span,
+            "function is marked #[verifier(publish)] but not marked `pub`; for the body of a function to be visible, the function symbol must also be visible",
+        );
+    }
+
     for req in function.x.require.iter() {
         let disallow_private_access = if function.x.visibility.is_private {
             None


### PR DESCRIPTION
A handful of well-formedness checks:

 * Check requires/ensures/decreases for private items, if the function is public (addresses https://github.com/secure-foundations/verus/issues/101)
 * Check requires/ensures/decreases for invalid uses of external_body datatypes
 * Error if a function is declared `publish` but not `pub`

I wasn't actually sure if we need to to the privacy check for `decreases` clauses though. Are `decreases` clauses exported?Can strongly connected components span module boundaries?