### PR TITLE
Extraction of `#[is_variant]` function declarations and calls was brittle

### DIFF
--- a/source/builtin_macros/src/is_variant.rs
+++ b/source/builtin_macros/src/is_variant.rs
@@ -23,19 +23,16 @@ pub fn attribute_is_variant(
                     .iter()
                     .map(|f| {
                         let field_ty = &f.ty;
+                        let field_ident = f.ident.as_ref().expect("missing field ident");
                         let get_ident = syn::Ident::new(
-                            &format!(
-                                "get_{}_{}",
-                                variant_ident_str,
-                                f.ident.as_ref().expect("missing field ident").to_string()
-                            ),
+                            &format!("get_{}_{}", variant_ident_str, field_ident.to_string()),
                             v.ast().ident.span(),
                         );
 
                         quote! {
                             #[spec]
                             #[allow(non_snake_case)]
-                            #[verifier(is_variant)]
+                            #[verifier(get_variant(#variant_ident, #field_ident))]
                             pub fn #get_ident(self) -> #field_ty {
                                 unimplemented!()
                             }
@@ -47,15 +44,19 @@ pub fn attribute_is_variant(
                     .zip(0..)
                     .map(|(f, i)| {
                         let field_ty = &f.ty;
+                        let field_lit = syn::Lit::Int(syn::LitInt::new(
+                            &format!("{}", i),
+                            v.ast().ident.span(),
+                        ));
                         let get_ident = syn::Ident::new(
-                            &format!("get_{}_{}", variant_ident_str, i),
+                            &format!("get_{}_{}", variant_ident, i),
                             v.ast().ident.span(),
                         );
 
                         quote! {
                             #[spec]
                             #[allow(non_snake_case)]
-                            #[verifier(is_variant)]
+                            #[verifier(get_variant(#variant_ident_str, #field_lit))]
                             pub fn #get_ident(self) -> #field_ty {
                                 unimplemented!()
                             }
@@ -67,7 +68,7 @@ pub fn attribute_is_variant(
 
             quote! {
                 #[spec]
-                #[verifier(is_variant)]
+                #[verifier(is_variant(#variant_ident_str))]
                 #[allow(non_snake_case)]
                 pub fn #fun_ident(&self) -> bool { unimplemented!() }
 

--- a/source/rust_verify/Cargo.toml
+++ b/source/rust_verify/Cargo.toml
@@ -11,7 +11,6 @@ air = { path = "../air" }
 vir = { path = "../vir" }
 sise = "0.6.0"
 getopts = { git = "https://github.com/utaal/getopts.git", branch = "parse-partial" }
-regex = "1"
 
 [target.'cfg(windows)'.dependencies]
 win32job = "1"

--- a/source/rust_verify/src/def.rs
+++ b/source/rust_verify/src/def.rs
@@ -1,38 +1,10 @@
-use regex::Regex;
+pub const IS_VARIANT_PREFIX: &str = "is";
+pub const GET_VARIANT_PREFIX: &str = "get";
 
-pub const IS_VARIANT_PREFIX: &str = "is_";
-pub const GET_VARIANT_PREFIX: &str = "get_";
-
-pub(crate) enum FieldName {
-    Named(String),
-    Unnamed(usize),
+pub(crate) fn is_variant_fn_name(variant_ident: &str) -> String {
+    format!("{}_{}", crate::def::IS_VARIANT_PREFIX, variant_ident)
 }
 
-/// Returns `Some((name, field))` if the ident matches the expected name for #[is_variant] functions
-/// `name` is the variant name
-/// `field` is `Some(num)` if this was a `.get_Variant_num()` function
-/// `field` is `None` if this was a `.is_Variant` function
-pub(crate) fn is_get_variant_fn_name(
-    ident: &rustc_span::symbol::Ident,
-) -> Option<(String, Option<FieldName>)> {
-    let fn_name = ident.as_str();
-    fn_name.strip_prefix(crate::def::IS_VARIANT_PREFIX).map(|n| (n.to_string(), None)).or_else(
-        || {
-            let re =
-                Regex::new(&("^".to_string() + crate::def::GET_VARIANT_PREFIX + r"(.+)_(.+)$"))
-                    .unwrap();
-            re.captures(&fn_name).map(|c| {
-                let f_name = c.get(2).unwrap().as_str().to_string();
-                let v_name = c.get(1).unwrap().as_str().to_string();
-
-                (
-                    v_name,
-                    Some(match f_name.parse::<usize>().ok() {
-                        Some(i) => FieldName::Unnamed(i),
-                        None => FieldName::Named(f_name),
-                    }),
-                )
-            })
-        },
-    )
+pub(crate) fn get_variant_fn_name(variant_ident: &str, field_ident: &str) -> String {
+    format!("{}_{}_{}", crate::def::GET_VARIANT_PREFIX, variant_ident, field_ident)
 }

--- a/source/rust_verify/src/erase.rs
+++ b/source/rust_verify/src/erase.rs
@@ -1097,7 +1097,7 @@ fn erase_assoc_item(
             if vattrs.external {
                 return Some(item.clone());
             }
-            if vattrs.is_variant {
+            if vattrs.is_variant.is_some() || vattrs.get_variant.is_some() {
                 return None;
             }
             let erased = erase_fn(ctxt, mctxt, f, vattrs.external_body, is_trait);

--- a/source/rust_verify/tests/adts.rs
+++ b/source/rust_verify/tests/adts.rs
@@ -722,3 +722,28 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] test_if_is_variant_underscore_in_name_regression code! {
+        #[is_variant]
+        #[allow(non_camel_case_types)]
+        enum Has_Underscores {
+            #[allow(non_camel_case_types)]
+            More_Underscores,
+            #[allow(non_camel_case_types)]
+            A_Couple_More(nat),
+        }
+
+        #[proof]
+        fn test(h: Has_Underscores) {
+            requires([
+                     h.is_A_Couple_More(),
+                     match h {
+                         Has_Underscores::More_Underscores => false,
+                         Has_Underscores::A_Couple_More(x) => x == 10,
+                     }
+            ]);
+            assert(h.get_A_Couple_More_0() == 10);
+        }
+    } => Ok(())
+}


### PR DESCRIPTION
Use more precise auto-generated `#[verifier(is_variant(...))]` and `get_variant` attributes that contain the variant ident and field separately.

cc/ @jonhnet 