### PR TITLE
Treat arithmetic overflow in non-spec code as an error rather than as uninterpreted

### DIFF
--- a/source/rust_verify/example/datatypes.rs
+++ b/source/rust_verify/example/datatypes.rs
@@ -39,6 +39,7 @@ fn get_len<A>(list: &List<A>) -> u64 {
             }
             List::Cons(_, tl) => {
                 iter = tl;
+                reveal_with_fuel(len::<A>, 2);
                 n = n + 1;
             }
         }

--- a/source/rust_verify/example/proposal-rw2022.rs
+++ b/source/rust_verify/example/proposal-rw2022.rs
@@ -45,9 +45,10 @@ fn fibo_impl(n: u64) -> u64 {
       fibo_fits_u64(n as nat), fibo_fits_u64(i as nat),
       cur == fibo(i), prev == fibo(i as nat - 1),
     ]);
-    let new_cur = cur + prev;
-    prev = cur; cur = new_cur; i = i + 1;
+    i = i + 1;
     lemma_fibo_is_monotonic(i, n);
+    let new_cur = cur + prev;
+    prev = cur; cur = new_cur;
   }
   cur
 }

--- a/source/rust_verify/example/statements.rs
+++ b/source/rust_verify/example/statements.rs
@@ -46,7 +46,7 @@ fn test_loop() {
         assert(b2 as int <= 255);
         i = i + 1;
         b1 = b1 + 2;
-        b2 = b2 + 1;
+        b2 = b2 / 2;
     }
 
     assert(b1 == 200);

--- a/source/rust_verify/example/summer_school/chapter-2-2.rs
+++ b/source/rust_verify/example/summer_school/chapter-2-2.rs
@@ -33,7 +33,10 @@ fn test_prime(candidate: u64) -> bool
     let mut factor:u64 = 2;
     while (factor < candidate)
     {
-        invariant(forall(|smallerfactor:nat| 1 < smallerfactor && smallerfactor < factor >>= !divides(smallerfactor, candidate)));
+        invariant([
+            1 <= factor,
+            forall(|smallerfactor:nat| 1 < smallerfactor && smallerfactor < factor >>= !divides(smallerfactor, candidate))
+        ]);
         if candidate % factor == 0 {
             assert(divides(factor, candidate));
             assume(!is_prime(candidate));   // TODO(chris): can't prove the !forall. (Dafny doesn't need this line, either.)

--- a/source/rust_verify/example/test.rs
+++ b/source/rust_verify/example/test.rs
@@ -4,6 +4,7 @@ mod pervasive;
 use pervasive::*;
 
 pub fn foo(a: u64) -> u64 {
+    requires(a < 100);
     a + 1
 }
 

--- a/source/rust_verify/src/context.rs
+++ b/source/rust_verify/src/context.rs
@@ -4,7 +4,7 @@ use rustc_middle::ty::{TyCtxt, TypeckResults};
 use rustc_span::SpanData;
 use std::collections::HashMap;
 use std::sync::Arc;
-use vir::ast::{Expr, Mode, Pattern, Typ};
+use vir::ast::{Expr, InferMode, Mode, Pattern, Typ};
 
 pub struct ErasureInfo {
     pub(crate) resolved_calls: Vec<(SpanData, ResolvedCall)>,
@@ -22,6 +22,7 @@ pub struct ContextX<'tcx> {
     pub(crate) krate: &'tcx Crate<'tcx>,
     pub(crate) erasure_info: ErasureInfoRef,
     pub(crate) autoviewed_call_typs: HashMap<HirId, Typ>,
+    pub(crate) unique_id: std::cell::Cell<u64>,
 }
 
 #[derive(Clone)]
@@ -30,4 +31,12 @@ pub(crate) struct BodyCtxt<'tcx> {
     pub(crate) types: &'tcx TypeckResults<'tcx>,
     pub(crate) mode: Mode,
     pub(crate) external_body: bool,
+}
+
+impl<'tcx> ContextX<'tcx> {
+    pub(crate) fn infer_mode(&self) -> InferMode {
+        let id = self.unique_id.get();
+        self.unique_id.set(id + 1);
+        id
+    }
 }

--- a/source/rust_verify/tests/integers.rs
+++ b/source/rust_verify/tests/integers.rs
@@ -71,7 +71,7 @@ test_verify_one_file! {
     #[test] test2_fails code! {
         #[proof]
         fn test1(i: int, n: nat, u: u8) {
-            assert((u as int) < 256 >>= u < 256); // FAILS, because 256 is a u8 in u < 256
+            assert((u as int) < 256 >>= u < ((256 as int) as u8)); // FAILS, because 256 is a u8 in u < 256
         }
     } => Err(err) => assert_one_fails(err)
 }
