### PR TITLE
verifier(non_linear) attribute

### DIFF
--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -136,6 +136,8 @@ pub(crate) enum Attr {
     DecreasesBy,
     // in a spec function, check the body for violations of recommends
     CheckRecommends,
+    // set smt.arith.nl=true
+    NonLinear,
 }
 
 fn get_trigger_arg(span: Span, attr_tree: &AttrTree) -> Result<u64, VirErr> {
@@ -245,6 +247,9 @@ pub(crate) fn parse_attrs(attrs: &[Attribute]) -> Result<Vec<Attr>, VirErr> {
                 {
                     v.push(Attr::ReturnMode(Mode::Exec))
                 }
+                Some(box [AttrTree::Fun(_, arg, None)]) if arg == "non_linear" => {
+                    v.push(Attr::NonLinear)
+                }
                 _ => return err_span_str(*span, "unrecognized verifier attribute"),
             },
             _ => {}
@@ -333,6 +338,7 @@ pub(crate) struct VerifierAttrs {
     pub(crate) is_variant: bool,
     pub(crate) decreases_by: bool,
     pub(crate) check_recommends: bool,
+    pub(crate) non_linear: bool,
 }
 
 pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, VirErr> {
@@ -354,6 +360,7 @@ pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, V
         is_variant: false,
         decreases_by: false,
         check_recommends: false,
+        non_linear: false,
     };
     for attr in parse_attrs(attrs)? {
         match attr {
@@ -374,6 +381,7 @@ pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, V
             Attr::IsVariant => vs.is_variant = true,
             Attr::DecreasesBy => vs.decreases_by = true,
             Attr::CheckRecommends => vs.check_recommends = true,
+            Attr::NonLinear => vs.non_linear = true,
             _ => {}
         }
     }

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -248,6 +248,7 @@ pub(crate) fn check_item_fn<'tcx>(
         atomic: vattrs.atomic,
         is_decrease_by: vattrs.decreases_by,
         check_recommends: vattrs.check_recommends,
+        non_linear: vattrs.non_linear,
     };
     let func = FunctionX {
         name: name.clone(),

--- a/source/rust_verify/tests/non_linear.rs
+++ b/source/rust_verify/tests/non_linear.rs
@@ -1,0 +1,94 @@
+// Some testcases are ported from https://github.com/secure-foundations/libraries/tree/master/src/NonlinearArithmetic
+
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+// TODO: add testcases for assert_by_nonlinear
+// TODO: make sure testcases do not timeout
+test_verify_one_file! {
+    #[test] test1 code! {
+        #[verifier(non_linear)]
+        #[proof]
+        fn LemmaMulUpperBound(x: int, XBound: int, y: int, YBound: int) {
+            requires([
+                x <= XBound,
+                y <= YBound,
+                0 <= x,
+                0 <= y,
+            ]);
+            ensures (x * y <= XBound * YBound);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test2 code! {
+        #[verifier(non_linear)]
+        #[proof]
+        fn LemmaMulStayPositive(x: int, y: int) {
+            requires([
+                0 <= x,
+                0 <= y,
+            ]);
+            ensures (0 <= x * y);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test3 code! {
+        #[verifier(non_linear)]
+        #[proof]
+        fn LemmaInequalityAfterMul(x: int, y: int, z: int) {
+            requires([
+                x <= y,
+                0 <= z,
+            ]);
+            ensures (x*z <= y*z);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test4 code! {
+        #[verifier(non_linear)]
+        #[proof]
+        fn LemmaDivPosIsPos(x: int, d: int) {
+            requires([
+                0 <= x,
+                0 < d,
+            ]);
+            ensures(0 <= x / d);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test1_fails code! {
+        #[verifier(non_linear)]
+        #[proof]
+        fn wrong_lemma_1(x: int, y: int, z: int) {
+            requires([
+                x <= y,
+                0 <= z,
+            ]);
+            ensures (x*z < y*z);
+        }
+    } => Err(_)
+}
+
+test_verify_one_file! {
+    #[test] test2_fails code! {
+        #[verifier(non_linear)]
+        #[proof]
+        fn wrong_lemma_2(x: int, y: int, z: int) {
+            requires([
+                x > y,
+                3 <= z,
+            ]);
+            ensures (y*z > x);
+        }
+    } => Err(_)
+}

--- a/source/rust_verify/tests/non_linear.rs
+++ b/source/rust_verify/tests/non_linear.rs
@@ -11,14 +11,14 @@ test_verify_one_file! {
     #[test] test1 code! {
         #[verifier(non_linear)]
         #[proof]
-        fn LemmaMulUpperBound(x: int, XBound: int, y: int, YBound: int) {
+        fn lemma_mul_upper_bound(x: int, x_bound: int, y: int, y_bound: int) {
             requires([
-                x <= XBound,
-                y <= YBound,
+                x <= x_bound,
+                y <= y_bound,
                 0 <= x,
                 0 <= y,
             ]);
-            ensures (x * y <= XBound * YBound);
+            ensures (x * y <= x_bound * y_bound);
         }
     } => Ok(())
 }
@@ -27,7 +27,7 @@ test_verify_one_file! {
     #[test] test2 code! {
         #[verifier(non_linear)]
         #[proof]
-        fn LemmaMulStayPositive(x: int, y: int) {
+        fn lemma_mul_stay_positive(x: int, y: int) {
             requires([
                 0 <= x,
                 0 <= y,
@@ -41,7 +41,7 @@ test_verify_one_file! {
     #[test] test3 code! {
         #[verifier(non_linear)]
         #[proof]
-        fn LemmaInequalityAfterMul(x: int, y: int, z: int) {
+        fn lemma_inequality_after_mul(x: int, y: int, z: int) {
             requires([
                 x <= y,
                 0 <= z,
@@ -55,7 +55,7 @@ test_verify_one_file! {
     #[test] test4 code! {
         #[verifier(non_linear)]
         #[proof]
-        fn LemmaDivPosIsPos(x: int, d: int) {
+        fn lemma_div_pos_is_pos(x: int, d: int) {
             requires([
                 0 <= x,
                 0 < d,

--- a/source/rust_verify/tests/non_linear.rs
+++ b/source/rust_verify/tests/non_linear.rs
@@ -74,9 +74,9 @@ test_verify_one_file! {
                 x <= y,
                 0 <= z,
             ]);
-            ensures (x*z < y*z);
+            ensures (x*z < y*z); // FAILS
         }
-    } => Err(_)
+    } => Err(e) => assert_one_fails(e)
 }
 
 test_verify_one_file! {
@@ -88,7 +88,7 @@ test_verify_one_file! {
                 x > y,
                 3 <= z,
             ]);
-            ensures (y*z > x);
+            ensures (y*z > x); // FAILS
         }
-    } => Err(_)
+    } => Err(e) => assert_one_fails(e)
 }

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -439,6 +439,8 @@ pub struct FunctionAttrsX {
     pub is_decrease_by: bool,
     /// In a spec function, check the body for violations of recommends
     pub check_recommends: bool,
+    /// set option smt.arith.nl=true
+    pub non_linear: bool,
 }
 
 /// Function specification of its invariant mask

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -675,6 +675,7 @@ pub fn func_def_to_air(
                 &stm,
                 function.x.attrs.bit_vector,
                 skip_ensures,
+                function.x.attrs.non_linear,
             );
 
             state.finalize();

--- a/source/vir/src/printer.rs
+++ b/source/vir/src/printer.rs
@@ -404,6 +404,7 @@ fn function_to_node(function: &FunctionX) -> Node {
             atomic,
             is_decrease_by,
             check_recommends,
+            non_linear,
         } = &**attrs;
 
         let mut nodes = vec![
@@ -435,6 +436,9 @@ fn function_to_node(function: &FunctionX) -> Node {
         }
         if *check_recommends {
             nodes.push(str_to_node("+check_recommends"));
+        }
+        if *non_linear {
+            nodes.push(str_to_node("+non_linear"));
         }
 
         Node::List(nodes)

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -371,6 +371,7 @@ pub(crate) fn check_termination_exp(
         &stm_block,
         false,
         false,
+        false,
     );
 
     // New body: substitute rec%f(args, fuel) for f(args)

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1429,6 +1429,7 @@ pub fn body_stm_to_air(
     stm: &Stm,
     is_bit_vector_mode: bool,
     skip_ensures: bool,
+    is_non_linear: bool,
 ) -> (Commands, Vec<(Span, SnapPos)>) {
     // Verifying a single function can generate multiple SMT queries.
     // Some declarations (local_shared) are shared among the queries.
@@ -1553,6 +1554,18 @@ pub fn body_stm_to_air(
     }
 
     let query = Arc::new(QueryX { local: Arc::new(local), assertion });
-    state.commands.push(Arc::new(CommandX::CheckValid(query)));
+    if is_non_linear {
+        state.commands.push(Arc::new(CommandX::SetOption(
+            Arc::new(String::from("smt.arith.nl")),
+            Arc::new(String::from("true")),
+        )));
+        state.commands.push(Arc::new(CommandX::CheckValid(query)));
+        state.commands.push(Arc::new(CommandX::SetOption(
+            Arc::new(String::from("smt.arith.nl")),
+            Arc::new(String::from("false")),
+        )));
+    } else {
+        state.commands.push(Arc::new(CommandX::CheckValid(query)));
+    }
     (Arc::new(state.commands), state.snap_map)
 }


### PR DESCRIPTION
This PR simply adds `#[verifier(non_linear)]`, which is to set `smt.arith.nl=true` only for the annotated function.
This is expected to be useful for functions with much non-linear arithmetic operations.


(In another branch, I am also working on single line non-linear assertion:  `assert_by_nonlinear`, which is `assert_by` with `smt.arith.nl=true`)