@@ -95,7 +95,6 @@ test_verify_one_file! {
             let i5: int = n; // implicit coercion ok
             let n3: nat = 10;
             let i6: int = -10;
-            let u3: u8 = 300;
             let x = 2 + 2;
             let b1: bool = u <= i; // implicit coercion ok
             let b2: bool = i <= u; // implicit coercion ok
@@ -117,7 +116,7 @@ test_verify_one_file! {
             let u3: u8 = 300;
             assert(u3 > 100); // FAILS
         }
-    } => Err(err) => assert_one_fails(err)
+    } => Err(err) => assert_vir_error(err)
 }
 
 test_verify_one_file! {
@@ -194,7 +193,7 @@ test_verify_one_file! {
         fn f() {
             assert(255u8 == 256u8 - 1); // FAILS
         }
-    } => Err(err) => assert_one_fails(err)
+    } => Err(err) => assert_vir_error(err)
 }
 
 test_verify_one_file! {
@@ -203,7 +202,7 @@ test_verify_one_file! {
         fn f() {
             assert(-128i8 == -129i8 + 1); // FAILS
         }
-    } => Err(err) => assert_one_fails(err)
+    } => Err(err) => assert_vir_error(err)
 }
 
 test_verify_one_file! {
@@ -212,7 +211,7 @@ test_verify_one_file! {
         fn f() {
             assert(127i8 == 128i8 - 1); // FAILS
         }
-    } => Err(err) => assert_one_fails(err)
+    } => Err(err) => assert_vir_error(err)
 }
 
 test_verify_one_file! {
@@ -221,7 +220,7 @@ test_verify_one_file! {
         fn f() {
             assert(-0x8000_0000_0000_0000_0000_0000_0000_0000i128 == -0x8000_0000_0000_0000_0000_0000_0000_0001i128 + 1); // FAILS
         }
-    } => Err(err) => assert_one_fails(err)
+    } => Err(err) => assert_vir_error(err)
 }
 
 test_verify_one_file! {
@@ -230,5 +229,5 @@ test_verify_one_file! {
         fn f() {
             assert(0x7fff_ffff_ffff_ffff_ffff_ffff_ffff_ffffi128 == 0x8000_0000_0000_0000_0000_0000_0000_0000i128 - 1); // FAILS
         }
-    } => Err(err) => assert_one_fails(err)
+    } => Err(err) => assert_vir_error(err)
 }

--- a/source/rust_verify/tests/match.rs
+++ b/source/rust_verify/tests/match.rs
@@ -105,6 +105,7 @@ test_verify_one_file! {
                     }
                     List::Cons(_, tl) => {
                         iter = tl;
+                        reveal_with_fuel(len::<A>, 2);
                         n = n + 1;
                     }
                 }
@@ -150,6 +151,7 @@ test_verify_one_file! {
                     }
                     List::Cons { hd: _, tl } => {
                         iter = tl;
+                        reveal_with_fuel(len::<A>, 2);
                         n = n + 1;
                     }
                 }
@@ -184,7 +186,7 @@ test_verify_one_file! {
             let mut iter = list;
             while !done {
                 invariant([
-                    n + len(iter) == len(list), // FAILS
+                    n + len(iter) == len(list),
                     done >>= len(iter) == 0,
                 ]);
 
@@ -194,7 +196,8 @@ test_verify_one_file! {
                     }
                     List::Cons(_, tl) => {
                         iter = tl;
-                        n = n + 1;
+                        reveal_with_fuel(len::<A>, 2);
+                        n = n + 1; // FAILS
                     }
                 }
             }

--- a/source/rust_verify/tests/overflow.rs
+++ b/source/rust_verify/tests/overflow.rs
@@ -82,6 +82,18 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] test_const_ok code! {
+        const C: u8 = 254 + 1;
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_const_fail code! {
+        const C: u8 = 255 + 1 /* FAILS */;
+    } => Err(e) => assert_one_fails(e)
+}
+
+test_verify_one_file! {
     #[test] test_literal_out_of_range code! {
         const C: u8 = 256 - 1;
     } => Err(e) => assert_vir_error(e)

--- a/source/rust_verify/tests/overflow.rs
+++ b/source/rust_verify/tests/overflow.rs
@@ -4,9 +4,9 @@ mod common;
 use common::*;
 
 test_verify_one_file! {
-    #[test] test_overflow_pass code! {
+    #[test] test_overflow_spec_pass code! {
         fn test(a: u64) {
-            let mut j = a;
+            #[spec] let mut j = a;
             j = j + 2;
             assert(j == a + 2);
         }
@@ -14,11 +14,42 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] test_overflow_fails_0 code! {
+        fn test(a: u64) {
+            let mut j = a;
+            j = j + 2; // FAILS
+            assert(j == a + 2);
+        }
+    } => Err(e) => assert_one_fails(e)
+}
+
+test_verify_one_file! {
+    #[test] test_overflow_spec_fails_1 code! {
+        fn test(a: u64) {
+            #[spec] let mut j = a;
+            j = j + 2;
+            assert(j == a as nat + 2); // FAILS
+        }
+    } => Err(e) => assert_one_fails(e)
+}
+
+test_verify_one_file! {
     #[test] test_overflow_fails_1 code! {
         fn test(a: u64) {
             let mut j = a;
+            j = j + 2; // FAILS
+            assert(j == a as nat + 2);
+        }
+    } => Err(e) => assert_one_fails(e)
+}
+
+test_verify_one_file! {
+    #[test] test_overflow_spec_fails_2 code! {
+        fn test(a: u64) {
+            #[spec] let mut j = a;
             j = j + 2;
-            assert(j == a as nat + 2); // FAILS
+            j = j + 2;
+            assert(j == a + 4); // FAILS
         }
     } => Err(e) => assert_one_fails(e)
 }
@@ -27,9 +58,31 @@ test_verify_one_file! {
     #[test] test_overflow_fails_2 code! {
         fn test(a: u64) {
             let mut j = a;
+            j = j + 2; // FAILS
             j = j + 2;
-            j = j + 2;
-            assert(j == a + 4); // FAILS
+            assert(j == a + 4);
         }
     } => Err(e) => assert_one_fails(e)
+}
+
+test_verify_one_file! {
+    #[test] test_divide_by_zero code! {
+        fn ok(a: u8, b: u8) {
+            requires(b != 0);
+            let x = a / b;
+            let y = a % b;
+        }
+        fn fail1(a: u8, b: u8) {
+            let x = a / b; // FAILS
+        }
+        fn fail2(a: u8, b: u8) {
+            let y = a % b; // FAILS
+        }
+    } => Err(e) => assert_fails(e, 2)
+}
+
+test_verify_one_file! {
+    #[test] test_literal_out_of_range code! {
+        const C: u8 = 256 - 1;
+    } => Err(e) => assert_vir_error(e)
 }

--- a/source/rust_verify/tests/refs.rs
+++ b/source/rust_verify/tests/refs.rs
@@ -249,14 +249,14 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_mut_ref_forward code! {
-        fn add1(a: &mut u64) {
-            ensures(*a == *old(a) + 1);
-            *a = *a + 1;
+        fn div2(a: &mut u64) {
+            ensures(*a == *old(a) / 2);
+            *a = *a / 2;
         }
 
         fn test(b: &mut u64) {
-            ensures(*b == *old(b) + 1);
-            add1(b);
+            ensures(*b == *old(b) / 2);
+            div2(b);
         }
     } => Ok(())
 }

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -596,6 +596,6 @@ pub fn simplify_krate(ctx: &mut GlobalCtx, krate: &Krate) -> Result<Krate, VirEr
     let traits = traits.clone();
     let module_ids = module_ids.clone();
     let krate = Arc::new(KrateX { functions, datatypes, traits, module_ids });
-    *ctx = crate::context::GlobalCtx::new(&krate, ctx.no_span.clone())?;
+    *ctx = crate::context::GlobalCtx::new(&krate, ctx.no_span.clone(), ctx.inferred_modes.clone())?;
     Ok(krate)
 }

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -22,7 +22,7 @@ type Args = Arc<Vec<Arg>>;
 
 pub(crate) struct State {
     // View exec/proof code as spec
-    // (used for is_const functions, where we let Rust --compile check for overflow)
+    // (used for is_const functions, which are viewable both as spec and exec)
     view_as_spec: bool,
     // Counter to generate temporary variables
     next_var: u64,

--- a/source/vir/src/context.rs
+++ b/source/vir/src/context.rs
@@ -1,6 +1,6 @@
 use crate::ast::{
-    Datatype, Fun, Function, FunctionKind, GenericBound, IntRange, Krate, Mode, Path, Trait, TypX,
-    Variants, VirErr,
+    Datatype, Fun, Function, FunctionKind, GenericBound, InferMode, IntRange, Krate, Mode, Path,
+    Trait, TypX, Variants, VirErr,
 };
 use crate::datatype_to_air::is_datatype_transparent;
 use crate::def::FUEL_ID;
@@ -24,6 +24,7 @@ pub struct GlobalCtx {
     pub func_call_graph: Graph<Node>,
     pub func_call_sccs: Vec<Node>,
     pub method_map: HashMap<(Fun, Path), Fun>,
+    pub(crate) inferred_modes: HashMap<InferMode, Mode>,
 }
 
 // Context for verifying one module
@@ -107,7 +108,11 @@ fn datatypes_invs(
 }
 
 impl GlobalCtx {
-    pub fn new(krate: &Krate, no_span: Span) -> Result<Self, VirErr> {
+    pub fn new(
+        krate: &Krate,
+        no_span: Span,
+        inferred_modes: HashMap<InferMode, Mode>,
+    ) -> Result<Self, VirErr> {
         let chosen_triggers: std::cell::RefCell<Vec<(Span, Vec<Vec<String>>)>> =
             std::cell::RefCell::new(Vec::new());
         let datatypes: HashMap<Path, Variants> =
@@ -143,6 +148,7 @@ impl GlobalCtx {
             func_call_graph,
             func_call_sccs,
             method_map,
+            inferred_modes,
         })
     }
 

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -113,7 +113,7 @@ fn func_body_to_air(
     let pars = params_to_pars(&function.x.params, false);
 
     // ast --> sst
-    let (local_decls, body_exp) = crate::ast_to_sst::expr_to_decls_exp(&ctx, &pars, &body)?;
+    let (local_decls, body_exp) = crate::ast_to_sst::expr_to_decls_exp(&ctx, true, &pars, &body)?;
 
     // Check termination
     let (is_recursive, termination_commands, body_exp) =
@@ -274,7 +274,7 @@ pub fn func_name_to_air(ctx: &Ctx, function: &Function) -> Result<Commands, VirE
 
         // Check whether we need to declare the recursive version too
         if let Some(body) = &function.x.body {
-            let body_exp = crate::ast_to_sst::expr_to_exp(
+            let body_exp = crate::ast_to_sst::expr_to_exp_as_spec(
                 &ctx,
                 &params_to_pars(&function.x.params, false),
                 &body,

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -518,8 +518,12 @@ pub fn func_def_to_air(
     ctx: &Ctx,
     function: &Function,
 ) -> Result<(Commands, Vec<(Span, SnapPos)>), VirErr> {
-    match (function.x.mode, function.x.ret.as_ref(), function.x.body.as_ref()) {
-        (Mode::Exec, _, Some(body)) | (Mode::Proof, _, Some(body)) => {
+    match (function.x.mode, function.x.is_const, function.x.body.as_ref()) {
+        (Mode::Spec, true, Some(body))
+        | (Mode::Proof, _, Some(body))
+        | (Mode::Exec, _, Some(body)) => {
+            // Note: since is_const functions serve double duty as exec and spec,
+            // we generate an exec check for them here to catch any arithmetic overflows.
             let (trait_typ_substs, req_ens_function) = if let FunctionKind::TraitMethodImpl {
                 method,
                 trait_path,

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -336,7 +336,7 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
             use BinaryOp::*;
             let native = match op {
                 And | Or | Xor | Implies | Le | Ge | Lt | Gt => true,
-                Add | Sub | Mul | EuclideanDiv | EuclideanMod => true,
+                Arith(..) => true,
                 Eq(_) | Ne => false,
                 BitXor | BitAnd | BitOr | Shr | Shl => true,
             };

--- a/source/vir/src/printer.rs
+++ b/source/vir/src/printer.rs
@@ -254,6 +254,9 @@ fn expr_to_node(expr: &Expr) -> Node {
             BinaryOp::Eq(mode) => {
                 nodes!(eq {str_to_node(":mode")} {str_to_node(&format!("{:?}", mode))} {expr_to_node(e1)} {expr_to_node(e2)})
             }
+            BinaryOp::Arith(op, _) => {
+                nodes!({str_to_node(&format!("{:?}", op))} {expr_to_node(e1)} {expr_to_node(e2)})
+            }
             _ => {
                 nodes!({str_to_node(&format!("{:?}", binary_op).to_lowercase())} {expr_to_node(e1)} {expr_to_node(e2)})
             }

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -92,7 +92,7 @@ fn check_trigger_expr(exp: &Exp, free_vars: &mut HashSet<Ident>) -> Result<(), V
                         err_str(&exp.span, "triggers cannot contain boolean operators")
                     }
                     Le | Ge | Lt | Gt => Ok(()),
-                    Add | Sub | Mul | EuclideanDiv | EuclideanMod => Ok(()),
+                    Arith(..) => Ok(()),
                     BitXor | BitAnd | BitOr | Shr | Shl => Ok(()),
                 }
             }

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -314,7 +314,7 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
             use BinaryOp::*;
             let depth = match op {
                 And | Or | Xor | Implies | Eq(_) => 0,
-                Ne | Le | Ge | Lt | Gt | Add | Sub | Mul | EuclideanDiv | EuclideanMod => 1,
+                Ne | Le | Ge | Lt | Gt | Arith(..) => 1,
                 BitXor | BitAnd | BitOr | Shr | Shl => 1,
             };
             let (_, term1) = gather_terms(ctxt, ctx, e1, depth);


### PR DESCRIPTION
This should make it easier to diagnose verification failures caused by potential integer overflow.  See https://github.com/secure-foundations/verus/issues/45 .