### PR TITLE
`assert_nonlinear_by`

### DIFF
--- a/source/air/src/ast.rs
+++ b/source/air/src/ast.rs
@@ -182,3 +182,6 @@ pub enum CommandX {
     Global(Decl),            // global declarations
     CheckValid(Query),       // SMT check-sat (reporting validity rather than satisfiability)
 }
+
+pub type SpannedCommand = (Option<Arc<Span>>, Command);
+pub type SpannedCommands = Arc<Vec<SpannedCommand>>;

--- a/source/air/src/ast.rs
+++ b/source/air/src/ast.rs
@@ -182,6 +182,3 @@ pub enum CommandX {
     Global(Decl),            // global declarations
     CheckValid(Query),       // SMT check-sat (reporting validity rather than satisfiability)
 }
-
-pub type SpannedCommand = (Option<Arc<Span>>, Command);
-pub type SpannedCommands = Arc<Vec<SpannedCommand>>;

--- a/source/air/src/ast_util.rs
+++ b/source/air/src/ast_util.rs
@@ -1,6 +1,6 @@
 use crate::ast::{
-    BinaryOp, Bind, BindX, Binder, BinderX, Constant, DeclX, Expr, ExprX, Exprs, Ident, MultiOp,
-    Quant, Span, Trigger, Typ, TypX, Typs, UnaryOp,
+    BinaryOp, Bind, BindX, Binder, BinderX, Command, CommandX, Constant, DeclX, Expr, ExprX, Exprs,
+    Ident, MultiOp, Quant, Span, Trigger, Typ, TypX, Typs, UnaryOp,
 };
 use crate::errors::ErrorX;
 use std::fmt::Debug;
@@ -258,4 +258,8 @@ pub fn mk_ite(e1: &Expr, e2: &Expr, e3: &Expr) -> Expr {
 
 pub fn mk_eq(e1: &Expr, e2: &Expr) -> Expr {
     Arc::new(ExprX::Binary(BinaryOp::Eq, e1.clone(), e2.clone()))
+}
+
+pub fn mk_option_command(s1: &str, s2: &str) -> Command {
+    Arc::new(CommandX::SetOption(Arc::new(String::from(s1)), Arc::new(String::from(s2))))
 }

--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -156,6 +156,11 @@ pub fn assert_by(_: bool, _: ()) {
 }
 
 #[proof]
+pub fn assert_by_nonlinear(_: ()) {
+    unimplemented!();
+}
+
+#[proof]
 pub fn assert_forall_by<A>(_a: A) {
     unimplemented!();
 }

--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -169,7 +169,7 @@ pub fn assert_by(_: bool, _: ()) {
 }
 
 #[proof]
-pub fn assert_by_nonlinear(_: bool, _: ()) {
+pub fn assert_nonlinear_by(_: ()) {
     unimplemented!();
 }
 

--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -156,7 +156,7 @@ pub fn assert_by(_: bool, _: ()) {
 }
 
 #[proof]
-pub fn assert_by_nonlinear(_: ()) {
+pub fn assert_by_nonlinear(_: bool, _: ()) {
     unimplemented!();
 }
 

--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -277,7 +277,7 @@ pub(crate) fn parse_attrs(attrs: &[Attribute]) -> Result<Vec<Attr>, VirErr> {
                 {
                     v.push(Attr::ReturnMode(Mode::Exec))
                 }
-                Some(box [AttrTree::Fun(_, arg, None)]) if arg == "non_linear" => {
+                Some(box [AttrTree::Fun(_, arg, None)]) if arg == "nonlinear" => {
                     v.push(Attr::NonLinear)
                 }
                 _ => return err_span_str(*span, "unrecognized verifier attribute"),
@@ -369,7 +369,7 @@ pub(crate) struct VerifierAttrs {
     pub(crate) get_variant: Option<(String, GetVariantField)>,
     pub(crate) decreases_by: bool,
     pub(crate) check_recommends: bool,
-    pub(crate) non_linear: bool,
+    pub(crate) nonlinear: bool,
 }
 
 pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, VirErr> {
@@ -392,7 +392,7 @@ pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, V
         get_variant: None,
         decreases_by: false,
         check_recommends: false,
-        non_linear: false,
+        nonlinear: false,
     };
     for attr in parse_attrs(attrs)? {
         match attr {
@@ -416,7 +416,7 @@ pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, V
             }
             Attr::DecreasesBy => vs.decreases_by = true,
             Attr::CheckRecommends => vs.check_recommends = true,
-            Attr::NonLinear => vs.non_linear = true,
+            Attr::NonLinear => vs.nonlinear = true,
             _ => {}
         }
     }

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -399,6 +399,7 @@ fn fn_call_to_vir<'tcx>(
     let is_reveal_fuel = f_name == "builtin::reveal_with_fuel";
     let is_implies = f_name == "builtin::imply";
     let is_assert_by = f_name == "builtin::assert_by";
+    let is_assert_by_nonlinear = f_name == "builtin::assert_by_nonlinear";
     let is_assert_forall_by = f_name == "builtin::assert_forall_by";
     let is_assert_bit_vector = f_name == "builtin::assert_bit_vector";
     let is_old = f_name == "builtin::old";
@@ -480,6 +481,7 @@ fn fn_call_to_vir<'tcx>(
             || is_choose_tuple
             || is_with_triggers
             || is_assert_by
+            || is_assert_by_nonlinear
             || is_assert_forall_by
             || is_assert_bit_vector
             || is_old
@@ -638,6 +640,32 @@ fn fn_call_to_vir<'tcx>(
         let proof = expr_to_vir(bctx, &args[1], ExprModifier::REGULAR)?;
         return Ok(mk_expr(ExprX::Forall { vars, require, ensure, proof }));
     }
+    if is_assert_by_nonlinear {
+        unsupported_err_unless!(len == 1, expr.span, "expected assert_by_nonlinear", &args);
+        // let vars = Arc::new(vec![]);
+        // let require =
+            // spanned_typed_new(expr.span, &Arc::new(TypX::Bool), ExprX::Const(Constant::Bool(true)));
+        let mut vir_expr = expr_to_vir(bctx, &args[0], ExprModifier::REGULAR)?; 
+        let header = vir::headers::read_header(&mut vir_expr)?;
+        // let ensure = expr_to_vir(bctx, &args[0], ExprModifier::REGULAR)?;
+        // let require = expr_to_vir(bctx, &args[1], ExprModifier::REGULAR)?;
+        // let require = if header.require.len() == 1 {
+        //     header.require[0].clone()
+        // } else {
+        //     spanned_typed_new(span, &Arc::new(TypX::Bool), ExprX::Const(Constant::Bool(true)))
+        // };
+        println!("{:?}", header.require[0]);
+        println!("{:?}", header.require.len());
+        let require = header.require[0].clone();
+        let ensure = header.ensure[0].clone();
+        let proof = vir_expr;
+        // println!("{:?}", require);
+        // println!("{:?}", ensure);
+        // println!("{:?}", proof);
+        // let proof = expr_to_vir(bctx, &args[2], ExprModifier::REGULAR)?;
+        // panic!();
+        return Ok(mk_expr(ExprX::AssertNonLinear{require , ensure, proof}));
+    } 
     if is_assert_forall_by {
         unsupported_err_unless!(len == 1, expr.span, "expected assert_forall_by", &args);
         return extract_assert_forall_by(bctx, expr.span, args[0]);

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -27,9 +27,9 @@ use rustc_span::def_id::DefId;
 use rustc_span::Span;
 use std::sync::Arc;
 use vir::ast::{
-    ArithOp, ArmX, BinaryOp, CallTarget, Constant, ExprX, FieldOpr, FunX, HeaderExpr, HeaderExprX,
-    Ident, IntRange, InvAtomicity, Mode, PatternX, SpannedTyped, StmtX, Stmts, Typ, TypX, UnaryOp,
-    UnaryOpr, VarAt, VirErr,
+    ArithOp, ArmX, AssertQueryMode, BinaryOp, CallTarget, Constant, ExprX, FieldOpr, FunX,
+    HeaderExpr, HeaderExprX, Ident, IntRange, InvAtomicity, Mode, PatternX, SpannedTyped, StmtX,
+    Stmts, Typ, TypX, UnaryOp, UnaryOpr, VarAt, VirErr,
 };
 use vir::ast_util::{ident_binder, path_as_rust_name};
 use vir::def::positional_field_ident;
@@ -400,7 +400,7 @@ fn fn_call_to_vir<'tcx>(
     let is_reveal_fuel = f_name == "builtin::reveal_with_fuel";
     let is_implies = f_name == "builtin::imply";
     let is_assert_by = f_name == "builtin::assert_by";
-    let is_assert_by_nonlinear = f_name == "builtin::assert_by_nonlinear";
+    let is_assert_nonlinear_by = f_name == "builtin::assert_nonlinear_by";
     let is_assert_forall_by = f_name == "builtin::assert_forall_by";
     let is_assert_bit_vector = f_name == "builtin::assert_bit_vector";
     let is_old = f_name == "builtin::old";
@@ -493,7 +493,7 @@ fn fn_call_to_vir<'tcx>(
             || is_choose_tuple
             || is_with_triggers
             || is_assert_by
-            || is_assert_by_nonlinear
+            || is_assert_nonlinear_by
             || is_assert_forall_by
             || is_assert_bit_vector
             || is_old
@@ -652,14 +652,14 @@ fn fn_call_to_vir<'tcx>(
         let proof = expr_to_vir(bctx, &args[1], ExprModifier::REGULAR)?;
         return Ok(mk_expr(ExprX::Forall { vars, require, ensure, proof }));
     }
-    if is_assert_by_nonlinear {
+    if is_assert_nonlinear_by {
         unsupported_err_unless!(
-            len == 2,
+            len == 1,
             expr.span,
-            "expected assert_by_nonlinear with two arguments",
+            "expected assert_nonlinear_by with one argument",
             &args
         );
-        let mut vir_expr = expr_to_vir(bctx, &args[1], ExprModifier::REGULAR)?;
+        let mut vir_expr = expr_to_vir(bctx, &args[0], ExprModifier::REGULAR)?;
         let header = vir::headers::read_header(&mut vir_expr)?;
         let requires = if header.require.len() >= 1 {
             header.require
@@ -670,9 +670,17 @@ fn fn_call_to_vir<'tcx>(
                 ExprX::Const(Constant::Bool(true)),
             )])
         };
-        let ensure = expr_to_vir(bctx, &args[0], ExprModifier::REGULAR)?;
+        if header.ensure.len() == 0 {
+            return err_span_str(expr.span, "assert_nonlinear_by must have at least one ensures");
+        }
+        let ensures = header.ensure;
         let proof = vir_expr;
-        return Ok(mk_expr(ExprX::AssertNonLinear { requires, ensure, proof }));
+        return Ok(mk_expr(ExprX::AssertQuery {
+            requires,
+            ensures,
+            proof,
+            mode: AssertQueryMode::NonLinear,
+        }));
     }
     if is_assert_forall_by {
         unsupported_err_unless!(len == 1, expr.span, "expected assert_forall_by", &args);

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -644,7 +644,7 @@ fn fn_call_to_vir<'tcx>(
         unsupported_err_unless!(
             len == 2,
             expr.span,
-            "expected assert_by_nonlinear with two argument",
+            "expected assert_by_nonlinear with two arguments",
             &args
         );
         let mut vir_expr = expr_to_vir(bctx, &args[1], ExprModifier::REGULAR)?;

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -641,31 +641,27 @@ fn fn_call_to_vir<'tcx>(
         return Ok(mk_expr(ExprX::Forall { vars, require, ensure, proof }));
     }
     if is_assert_by_nonlinear {
-        unsupported_err_unless!(len == 1, expr.span, "expected assert_by_nonlinear", &args);
-        // let vars = Arc::new(vec![]);
-        // let require =
-            // spanned_typed_new(expr.span, &Arc::new(TypX::Bool), ExprX::Const(Constant::Bool(true)));
-        let mut vir_expr = expr_to_vir(bctx, &args[0], ExprModifier::REGULAR)?; 
+        unsupported_err_unless!(
+            len == 2,
+            expr.span,
+            "expected assert_by_nonlinear with two argument",
+            &args
+        );
+        let mut vir_expr = expr_to_vir(bctx, &args[1], ExprModifier::REGULAR)?;
         let header = vir::headers::read_header(&mut vir_expr)?;
-        // let ensure = expr_to_vir(bctx, &args[0], ExprModifier::REGULAR)?;
-        // let require = expr_to_vir(bctx, &args[1], ExprModifier::REGULAR)?;
-        // let require = if header.require.len() == 1 {
-        //     header.require[0].clone()
-        // } else {
-        //     spanned_typed_new(span, &Arc::new(TypX::Bool), ExprX::Const(Constant::Bool(true)))
-        // };
-        println!("{:?}", header.require[0]);
-        println!("{:?}", header.require.len());
-        let require = header.require[0].clone();
-        let ensure = header.ensure[0].clone();
+        let requires = if header.require.len() >= 1 {
+            header.require
+        } else {
+            Arc::new(vec![spanned_typed_new(
+                expr.span,
+                &Arc::new(TypX::Bool),
+                ExprX::Const(Constant::Bool(true)),
+            )])
+        };
+        let ensure = expr_to_vir(bctx, &args[0], ExprModifier::REGULAR)?;
         let proof = vir_expr;
-        // println!("{:?}", require);
-        // println!("{:?}", ensure);
-        // println!("{:?}", proof);
-        // let proof = expr_to_vir(bctx, &args[2], ExprModifier::REGULAR)?;
-        // panic!();
-        return Ok(mk_expr(ExprX::AssertNonLinear{require , ensure, proof}));
-    } 
+        return Ok(mk_expr(ExprX::AssertNonLinear { requires, ensure, proof }));
+    }
     if is_assert_forall_by {
         unsupported_err_unless!(len == 1, expr.span, "expected assert_forall_by", &args);
         return extract_assert_forall_by(bctx, expr.span, args[0]);

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -248,7 +248,7 @@ pub(crate) fn check_item_fn<'tcx>(
         atomic: vattrs.atomic,
         is_decrease_by: vattrs.decreases_by,
         check_recommends: vattrs.check_recommends,
-        non_linear: vattrs.non_linear,
+        nonlinear: vattrs.nonlinear,
     };
     let func = FunctionX {
         name: name.clone(),

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -231,7 +231,7 @@ impl Verifier {
         assign_map: &HashMap<*const air::ast::Span, HashSet<Arc<std::string::String>>>,
         snap_map: &Vec<(air::ast::Span, SnapPos)>,
         command: &Command,
-        context: &(&air::ast::Span, String),
+        context: &(&air::ast::Span, &str),
     ) -> bool {
         let report_long_running = || {
             let mut counter = 0;
@@ -288,7 +288,7 @@ impl Verifier {
 
                     self.errors.push(vec![ErrorSpan::new_from_air_span(
                         compiler.session().source_map(),
-                        &context.1,
+                        &context.1.to_string(),
                         &context.0,
                     )]);
                     break;
@@ -399,7 +399,7 @@ impl Verifier {
                     assign_map,
                     snap_map,
                     &command,
-                    &(span, desc.clone()), // TODO string clone
+                    &(span, desc),
                 );
                 invalidity = invalidity || result_invalidity;
                 let time1 = Instant::now();
@@ -556,11 +556,6 @@ impl Verifier {
                     compiler,
                     error_as,
                     air_context,
-                    // TODO if check_recommends {
-                    // TODO     "recommends check"
-                    // TODO } else {
-                    // TODO     "function definition check"
-                    // TODO }
                     &commands,
                     &HashMap::new(),
                     &snap_map,

--- a/source/rust_verify/tests/assert_forall_by.rs
+++ b/source/rust_verify/tests/assert_forall_by.rs
@@ -261,3 +261,36 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_one_fails(err)
 }
+
+test_verify_one_file! {
+    #[test] test_assertby1_let code! {
+        #[spec]
+        #[verifier(opaque)]
+        fn f1(i: int) -> int {
+            i + 1
+        }
+
+        fn assertby_test() {
+            assert_by({ #[spec] let a = 3; f1(a) > a }, reveal(f1));
+            assert(f1(3) > 3);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_forallstmt_let code! {
+        #[spec]
+        #[verifier(opaque)]
+        fn f1(i: int) -> int {
+            i + 1
+        }
+
+        fn forallstmt_test() {
+            assert_forall_by(|x: nat| {
+                ensures({ #[spec] let a = 1; a <= #[trigger] f1(x) });
+                reveal(f1);
+            });
+            assert(f1(3) > 0);
+        }
+    } => Ok(())
+}

--- a/source/rust_verify/tests/loops.rs
+++ b/source/rust_verify/tests/loops.rs
@@ -273,3 +273,18 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_one_fails(err)
 }
+
+test_verify_one_file! {
+    #[test] basic_loop_new_vars code! {
+        fn test() {
+            #[spec] let mut a: int = 5;
+            loop {
+                invariant([
+                    {#[spec] let b = 0; a > b},
+                    {#[spec] let b = 0; a > b},
+                ]);
+                a = a + 1;
+            }
+        }
+    } => Ok(())
+}

--- a/source/rust_verify/tests/non_linear.rs
+++ b/source/rust_verify/tests/non_linear.rs
@@ -7,6 +7,7 @@ use common::*;
 
 // TODO: add testcases for assert_by_nonlinear
 // TODO: make sure testcases do not timeout
+// Test #[verifier(non_linear)]
 test_verify_one_file! {
     #[test] test1 code! {
         #[verifier(non_linear)]
@@ -65,6 +66,70 @@ test_verify_one_file! {
     } => Ok(())
 }
 
+// Test `assert_by_nonlinear
+test_verify_one_file! {
+    #[test] test5 code! {
+        #[proof]
+        fn test5_bound_checking(x: u32, y: u32, z:u32) {
+            requires([
+                x <= 0xffff,
+                y <= 0xffff,
+                z <= 0xffff,
+            ]);
+
+            assert_by_nonlinear( (x as int) * (z as int) == ((x*z) as int), {
+                requires([
+                    x <= 0xffff,
+                    z <= 0xffff,
+                ]);
+                assert(0 <= (x as int) * (z as int));
+                assert((x as int) * (z as int) <= 0xffff*0xffff);
+            });
+            assert((x as int) * (z as int) == ((x*z) as int));
+
+            assert_by_nonlinear((y as int) * (z as int) == ( (y*z) as int), {
+                requires([
+                    y <= 0xffff,
+                    z <= 0xffff,
+                ]);
+                assert(0 <= (y as int) * (z as int));
+                assert((y as int) * (z as int) <= 0xffff*0xffff);
+            });
+            assert((y as int) * (z as int) == ((y*z) as int));
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test6 code! {
+        #[proof]
+        fn test6(x: u32, y: u32, z:u32) {
+            requires(x < 0xfff);
+
+            assert_by_nonlinear(x*x + x == x * (x + 1), {
+                requires(x < 0xfff);
+            });
+            assert(x*x + x == x * (x + 1));
+
+            assert_by_nonlinear(x*y == y*x, {});
+            assert(x*y == y*x);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test7 code! {
+        #[proof]
+        fn test6(x: int, y: int, z:int) {
+            assert_by_nonlinear( (x+y)*z == x*z + y*z, {});
+            assert( (x+y)*z == x*z + y*z);
+
+            assert_by_nonlinear( (x-y)*z == x*z - y*z, {});
+            assert( (x-y)*z == x*z - y*z);
+        }
+    } => Ok(())
+}
+
 test_verify_one_file! {
     #[test] test1_fails code! {
         #[verifier(non_linear)]
@@ -89,6 +154,24 @@ test_verify_one_file! {
                 3 <= z,
             ]);
             ensures (y*z > x); // FAILS
+        }
+    } => Err(e) => assert_one_fails(e)
+}
+
+test_verify_one_file! {
+    #[test] test3_fails code! {
+        #[proof]
+        fn test3_fails(x: int, y: int, z: int) {
+            assert_by_nonlinear(x*y == y*z,{}) // FAILS
+        }
+    } => Err(e) => assert_one_fails(e)
+}
+
+test_verify_one_file! {
+    #[test] test4_fails code! {
+        #[proof]
+        fn test4_fails(x: u32, y: u32, z: u32) {
+            assert_by_nonlinear( (x as int) * (z as int) == ((x*z) as int), {}); //FAILS
         }
     } => Err(e) => assert_one_fails(e)
 }

--- a/source/rust_verify/tests/non_linear.rs
+++ b/source/rust_verify/tests/non_linear.rs
@@ -66,6 +66,34 @@ test_verify_one_file! {
     } => Ok(())
 }
 
+test_verify_one_file! {
+    #[test] test1_fails code! {
+        #[verifier(non_linear)]
+        #[proof]
+        fn wrong_lemma_1(x: int, y: int, z: int) {
+            requires([
+                x <= y,
+                0 <= z,
+            ]);
+            ensures (x*z < y*z); // FAILS
+        }
+    } => Err(e) => assert_one_fails(e)
+}
+
+test_verify_one_file! {
+    #[test] test2_fails code! {
+        #[verifier(non_linear)]
+        #[proof]
+        fn wrong_lemma_2(x: int, y: int, z: int) {
+            requires([
+                x > y,
+                3 <= z,
+            ]);
+            ensures (y*z > x); // FAILS
+        }
+    } => Err(e) => assert_one_fails(e)
+}
+
 // Test assert_by_nonlinear
 test_verify_one_file! {
     #[test] test5 code! {
@@ -131,34 +159,6 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test1_fails code! {
-        #[verifier(non_linear)]
-        #[proof]
-        fn wrong_lemma_1(x: int, y: int, z: int) {
-            requires([
-                x <= y,
-                0 <= z,
-            ]);
-            ensures (x*z < y*z); // FAILS
-        }
-    } => Err(e) => assert_one_fails(e)
-}
-
-test_verify_one_file! {
-    #[test] test2_fails code! {
-        #[verifier(non_linear)]
-        #[proof]
-        fn wrong_lemma_2(x: int, y: int, z: int) {
-            requires([
-                x > y,
-                3 <= z,
-            ]);
-            ensures (y*z > x); // FAILS
-        }
-    } => Err(e) => assert_one_fails(e)
-}
-
-test_verify_one_file! {
     #[test] test3_fails code! {
         #[proof]
         fn test3_fails(x: int, y: int, z: int) {
@@ -174,4 +174,17 @@ test_verify_one_file! {
             assert_by_nonlinear( (x as int) * (z as int) == ((x*z) as int), {}); //FAILS
         }
     } => Err(e) => assert_one_fails(e)
+}
+
+test_verify_one_file! {
+    #[test] test_assert_by_nonlinear_in_nonlinear code! {
+        #[proof] #[verifier(non_linear)]
+        fn test(x: u32) {
+            requires(x < 0xfff);
+            assert_by_nonlinear(x*x + x == x * (x + 1), {
+                requires(x < 0xfff);
+            });
+            assert(x*x + x == x * (x + 1));
+        }
+    } => Err(_)
 }

--- a/source/rust_verify/tests/non_linear.rs
+++ b/source/rust_verify/tests/non_linear.rs
@@ -5,8 +5,8 @@
 mod common;
 use common::*;
 
-// TODO: add testcases for assert_by_nonlinear
 // TODO: make sure testcases do not timeout
+
 // Test #[verifier(non_linear)]
 test_verify_one_file! {
     #[test] test1 code! {
@@ -66,7 +66,7 @@ test_verify_one_file! {
     } => Ok(())
 }
 
-// Test `assert_by_nonlinear
+// Test assert_by_nonlinear
 test_verify_one_file! {
     #[test] test5 code! {
         #[proof]

--- a/source/rust_verify/tests/nonlinear.rs
+++ b/source/rust_verify/tests/nonlinear.rs
@@ -266,7 +266,7 @@ test_verify_one_file! {
             assert_nonlinear_by({
                 requires({let z = 5; x == z});
                 ensures({let z = 2; x * z == 10});
-                let y = x * 2;
+                let y: nat = x as nat * 2;
                 assert(y == 10);
             });
             assert(x * 2 == 10);

--- a/source/rust_verify/tests/nonlinear.rs
+++ b/source/rust_verify/tests/nonlinear.rs
@@ -239,3 +239,16 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] test_new_vars code! {
+        #[proof]
+        fn test6(x: int) {
+            assert_by_nonlinear(x * 2 == 10, {
+                requires({let z = 5; x == z});
+                let y = x * 2;
+                assert(y == 10);
+            });
+        }
+    } => Ok(())
+}

--- a/source/rust_verify/tests/nonlinear.rs
+++ b/source/rust_verify/tests/nonlinear.rs
@@ -7,10 +7,10 @@ use common::*;
 
 // TODO: make sure testcases do not timeout
 
-// Test #[verifier(non_linear)]
+// Test #[verifier(nonlinear)]
 test_verify_one_file! {
     #[test] test1 code! {
-        #[verifier(non_linear)]
+        #[verifier(nonlinear)]
         #[proof]
         fn lemma_mul_upper_bound(x: int, x_bound: int, y: int, y_bound: int) {
             requires([
@@ -26,7 +26,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test2 code! {
-        #[verifier(non_linear)]
+        #[verifier(nonlinear)]
         #[proof]
         fn lemma_mul_stay_positive(x: int, y: int) {
             requires([
@@ -40,7 +40,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test3 code! {
-        #[verifier(non_linear)]
+        #[verifier(nonlinear)]
         #[proof]
         fn lemma_inequality_after_mul(x: int, y: int, z: int) {
             requires([
@@ -54,7 +54,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test4 code! {
-        #[verifier(non_linear)]
+        #[verifier(nonlinear)]
         #[proof]
         fn lemma_div_pos_is_pos(x: int, d: int) {
             requires([
@@ -68,7 +68,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test1_fails code! {
-        #[verifier(non_linear)]
+        #[verifier(nonlinear)]
         #[proof]
         fn wrong_lemma_1(x: int, y: int, z: int) {
             requires([
@@ -82,7 +82,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test2_fails code! {
-        #[verifier(non_linear)]
+        #[verifier(nonlinear)]
         #[proof]
         fn wrong_lemma_2(x: int, y: int, z: int) {
             requires([
@@ -178,7 +178,7 @@ test_verify_one_file! {
 
 test_verify_one_file! {
     #[test] test_assert_by_nonlinear_in_nonlinear code! {
-        #[proof] #[verifier(non_linear)]
+        #[proof] #[verifier(nonlinear)]
         fn test(x: u32) {
             requires(x < 0xfff);
             assert_by_nonlinear(x*x + x == x * (x + 1), {

--- a/source/rust_verify/tests/nonlinear.rs
+++ b/source/rust_verify/tests/nonlinear.rs
@@ -146,6 +146,19 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] test_requires code! {
+        #[proof]
+        fn test(x: nat, y: nat, z:nat) {
+            assert_by_nonlinear(x*x + x == x * (x + 1), {
+                requires(x < 0xfff);
+            });
+            assert(x < 0xfff >>= x*x + x == x * (x + 1));
+            assert(x*x + x == x * (x + 1)); // FAILS
+        }
+    } => Err(e) => assert_one_fails(e)
+}
+
+test_verify_one_file! {
     #[test] test7 code! {
         #[proof]
         fn test6(x: int, y: int, z:int) {
@@ -187,4 +200,14 @@ test_verify_one_file! {
             assert(x*x + x == x * (x + 1));
         }
     } => Err(_)
+}
+
+test_verify_one_file! {
+    #[test] test_negative code! {
+        #[proof]
+        fn test6(x: int, y: int, z:int) {
+            assert_by_nonlinear((x+y)*z == x*z + y*z, {});
+            assert(false); // FAILS
+        }
+    } => Err(e) => assert_one_fails(e)
 }

--- a/source/rust_verify/tests/nonlinear.rs
+++ b/source/rust_verify/tests/nonlinear.rs
@@ -249,6 +249,7 @@ test_verify_one_file! {
                 let y = x * 2;
                 assert(y == 10);
             });
+            assert(x * 2 == 10);
         }
     } => Ok(())
 }

--- a/source/rust_verify/tests/nonlinear.rs
+++ b/source/rust_verify/tests/nonlinear.rs
@@ -223,3 +223,19 @@ test_verify_one_file! {
         }
     } => Err(e) => assert_vir_error(e)
 }
+
+test_verify_one_file! {
+    #[test] test_complex_vars code! {
+        #[proof]
+        fn test6(a1: int, a2: int) {
+            let (b1, b2) = if a1 <= a2 {
+                (a1, a2)
+            } else {
+                (a2, a1)
+            };
+            assert_by_nonlinear(b1 <= b2, {
+                requires(b1 <= b2);
+            });
+        }
+    } => Ok(())
+}

--- a/source/rust_verify/tests/nonlinear.rs
+++ b/source/rust_verify/tests/nonlinear.rs
@@ -94,7 +94,7 @@ test_verify_one_file! {
     } => Err(e) => assert_one_fails(e)
 }
 
-// Test assert_by_nonlinear
+// Test assert_nonlinear_by
 test_verify_one_file! {
     #[test] test5 code! {
         #[proof]
@@ -105,21 +105,23 @@ test_verify_one_file! {
                 z <= 0xffff,
             ]);
 
-            assert_by_nonlinear( (x as int) * (z as int) == ((x*z) as int), {
+            assert_nonlinear_by({
                 requires([
                     x <= 0xffff,
                     z <= 0xffff,
                 ]);
+                ensures((x as int) * (z as int) == ((x*z) as int));
                 assert(0 <= (x as int) * (z as int));
                 assert((x as int) * (z as int) <= 0xffff*0xffff);
             });
             assert((x as int) * (z as int) == ((x*z) as int));
 
-            assert_by_nonlinear((y as int) * (z as int) == ( (y*z) as int), {
+            assert_nonlinear_by({
                 requires([
                     y <= 0xffff,
                     z <= 0xffff,
                 ]);
+                ensures((y as int) * (z as int) == ( (y*z) as int));
                 assert(0 <= (y as int) * (z as int));
                 assert((y as int) * (z as int) <= 0xffff*0xffff);
             });
@@ -134,12 +136,15 @@ test_verify_one_file! {
         fn test6(x: u32, y: u32, z:u32) {
             requires(x < 0xfff);
 
-            assert_by_nonlinear(x*x + x == x * (x + 1), {
+            assert_nonlinear_by({
                 requires(x < 0xfff);
+                ensures(x*x + x == x * (x + 1));
             });
             assert(x*x + x == x * (x + 1));
 
-            assert_by_nonlinear(x*y == y*x, {});
+            assert_nonlinear_by({
+                ensures(x*y == y*x);
+            });
             assert(x*y == y*x);
         }
     } => Ok(())
@@ -149,11 +154,11 @@ test_verify_one_file! {
     #[test] test_requires code! {
         #[proof]
         fn test(x: nat, y: nat, z:nat) {
-            assert_by_nonlinear(x*x + x == x * (x + 1), {
-                requires(x < 0xfff);
+            assert_nonlinear_by({
+                requires(x < 0xfff); // FAILS
+                ensures(x*x + x == x * (x + 1));
             });
-            assert(x < 0xfff >>= x*x + x == x * (x + 1));
-            assert(x*x + x == x * (x + 1)); // FAILS
+            assert(x*x + x == x * (x + 1));
         }
     } => Err(e) => assert_one_fails(e)
 }
@@ -162,11 +167,15 @@ test_verify_one_file! {
     #[test] test7 code! {
         #[proof]
         fn test6(x: int, y: int, z:int) {
-            assert_by_nonlinear( (x+y)*z == x*z + y*z, {});
-            assert( (x+y)*z == x*z + y*z);
+            assert_nonlinear_by({
+                ensures((x+y)*z == x*z + y*z);
+            });
+            assert((x+y)*z == x*z + y*z);
 
-            assert_by_nonlinear( (x-y)*z == x*z - y*z, {});
-            assert( (x-y)*z == x*z - y*z);
+            assert_nonlinear_by({
+                ensures((x-y)*z == x*z - y*z);
+            });
+            assert((x-y)*z == x*z - y*z);
         }
     } => Ok(())
 }
@@ -175,7 +184,9 @@ test_verify_one_file! {
     #[test] test3_fails code! {
         #[proof]
         fn test3_fails(x: int, y: int, z: int) {
-            assert_by_nonlinear(x*y == y*z,{}) // FAILS
+            assert_nonlinear_by({
+                ensures(x*y == y*z); // FAILS
+            });
         }
     } => Err(e) => assert_one_fails(e)
 }
@@ -184,18 +195,21 @@ test_verify_one_file! {
     #[test] test4_fails code! {
         #[proof]
         fn test4_fails(x: u32, y: u32, z: u32) {
-            assert_by_nonlinear( (x as int) * (z as int) == ((x*z) as int), {}); //FAILS
+            assert_nonlinear_by({
+                ensures((x as int) * (z as int) == ((x*z) as int)); //FAILS
+            });
         }
     } => Err(e) => assert_one_fails(e)
 }
 
 test_verify_one_file! {
-    #[test] test_assert_by_nonlinear_in_nonlinear code! {
+    #[test] test_assert_nonlinear_by_in_nonlinear code! {
         #[proof] #[verifier(nonlinear)]
         fn test(x: u32) {
             requires(x < 0xfff);
-            assert_by_nonlinear(x*x + x == x * (x + 1), {
+            assert_nonlinear_by({
                 requires(x < 0xfff);
+                ensures(x*x + x == x * (x + 1));
             });
             assert(x*x + x == x * (x + 1));
         }
@@ -206,7 +220,9 @@ test_verify_one_file! {
     #[test] test_negative code! {
         #[proof]
         fn test6(x: int, y: int, z:int) {
-            assert_by_nonlinear((x+y)*z == x*z + y*z, {});
+            assert_nonlinear_by({
+                ensures((x+y)*z == x*z + y*z);
+            });
             assert(false); // FAILS
         }
     } => Err(e) => assert_one_fails(e)
@@ -216,8 +232,9 @@ test_verify_one_file! {
     #[test] test_unexpected_vars code! {
         #[proof]
         fn test6(x: int, y: int, z:int) {
-            assert_by_nonlinear(x + y == x, {
+            assert_nonlinear_by({
                 requires(y == 0);
+                ensures(x + y == x);
                 assert(z == 0);
             });
         }
@@ -233,8 +250,9 @@ test_verify_one_file! {
             } else {
                 (a2, a1)
             };
-            assert_by_nonlinear(b1 <= b2, {
+            assert_nonlinear_by({
                 requires(b1 <= b2);
+                ensures(b1 <= b2);
             });
         }
     } => Ok(())
@@ -244,8 +262,10 @@ test_verify_one_file! {
     #[test] test_new_vars code! {
         #[proof]
         fn test6(x: int) {
-            assert_by_nonlinear(x * 2 == 10, {
+            requires(x == 5);
+            assert_nonlinear_by({
                 requires({let z = 5; x == z});
+                ensures({let z = 2; x * z == 10});
                 let y = x * 2;
                 assert(y == 10);
             });

--- a/source/rust_verify/tests/nonlinear.rs
+++ b/source/rust_verify/tests/nonlinear.rs
@@ -211,3 +211,15 @@ test_verify_one_file! {
         }
     } => Err(e) => assert_one_fails(e)
 }
+
+test_verify_one_file! {
+    #[test] test_unexpected_vars code! {
+        #[proof]
+        fn test6(x: int, y: int, z:int) {
+            assert_by_nonlinear(x + y == x, {
+                requires(y == 0);
+                assert(z == 0);
+            });
+        }
+    } => Err(e) => assert_vir_error(e)
+}

--- a/source/rust_verify/tests/nonlinear.rs
+++ b/source/rust_verify/tests/nonlinear.rs
@@ -232,6 +232,8 @@ test_verify_one_file! {
     #[test] test_unexpected_vars code! {
         #[proof]
         fn test6(x: int, y: int, z:int) {
+            requires(y == 0);
+            requires(z == 0);
             assert_nonlinear_by({
                 requires(y == 0);
                 ensures(x + y == x);

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -378,7 +378,7 @@ pub enum ExprX {
     /// Sequence of statements, optionally including an expression at the end
     Block(Stmts, Option<Expr>),
     /// assert_by with smt.arith.nl=true
-    AssertNonLinear{require: Expr, ensure: Expr, proof: Expr},
+    AssertNonLinear { requires: Exprs, ensure: Expr, proof: Expr },
 }
 
 /// Statement, similar to rustc_hir::Stmt

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -377,6 +377,8 @@ pub enum ExprX {
     Return(Option<Expr>),
     /// Sequence of statements, optionally including an expression at the end
     Block(Stmts, Option<Expr>),
+    /// assert_by with smt.arith.nl=true
+    AssertNonLinear{require: Expr, ensure: Expr, proof: Expr},
 }
 
 /// Statement, similar to rustc_hir::Stmt

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -442,7 +442,7 @@ pub struct FunctionAttrsX {
     /// In a spec function, check the body for violations of recommends
     pub check_recommends: bool,
     /// set option smt.arith.nl=true
-    pub non_linear: bool,
+    pub nonlinear: bool,
 }
 
 /// Function specification of its invariant mask

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -313,6 +313,11 @@ pub enum InvAtomicity {
     NonAtomic,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum AssertQueryMode {
+    NonLinear,
+}
+
 /// Expression, similar to rustc_hir::Expr
 pub type Expr = Arc<SpannedTyped<ExprX>>;
 pub type Exprs = Arc<Vec<Expr>>;
@@ -380,7 +385,7 @@ pub enum ExprX {
     /// Sequence of statements, optionally including an expression at the end
     Block(Stmts, Option<Expr>),
     /// assert_by with smt.arith.nl=true
-    AssertNonLinear { requires: Exprs, ensure: Expr, proof: Expr },
+    AssertQuery { requires: Exprs, ensures: Exprs, proof: Expr, mode: AssertQueryMode },
 }
 
 /// Statement, similar to rustc_hir::Stmt

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1075,32 +1075,85 @@ fn expr_to_stm_opt(
             stms.push(assume);
             Ok((stms, ReturnValue::ImplicitUnit(expr.span.clone())))
         }
-        ExprX::AssertNonLinear { requires, ensure, proof } => {
-            let requires = Arc::new(vec_map_result(requires, |e| expr_to_pure_exp(ctx, state, e))?);
-            let ensure = expr_to_pure_exp(ctx, state, &ensure)?;
+        ExprX::AssertQuery { requires, ensures, proof, mode } => {
+            let mut inner_body: Vec<Stm> = Vec::new();
             let mut vars = BTreeMap::new(); // order vars by UniqueIdent
+
+            // Translate body as separate query
+            state.push_scope();
             for r in requires.iter() {
-                vars.extend(referenced_vars_exp(&r).into_iter());
+                let (require_check_recommends, require_exp) =
+                    expr_to_pure_exp_check(ctx, state, &r)?;
+                inner_body.extend(require_check_recommends);
+                vars.extend(referenced_vars_exp(&require_exp).into_iter());
+                let assume = Spanned::new(r.span.clone(), StmX::Assume(require_exp));
+                inner_body.push(assume);
             }
-            vars.extend(referenced_vars_exp(&ensure).into_iter());
+
             let (proof_stms, e) = expr_to_stm_opt(ctx, state, proof)?;
-            for s in proof_stms.iter() {
-                vars.extend(referenced_vars_stm(&s).into_iter());
-            }
-            let vars = vars.into_iter().collect();
             if let ReturnValue::Some(_) = e {
-                return err_str(&expr.span, "assert_by_nonlinear cannot end with an expression");
-            };
+                return err_str(&expr.span, "forall/assert-by cannot end with an expression");
+            }
+            inner_body.extend(proof_stms);
+
+            for e in ensures.iter() {
+                if state.checking_recommends(ctx) {
+                    let check_stms = check_pure_expr(ctx, state, &e)?;
+                    for s in check_stms.iter() {
+                        vars.extend(referenced_vars_stm(&s).into_iter());
+                    }
+                    inner_body.extend(check_stms);
+                } else {
+                    let ensure_exp = expr_to_pure_exp(ctx, state, &e)?;
+                    vars.extend(referenced_vars_exp(&ensure_exp).into_iter());
+                    let assert = Spanned::new(e.span.clone(), StmX::Assert(None, ensure_exp));
+                    inner_body.push(assert);
+                }
+            }
+
+            // REVIEW is this the right place for finalize_stm?
+            let inner_body = state
+                .finalize_stm(&Spanned::new(expr.span.clone(), StmX::Block(Arc::new(inner_body))));
+            state.pop_scope();
+
+            let mut outer: Vec<Stm> = Vec::new();
+
+            // Translate as assert, assume in outer query
+            for r in requires.iter() {
+                if state.checking_recommends(ctx) {
+                    outer.extend(check_pure_expr(ctx, state, &r)?);
+                } else {
+                    let require_exp = expr_to_pure_exp(ctx, state, &r)?;
+                    let assert = Spanned::new(
+                        r.span.clone(),
+                        StmX::Assert(
+                            Some(air::errors::error(
+                                "requires not satisfied".to_string(),
+                                &r.span.clone(),
+                            )),
+                            require_exp,
+                        ),
+                    );
+                    outer.push(assert);
+                }
+            }
+            for e in ensures.iter() {
+                let ensure_exp = expr_to_pure_exp(ctx, state, &e)?;
+                let assume = Spanned::new(e.span.clone(), StmX::Assume(ensure_exp));
+                outer.push(assume);
+            }
+
+            let outer_block = Spanned::new(expr.span.clone(), StmX::Block(Arc::new(outer)));
+
             let nonlinear = Spanned::new(
                 expr.span.clone(),
-                StmX::AssertNonLinear {
-                    requires: requires,
-                    ensure: ensure,
-                    proof: Arc::new(proof_stms),
-                    vars: Arc::new(vars),
+                StmX::AssertQuery {
+                    body: inner_body,
+                    typ_inv_vars: Arc::new(vars.into_iter().collect()),
+                    mode: *mode,
                 },
             );
-            Ok((vec![nonlinear], ReturnValue::ImplicitUnit(expr.span.clone())))
+            Ok((vec![outer_block, nonlinear], ReturnValue::ImplicitUnit(expr.span.clone())))
         }
         ExprX::AssertBV(e) => {
             let expr = expr_to_pure_exp(ctx, state, &e)?;

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1074,6 +1074,58 @@ fn expr_to_stm_opt(
             stms.push(assume);
             Ok((stms, ReturnValue::ImplicitUnit(expr.span.clone())))
         }
+        ExprX::AssertNonLinear{ require, ensure, proof} => {
+            // let mut stms_check: Vec<Stm> = Vec::new();
+            // Translate proof into a dead-end ending with an assert
+            // state.push_scope();
+            let mut body: Vec<Stm> = Vec::new();
+            // for var in vars.iter() {
+
+            //     let x = state.declare_new_var(&var.name, &var.a, false, true);
+            //     let xvarx = ExpX::Var(x);
+            //     let xvar = SpannedTyped::new(&expr.span, &Arc::new(TypX::Bool), xvarx);
+            //     let has_typx = ExpX::UnaryOpr(UnaryOpr::HasType(var.a.clone()), xvar);
+            //     let has_typ = SpannedTyped::new(&expr.span, &Arc::new(TypX::Bool), has_typx);
+            //     let assume = Spanned::new(require.span.clone(), StmX::Assume(has_typ));
+            //     body.push(assume);
+            // }
+            let (mut proof_stms, e) = expr_to_stm_opt(ctx, state, proof)?;
+            if let ReturnValue::Some(_) = e {
+                return err_str(&expr.span, "forall/assert-by cannot end with an expression");
+            }
+            let require_exp = expr_to_pure_exp(ctx, state, &require)?;
+            let assume = Spanned::new(require.span.clone(), StmX::Assume(require_exp));
+            body.push(assume);
+            body.append(&mut proof_stms);
+            let ensure_exp = expr_to_pure_exp(ctx, state, &ensure)?;
+            let ensure_assert = Spanned::new(ensure.span.clone(), StmX::Assert(None, ensure_exp));
+            body.push(ensure_assert);
+            let block = Spanned::new(expr.span.clone(), StmX::Block(Arc::new(body)));
+            // let assert = Spanned::new(ensure.span.clone(), StmX::Assert(None, body));
+            // body.push(assert);
+            // let block = Spanned::new(expr.span.clone(), StmX::Block(Arc::new(body)));
+            // let deadend = Spanned::new(expr.span.clone(), StmX::DeadEnd(block));
+            // state.pop_scope();
+            
+        
+
+            
+            // Translate ensure into an assume
+            // let mut stms_assume: Vec<Stm> = Vec::new();
+            let implyx = ExprX::Binary(BinaryOp::Implies, require.clone(), ensure.clone());
+            let imply = SpannedTyped::new(&ensure.span, &Arc::new(TypX::Bool), implyx);
+            // let forallx = ExprX::Quant(Quant::Forall, vars.clone(), imply);
+            // let forall = SpannedTyped::new(&ensure.span, &Arc::new(TypX::Bool), forallx);
+            let forall_exp = expr_to_pure_exp(ctx, state, &imply)?;
+            let assume = Spanned::new(ensure.span.clone(), StmX::Assume(forall_exp));
+            // stms_assume.push(assume);
+            // let mut stms: Vec<Stm> = Vec::new();
+            let nonlinear = Spanned::new(expr.span.clone(), StmX::AssertNonLinear{check:block, assume:assume, vars:Arc::new(vec![])});
+            // stms.push(nonlinear);
+            Ok((vec![nonlinear], ReturnValue::ImplicitUnit(expr.span.clone())))
+            // make assume for main query
+            // make Stmx::nonlinear disappear in sst_to_air translation, to a separate query
+        }
         ExprX::AssertBV(e) => {
             let expr = expr_to_pure_exp(ctx, state, &e)?;
             let ret = ReturnValue::ImplicitUnit(expr.span.clone());

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1111,9 +1111,7 @@ fn expr_to_stm_opt(
                 }
             }
 
-            // REVIEW is this the right place for finalize_stm?
-            let inner_body = state
-                .finalize_stm(&Spanned::new(expr.span.clone(), StmX::Block(Arc::new(inner_body))));
+            let inner_body = Spanned::new(expr.span.clone(), StmX::Block(Arc::new(inner_body)));
             state.pop_scope();
 
             let mut outer: Vec<Stm> = Vec::new();

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -260,6 +260,16 @@ where
                     expr_visitor_control_flow!(expr_visitor_dfs(proof, map, mf));
                     map.pop_scope();
                 }
+                ExprX::AssertNonLinear { require, ensure, proof } => {
+                    // map.push_scope(true);
+                    // for binder in vars.iter() {
+                    //     let _ = map.insert(binder.name.clone(), binder.a.clone());
+                    // }
+                    expr_visitor_control_flow!(expr_visitor_dfs(require, map, mf));
+                    expr_visitor_control_flow!(expr_visitor_dfs(ensure, map, mf));
+                    expr_visitor_control_flow!(expr_visitor_dfs(proof, map, mf));
+                    // map.pop_scope();
+                }
                 ExprX::If(e1, e2, e3) => {
                     expr_visitor_control_flow!(expr_visitor_dfs(e1, map, mf));
                     expr_visitor_control_flow!(expr_visitor_dfs(e2, map, mf));
@@ -548,6 +558,19 @@ where
             let proof = map_expr_visitor_env(proof, map, env, fe, fs, ft)?;
             map.pop_scope();
             ExprX::Forall { vars: Arc::new(vars), require, ensure, proof }
+        }
+        ExprX::AssertNonLinear { require, ensure, proof } => {
+            // let vars =
+            //     vec_map_result(&**vars, |x| x.map_result(|t| map_typ_visitor_env(t, env, ft)))?;
+            // map.push_scope(true);
+            // for binder in vars.iter() {
+            //     let _ = map.insert(binder.name.clone(), binder.a.clone());
+            // }
+            let require = map_expr_visitor_env(require, map, env, fe, fs, ft)?;
+            let ensure = map_expr_visitor_env(ensure, map, env, fe, fs, ft)?;
+            let proof = map_expr_visitor_env(proof, map, env, fe, fs, ft)?;
+            // map.pop_scope();
+            ExprX::AssertNonLinear {  require, ensure, proof }
         }
         ExprX::AssertBV(e) => {
             let expr1 = map_expr_visitor_env(e, map, env, fe, fs, ft)?;

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -557,19 +557,11 @@ where
             ExprX::Forall { vars: Arc::new(vars), require, ensure, proof }
         }
         ExprX::AssertNonLinear { requires, ensure, proof } => {
-            // let vars =
-            //     vec_map_result(&**vars, |x| x.map_result(|t| map_typ_visitor_env(t, env, ft)))?;
-            // map.push_scope(true);
-            // for binder in vars.iter() {
-            //     let _ = map.insert(binder.name.clone(), binder.a.clone());
-            // }
             let requires = Arc::new(vec_map_result(requires, |e| {
                 map_expr_visitor_env(e, map, env, fe, fs, ft)
             })?);
-            // let require = map_expr_visitor_env(require, map, env, fe, fs, ft)?;
             let ensure = map_expr_visitor_env(ensure, map, env, fe, fs, ft)?;
             let proof = map_expr_visitor_env(proof, map, env, fe, fs, ft)?;
-            // map.pop_scope();
             ExprX::AssertNonLinear { requires, ensure, proof }
         }
         ExprX::AssertBV(e) => {

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -260,11 +260,13 @@ where
                     expr_visitor_control_flow!(expr_visitor_dfs(proof, map, mf));
                     map.pop_scope();
                 }
-                ExprX::AssertNonLinear { requires, ensure, proof } => {
+                ExprX::AssertQuery { requires, ensures, proof, mode: _ } => {
                     for req in requires.iter() {
                         expr_visitor_control_flow!(expr_visitor_dfs(req, map, mf));
                     }
-                    expr_visitor_control_flow!(expr_visitor_dfs(ensure, map, mf));
+                    for ens in ensures.iter() {
+                        expr_visitor_control_flow!(expr_visitor_dfs(ens, map, mf));
+                    }
                     expr_visitor_control_flow!(expr_visitor_dfs(proof, map, mf));
                 }
                 ExprX::If(e1, e2, e3) => {
@@ -560,13 +562,15 @@ where
             map.pop_scope();
             ExprX::Forall { vars: Arc::new(vars), require, ensure, proof }
         }
-        ExprX::AssertNonLinear { requires, ensure, proof } => {
+        ExprX::AssertQuery { requires, ensures, proof, mode } => {
             let requires = Arc::new(vec_map_result(requires, |e| {
                 map_expr_visitor_env(e, map, env, fe, fs, ft)
             })?);
-            let ensure = map_expr_visitor_env(ensure, map, env, fe, fs, ft)?;
+            let ensures = Arc::new(vec_map_result(ensures, |e| {
+                map_expr_visitor_env(e, map, env, fe, fs, ft)
+            })?);
             let proof = map_expr_visitor_env(proof, map, env, fe, fs, ft)?;
-            ExprX::AssertNonLinear { requires, ensure, proof }
+            ExprX::AssertQuery { requires, ensures, proof, mode: *mode }
         }
         ExprX::AssertBV(e) => {
             let expr1 = map_expr_visitor_env(e, map, env, fe, fs, ft)?;

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -260,15 +260,12 @@ where
                     expr_visitor_control_flow!(expr_visitor_dfs(proof, map, mf));
                     map.pop_scope();
                 }
-                ExprX::AssertNonLinear { require, ensure, proof } => {
-                    // map.push_scope(true);
-                    // for binder in vars.iter() {
-                    //     let _ = map.insert(binder.name.clone(), binder.a.clone());
-                    // }
-                    expr_visitor_control_flow!(expr_visitor_dfs(require, map, mf));
+                ExprX::AssertNonLinear { requires, ensure, proof } => {
+                    for req in requires.iter() {
+                        expr_visitor_control_flow!(expr_visitor_dfs(req, map, mf));
+                    }
                     expr_visitor_control_flow!(expr_visitor_dfs(ensure, map, mf));
                     expr_visitor_control_flow!(expr_visitor_dfs(proof, map, mf));
-                    // map.pop_scope();
                 }
                 ExprX::If(e1, e2, e3) => {
                     expr_visitor_control_flow!(expr_visitor_dfs(e1, map, mf));
@@ -559,18 +556,21 @@ where
             map.pop_scope();
             ExprX::Forall { vars: Arc::new(vars), require, ensure, proof }
         }
-        ExprX::AssertNonLinear { require, ensure, proof } => {
+        ExprX::AssertNonLinear { requires, ensure, proof } => {
             // let vars =
             //     vec_map_result(&**vars, |x| x.map_result(|t| map_typ_visitor_env(t, env, ft)))?;
             // map.push_scope(true);
             // for binder in vars.iter() {
             //     let _ = map.insert(binder.name.clone(), binder.a.clone());
             // }
-            let require = map_expr_visitor_env(require, map, env, fe, fs, ft)?;
+            let requires = Arc::new(vec_map_result(requires, |e| {
+                map_expr_visitor_env(e, map, env, fe, fs, ft)
+            })?);
+            // let require = map_expr_visitor_env(require, map, env, fe, fs, ft)?;
             let ensure = map_expr_visitor_env(ensure, map, env, fe, fs, ft)?;
             let proof = map_expr_visitor_env(proof, map, env, fe, fs, ft)?;
             // map.pop_scope();
-            ExprX::AssertNonLinear {  require, ensure, proof }
+            ExprX::AssertNonLinear { requires, ensure, proof }
         }
         ExprX::AssertBV(e) => {
             let expr1 = map_expr_visitor_env(e, map, env, fe, fs, ft)?;

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -1,7 +1,7 @@
 use crate::ast::{Fun, FunX, InvAtomicity, Path, PathX};
 use crate::sst::UniqueIdent;
 use crate::util::vec_map;
-use air::ast::{Ident, Span};
+use air::ast::{Commands, Ident, Span};
 use air::ast_util::str_ident;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -384,6 +384,14 @@ impl<X: Debug> Debug for Spanned<X> {
         f.debug_tuple("Spanned").field(&self.span.as_string).field(&self.x).finish()
     }
 }
+
+pub struct CommandsWithContextX {
+    pub span: air::ast::Span,
+    pub desc: String,
+    pub commands: Commands,
+}
+
+pub type CommandsWithContext = Arc<CommandsWithContextX>;
 
 fn atomicity_type_name(atomicity: InvAtomicity) -> Ident {
     match atomicity {

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -391,6 +391,12 @@ pub struct CommandsWithContextX {
     pub commands: Commands,
 }
 
+impl CommandsWithContextX {
+    pub fn new(span: Span, desc: String, commands: Commands) -> CommandsWithContext {
+        Arc::new(CommandsWithContextX { span: span, desc: desc, commands: commands })
+    }
+}
+
 pub type CommandsWithContext = Arc<CommandsWithContextX>;
 
 fn atomicity_type_name(atomicity: InvAtomicity) -> Ident {

--- a/source/vir/src/early_exit_cf.rs
+++ b/source/vir/src/early_exit_cf.rs
@@ -74,7 +74,7 @@ fn expr_get_early_exits_rec(
             | ExprX::Header(..)
             | ExprX::Admit
             | ExprX::Forall { .. } => VisitorControlFlow::Return,
-            | ExprX::AssertNonLinear { .. } => VisitorControlFlow::Return,
+            ExprX::AssertNonLinear { .. } => VisitorControlFlow::Return,
             ExprX::While { cond, body, invs: _ } => {
                 expr_get_early_exits_rec(cond, in_loop, scope_map, results);
                 expr_get_early_exits_rec(body, true, scope_map, results);

--- a/source/vir/src/early_exit_cf.rs
+++ b/source/vir/src/early_exit_cf.rs
@@ -74,6 +74,7 @@ fn expr_get_early_exits_rec(
             | ExprX::Header(..)
             | ExprX::Admit
             | ExprX::Forall { .. } => VisitorControlFlow::Return,
+            | ExprX::AssertNonLinear { .. } => VisitorControlFlow::Return,
             ExprX::While { cond, body, invs: _ } => {
                 expr_get_early_exits_rec(cond, in_loop, scope_map, results);
                 expr_get_early_exits_rec(body, true, scope_map, results);

--- a/source/vir/src/early_exit_cf.rs
+++ b/source/vir/src/early_exit_cf.rs
@@ -74,7 +74,7 @@ fn expr_get_early_exits_rec(
             | ExprX::Header(..)
             | ExprX::Admit
             | ExprX::Forall { .. } => VisitorControlFlow::Return,
-            ExprX::AssertNonLinear { .. } => VisitorControlFlow::Return,
+            ExprX::AssertQuery { .. } => VisitorControlFlow::Return,
             ExprX::While { cond, body, invs: _ } => {
                 expr_get_early_exits_rec(cond, in_loop, scope_map, results);
                 expr_get_early_exits_rec(body, true, scope_map, results);

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -15,7 +15,7 @@ use crate::sst_to_air::{
 use crate::util::vec_map;
 use air::ast::{
     BinaryOp, Bind, BindX, Binder, BinderX, Command, CommandX, Commands, DeclX, Expr, ExprX, Quant,
-    Span, Trigger, Triggers,
+    Span, SpannedCommands, Trigger, Triggers,
 };
 use air::ast_util::{
     bool_typ, ident_apply, ident_binder, ident_var, mk_and, mk_bind_expr, mk_eq, mk_implies,
@@ -556,7 +556,7 @@ pub fn func_decl_to_air(
 pub fn func_def_to_air(
     ctx: &Ctx,
     function: &Function,
-) -> Result<(Commands, Vec<(Span, SnapPos)>), VirErr> {
+) -> Result<(SpannedCommands, Vec<(Span, SnapPos)>), VirErr> {
     match (
         function.x.mode,
         function.x.is_const || function.x.attrs.check_recommends,

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -675,7 +675,7 @@ pub fn func_def_to_air(
                 &stm,
                 function.x.attrs.bit_vector,
                 skip_ensures,
-                function.x.attrs.non_linear,
+                function.x.attrs.nonlinear,
             );
 
             state.finalize();

--- a/source/vir/src/lib.rs
+++ b/source/vir/src/lib.rs
@@ -51,6 +51,7 @@ pub mod recursive_types;
 mod scc;
 mod sst;
 mod sst_to_air;
+mod sst_util;
 mod sst_vars;
 mod sst_visitor;
 pub mod traits;

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -504,6 +504,22 @@ fn check_expr(
             typing.in_forall_stmt = in_forall_stmt;
             Ok(Mode::Proof)
         }
+        ExprX::AssertNonLinear {require, ensure, proof } => {
+            // let in_forall_stmt = typing.in_forall_stmt;
+            // REVIEW: we could allow proof vars when vars.len() == 0,
+            // but we'd have to implement the proper lifetime checking in erase.rs
+            // typing.in_forall_stmt = true;
+            // typing.vars.push_scope(true);
+            // for var in vars.iter() {
+            //     typing.insert(&expr.span, &var.name, false, Mode::Spec);
+            // }
+            check_expr_has_mode(typing, Mode::Spec, require, Mode::Spec)?;
+            check_expr_has_mode(typing, Mode::Spec, ensure, Mode::Spec)?;
+            check_expr_has_mode(typing, Mode::Proof, proof, Mode::Proof)?;
+            // typing.vars.pop_scope();
+            // typing.in_forall_stmt = in_forall_stmt;
+            Ok(Mode::Proof)
+        }
         ExprX::AssertBV(e) => {
             check_expr_has_mode(typing, Mode::Spec, e, Mode::Spec)?;
             Ok(Mode::Proof)

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -504,20 +504,12 @@ fn check_expr(
             typing.in_forall_stmt = in_forall_stmt;
             Ok(Mode::Proof)
         }
-        ExprX::AssertNonLinear {require, ensure, proof } => {
-            // let in_forall_stmt = typing.in_forall_stmt;
-            // REVIEW: we could allow proof vars when vars.len() == 0,
-            // but we'd have to implement the proper lifetime checking in erase.rs
-            // typing.in_forall_stmt = true;
-            // typing.vars.push_scope(true);
-            // for var in vars.iter() {
-            //     typing.insert(&expr.span, &var.name, false, Mode::Spec);
-            // }
-            check_expr_has_mode(typing, Mode::Spec, require, Mode::Spec)?;
+        ExprX::AssertNonLinear { requires, ensure, proof } => {
+            for req in requires.iter() {
+                check_expr_has_mode(typing, Mode::Spec, req, Mode::Spec)?;
+            }
             check_expr_has_mode(typing, Mode::Spec, ensure, Mode::Spec)?;
             check_expr_has_mode(typing, Mode::Proof, proof, Mode::Proof)?;
-            // typing.vars.pop_scope();
-            // typing.in_forall_stmt = in_forall_stmt;
             Ok(Mode::Proof)
         }
         ExprX::AssertBV(e) => {

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -504,11 +504,13 @@ fn check_expr(
             typing.in_forall_stmt = in_forall_stmt;
             Ok(Mode::Proof)
         }
-        ExprX::AssertNonLinear { requires, ensure, proof } => {
+        ExprX::AssertQuery { requires, ensures, proof, mode: _ } => {
             for req in requires.iter() {
                 check_expr_has_mode(typing, Mode::Spec, req, Mode::Spec)?;
             }
-            check_expr_has_mode(typing, Mode::Spec, ensure, Mode::Spec)?;
+            for ens in ensures.iter() {
+                check_expr_has_mode(typing, Mode::Spec, ens, Mode::Spec)?;
+            }
             check_expr_has_mode(typing, Mode::Proof, proof, Mode::Proof)?;
             Ok(Mode::Proof)
         }

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -427,15 +427,17 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
             let vars = Arc::new(bs);
             mk_expr(ExprX::Forall { vars, require, ensure, proof })
         }
-        ExprX::AssertNonLinear { requires, ensure, proof } => {
+        ExprX::AssertQuery { requires, ensures, proof, mode } => {
             state.types.push_scope(true);
             let requires =
                 requires.iter().map(|e| coerce_expr_to_native(ctx, &poly_expr(ctx, state, e)));
             let requires = Arc::new(requires.collect());
-            let ensure = coerce_expr_to_native(ctx, &poly_expr(ctx, state, ensure));
+            let ensures =
+                ensures.iter().map(|e| coerce_expr_to_native(ctx, &poly_expr(ctx, state, e)));
+            let ensures = Arc::new(ensures.collect());
             let proof = poly_expr(ctx, state, proof);
             state.types.pop_scope();
-            mk_expr(ExprX::AssertNonLinear { requires, ensure, proof })
+            mk_expr(ExprX::AssertQuery { requires, ensures, proof, mode: *mode })
         }
         ExprX::If(e0, e1, None) => {
             let e0 = coerce_expr_to_native(ctx, &poly_expr(ctx, state, e0));

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -427,6 +427,14 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
             let vars = Arc::new(bs);
             mk_expr(ExprX::Forall { vars, require, ensure, proof })
         }
+        ExprX::AssertNonLinear {  require, ensure, proof } => {
+            state.types.push_scope(true);
+            let require = coerce_expr_to_native(ctx, &poly_expr(ctx, state, require));
+            let ensure = coerce_expr_to_native(ctx, &poly_expr(ctx, state, ensure));
+            let proof = poly_expr(ctx, state, proof);
+            state.types.pop_scope();
+            mk_expr(ExprX::AssertNonLinear { require, ensure, proof })
+        }
         ExprX::If(e0, e1, None) => {
             let e0 = coerce_expr_to_native(ctx, &poly_expr(ctx, state, e0));
             let e1 = poly_expr(ctx, state, e1);

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -427,13 +427,15 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
             let vars = Arc::new(bs);
             mk_expr(ExprX::Forall { vars, require, ensure, proof })
         }
-        ExprX::AssertNonLinear {  require, ensure, proof } => {
+        ExprX::AssertNonLinear { requires, ensure, proof } => {
             state.types.push_scope(true);
-            let require = coerce_expr_to_native(ctx, &poly_expr(ctx, state, require));
+            let requires =
+                requires.iter().map(|e| coerce_expr_to_native(ctx, &poly_expr(ctx, state, e)));
+            let requires = Arc::new(requires.collect());
             let ensure = coerce_expr_to_native(ctx, &poly_expr(ctx, state, ensure));
             let proof = poly_expr(ctx, state, proof);
             state.types.pop_scope();
-            mk_expr(ExprX::AssertNonLinear { require, ensure, proof })
+            mk_expr(ExprX::AssertNonLinear { requires, ensure, proof })
         }
         ExprX::If(e0, e1, None) => {
             let e0 = coerce_expr_to_native(ctx, &poly_expr(ctx, state, e0));

--- a/source/vir/src/printer.rs
+++ b/source/vir/src/printer.rs
@@ -294,8 +294,8 @@ fn expr_to_node(expr: &Expr) -> Node {
         ExprX::Forall { vars, require, ensure, proof } => {
             nodes!(forall {binders_node(vars, &typ_to_node)} {str_to_node(":require")} {expr_to_node(require)} {str_to_node(":ensure")} {expr_to_node(ensure)} {str_to_node(":proof")} {expr_to_node(proof)})
         }
-        ExprX::AssertNonLinear { requires, ensure, proof } => {
-            nodes!(assertNonLinear {str_to_node(":requires")} {exprs_to_node(requires)} {str_to_node(":ensure")} {expr_to_node(ensure)} {str_to_node(":proof")} {expr_to_node(proof)})
+        ExprX::AssertQuery { requires, ensures, proof, mode } => {
+            nodes!(assertQuery {str_to_node(":requires")} {exprs_to_node(requires)} {str_to_node(":ensures")} {exprs_to_node(ensures)} {str_to_node(":proof")} {expr_to_node(proof)} {str_to_node(":mode")} {str_to_node(&format!("{:?}", mode))})
         }
         ExprX::AssertBV(expr) => nodes!(assertbv {expr_to_node(expr)}),
         ExprX::If(e0, e1, e2) => {

--- a/source/vir/src/printer.rs
+++ b/source/vir/src/printer.rs
@@ -293,8 +293,8 @@ fn expr_to_node(expr: &Expr) -> Node {
         ExprX::Forall { vars, require, ensure, proof } => {
             nodes!(forall {binders_node(vars, &typ_to_node)} {str_to_node(":require")} {expr_to_node(require)} {str_to_node(":ensure")} {expr_to_node(ensure)} {str_to_node(":proof")} {expr_to_node(proof)})
         }
-        ExprX::AssertNonLinear {require, ensure, proof } => {
-            nodes!(assertNonLinear {str_to_node(":require")} {expr_to_node(require)} {str_to_node(":ensure")} {expr_to_node(ensure)} {str_to_node(":proof")} {expr_to_node(proof)})
+        ExprX::AssertNonLinear { requires, ensure, proof } => {
+            nodes!(assertNonLinear {str_to_node(":requires")} {exprs_to_node(requires)} {str_to_node(":ensure")} {expr_to_node(ensure)} {str_to_node(":proof")} {expr_to_node(proof)})
         }
         ExprX::AssertBV(expr) => nodes!(assertbv {expr_to_node(expr)}),
         ExprX::If(e0, e1, e2) => {

--- a/source/vir/src/printer.rs
+++ b/source/vir/src/printer.rs
@@ -293,6 +293,9 @@ fn expr_to_node(expr: &Expr) -> Node {
         ExprX::Forall { vars, require, ensure, proof } => {
             nodes!(forall {binders_node(vars, &typ_to_node)} {str_to_node(":require")} {expr_to_node(require)} {str_to_node(":ensure")} {expr_to_node(ensure)} {str_to_node(":proof")} {expr_to_node(proof)})
         }
+        ExprX::AssertNonLinear {require, ensure, proof } => {
+            nodes!(assertNonLinear {str_to_node(":require")} {expr_to_node(require)} {str_to_node(":ensure")} {expr_to_node(ensure)} {str_to_node(":proof")} {expr_to_node(proof)})
+        }
         ExprX::AssertBV(expr) => nodes!(assertbv {expr_to_node(expr)}),
         ExprX::If(e0, e1, e2) => {
             let mut nodes = nodes_vec!(if { expr_to_node(e0) } {

--- a/source/vir/src/printer.rs
+++ b/source/vir/src/printer.rs
@@ -407,7 +407,7 @@ fn function_to_node(function: &FunctionX) -> Node {
             atomic,
             is_decrease_by,
             check_recommends,
-            non_linear,
+            nonlinear,
         } = &**attrs;
 
         let mut nodes = vec![
@@ -440,8 +440,8 @@ fn function_to_node(function: &FunctionX) -> Node {
         if *check_recommends {
             nodes.push(str_to_node("+check_recommends"));
         }
-        if *non_linear {
-            nodes.push(str_to_node("+non_linear"));
+        if *nonlinear {
+            nodes.push(str_to_node("+nonlinear"));
         }
 
         Node::List(nodes)

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -359,6 +359,7 @@ pub(crate) fn check_termination_exp(
     local_decls.append(&mut decls);
     let (commands, _snap_map) = crate::sst_to_air::body_stm_to_air(
         ctx,
+        &function.span,
         &vec![],
         &function.x.typ_params(),
         &function.x.params,
@@ -373,7 +374,9 @@ pub(crate) fn check_termination_exp(
         false,
         false,
     );
-    let commands: Commands = Arc::new((*commands).iter().map(|c| (*c).1.clone()).collect());
+
+    assert_eq!(commands.len(), 1);
+    let commands = commands.into_iter().next().unwrap().commands.clone();
 
     // New body: substitute rec%f(args, fuel) for f(args)
     let body = map_exp_visitor(&body, &mut |exp| match &exp.x {

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -373,6 +373,7 @@ pub(crate) fn check_termination_exp(
         false,
         false,
     );
+    let commands: Commands = Arc::new((*commands).iter().map(|c| (*c).1.clone()).collect());
 
     // New body: substitute rec%f(args, fuel) for f(args)
     let body = map_exp_visitor(&body, &mut |exp| match &exp.x {

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -105,7 +105,12 @@ pub enum StmX {
     },
     OpenInvariant(Exp, UniqueIdent, Typ, Stm, InvAtomicity),
     Block(Stms),
-    AssertNonLinear{check: Stm , assume: Stm, vars:Arc<Vec<(UniqueIdent, Typ)>>},
+    AssertNonLinear {
+        requires: Exps,
+        ensure: Exp,
+        proof: Stms,
+        vars: Arc<Vec<(UniqueIdent, Typ)>>,
+    },
 }
 
 pub type LocalDecl = Arc<LocalDeclX>;

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -7,8 +7,8 @@
 //! SST is designed to make the translation to AIR as straightforward as possible.
 
 use crate::ast::{
-    BinaryOp, Constant, Fun, InvAtomicity, Mode, Path, SpannedTyped, Typ, Typs, UnaryOp, UnaryOpr,
-    VarAt,
+    AssertQueryMode, BinaryOp, Constant, Fun, InvAtomicity, Mode, Path, SpannedTyped, Typ, Typs,
+    UnaryOp, UnaryOpr, VarAt,
 };
 use crate::def::Spanned;
 use air::ast::{Binders, Ident, Quant};
@@ -105,11 +105,10 @@ pub enum StmX {
     },
     OpenInvariant(Exp, UniqueIdent, Typ, Stm, InvAtomicity),
     Block(Stms),
-    AssertNonLinear {
-        requires: Exps,
-        ensure: Exp,
-        proof: Stms,
-        vars: Arc<Vec<(UniqueIdent, Typ)>>,
+    AssertQuery {
+        mode: AssertQueryMode,
+        typ_inv_vars: Arc<Vec<(UniqueIdent, Typ)>>,
+        body: Stm,
     },
 }
 

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -105,6 +105,7 @@ pub enum StmX {
     },
     OpenInvariant(Exp, UniqueIdent, Typ, Stm, InvAtomicity),
     Block(Stms),
+    AssertNonLinear{check: Stm , assume: Stm, vars:Arc<Vec<(UniqueIdent, Typ)>>},
 }
 
 pub type LocalDecl = Arc<LocalDeclX>;

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1487,7 +1487,7 @@ pub fn body_stm_to_air(
     stm: &Stm,
     is_bit_vector_mode: bool,
     skip_ensures: bool,
-    is_non_linear: bool,
+    is_nonlinear: bool,
 ) -> (Commands, Vec<(Span, SnapPos)>) {
     // Verifying a single function can generate multiple SMT queries.
     // Some declarations (local_shared) are shared among the queries.
@@ -1612,7 +1612,7 @@ pub fn body_stm_to_air(
     }
 
     let query = Arc::new(QueryX { local: Arc::new(local), assertion });
-    if is_non_linear {
+    if is_nonlinear {
         state.commands.push(Arc::new(CommandX::SetOption(
             Arc::new(String::from("smt.arith.nl")),
             Arc::new(String::from("true")),

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1563,13 +1563,16 @@ pub fn body_stm_to_air(
         mask,
     };
 
+    let mut _modified = HashSet::new();
+
     let stm = crate::sst_vars::stm_assign(
         &mut state.assign_map,
         &declared,
         &mut assigned,
-        &mut HashSet::new(),
+        &mut _modified,
         stm,
     );
+
     let mut stmts = stm_to_stmts(ctx, &mut state, &stm);
 
     if has_mut_params {

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1643,7 +1643,7 @@ pub fn body_stm_to_air(
     };
     state.commands.push(CommandsWithContextX::new(
         func_span.clone(),
-        "function body".to_string(),
+        "function body check".to_string(),
         Arc::new(commands),
     ));
     (state.commands, state.snap_map)

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -11,11 +11,14 @@ fn referenced_vars_exp_sm(
     scope_map: &mut crate::sst_visitor::VisitorScopeMap,
 ) -> HashMap<UniqueIdent, Typ> {
     let mut vars: HashMap<UniqueIdent, Typ> = HashMap::new();
-    crate::sst_visitor::exp_visitor_dfs::<(), _>(exp, scope_map, &mut |e, _| {
+    crate::sst_visitor::exp_visitor_dfs::<(), _>(exp, scope_map, &mut |e, scope_map| {
         match &e.x {
-            ExpX::Var(x) | ExpX::VarLoc(x) => {
-                vars.insert(x.clone(), e.typ.clone());
-            }
+            ExpX::Var(x) | ExpX::VarLoc(x) => match scope_map.scope_and_index_of_key(&x.0) {
+                Some(_) => {}
+                None => {
+                    vars.insert(x.clone(), e.typ.clone());
+                }
+            },
             _ => (),
         }
         crate::sst_visitor::VisitorControlFlow::Recurse

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -1,0 +1,32 @@
+use crate::sst::{Exp, ExpX, Stm, UniqueIdent};
+use std::collections::HashSet;
+
+pub(crate) fn referenced_vars_exp(exp: &Exp) -> HashSet<UniqueIdent> {
+    referenced_vars_exp_sm(exp, &mut crate::sst_visitor::VisitorScopeMap::new())
+}
+
+fn referenced_vars_exp_sm(
+    exp: &Exp,
+    scope_map: &mut crate::sst_visitor::VisitorScopeMap,
+) -> HashSet<UniqueIdent> {
+    let mut vars: HashSet<UniqueIdent> = HashSet::new();
+    crate::sst_visitor::exp_visitor_dfs::<(), _>(exp, scope_map, &mut |e, _| {
+        match &e.x {
+            ExpX::Var(x) | ExpX::VarLoc(x) => {
+                vars.insert(x.clone());
+            }
+            _ => (),
+        }
+        crate::sst_visitor::VisitorControlFlow::Recurse
+    });
+    vars
+}
+
+pub(crate) fn referenced_vars_stm(stm: &Stm) -> HashSet<UniqueIdent> {
+    let mut vars: HashSet<UniqueIdent> = HashSet::new();
+    crate::sst_visitor::stm_exp_visitor_dfs::<(), _>(stm, &mut |exp, scope_map| {
+        vars.extend(referenced_vars_exp_sm(exp, scope_map).into_iter());
+        crate::sst_visitor::VisitorControlFlow::Recurse
+    });
+    vars
+}

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -13,12 +13,9 @@ fn referenced_vars_exp_sm(
     let mut vars: HashMap<UniqueIdent, Typ> = HashMap::new();
     crate::sst_visitor::exp_visitor_dfs::<(), _>(exp, scope_map, &mut |e, scope_map| {
         match &e.x {
-            ExpX::Var(x) | ExpX::VarLoc(x) => match scope_map.scope_and_index_of_key(&x.0) {
-                Some(_) => {}
-                None => {
-                    vars.insert(x.clone(), e.typ.clone());
-                }
-            },
+            ExpX::Var(x) | ExpX::VarLoc(x) if !scope_map.contains_key(&x.0) => {
+                vars.insert(x.clone(), e.typ.clone());
+            }
             _ => (),
         }
         crate::sst_visitor::VisitorControlFlow::Recurse

--- a/source/vir/src/sst_util.rs
+++ b/source/vir/src/sst_util.rs
@@ -1,19 +1,20 @@
+use crate::ast::Typ;
 use crate::sst::{Exp, ExpX, Stm, UniqueIdent};
-use std::collections::HashSet;
+use std::collections::HashMap;
 
-pub(crate) fn referenced_vars_exp(exp: &Exp) -> HashSet<UniqueIdent> {
+pub(crate) fn referenced_vars_exp(exp: &Exp) -> HashMap<UniqueIdent, Typ> {
     referenced_vars_exp_sm(exp, &mut crate::sst_visitor::VisitorScopeMap::new())
 }
 
 fn referenced_vars_exp_sm(
     exp: &Exp,
     scope_map: &mut crate::sst_visitor::VisitorScopeMap,
-) -> HashSet<UniqueIdent> {
-    let mut vars: HashSet<UniqueIdent> = HashSet::new();
+) -> HashMap<UniqueIdent, Typ> {
+    let mut vars: HashMap<UniqueIdent, Typ> = HashMap::new();
     crate::sst_visitor::exp_visitor_dfs::<(), _>(exp, scope_map, &mut |e, _| {
         match &e.x {
             ExpX::Var(x) | ExpX::VarLoc(x) => {
-                vars.insert(x.clone());
+                vars.insert(x.clone(), e.typ.clone());
             }
             _ => (),
         }
@@ -22,8 +23,8 @@ fn referenced_vars_exp_sm(
     vars
 }
 
-pub(crate) fn referenced_vars_stm(stm: &Stm) -> HashSet<UniqueIdent> {
-    let mut vars: HashSet<UniqueIdent> = HashSet::new();
+pub(crate) fn referenced_vars_stm(stm: &Stm) -> HashMap<UniqueIdent, Typ> {
+    let mut vars: HashMap<UniqueIdent, Typ> = HashMap::new();
     crate::sst_visitor::stm_exp_visitor_dfs::<(), _>(stm, &mut |exp, scope_map| {
         vars.extend(referenced_vars_exp_sm(exp, scope_map).into_iter());
         crate::sst_visitor::VisitorControlFlow::Recurse

--- a/source/vir/src/sst_vars.rs
+++ b/source/vir/src/sst_vars.rs
@@ -120,6 +120,11 @@ pub(crate) fn stm_assign(
             for (x, typ) in declared.iter() {
                 vars.push((x.clone(), typ.clone()));
             }
+            vars.sort_by(|a, b| {
+                let str1: &String = &*(((*a).0).0);
+                let str2: &String = &*(((*b).0).0);
+                str1.cmp(str2)
+            });
             Spanned::new(
                 stm.span.clone(),
                 StmX::AssertNonLinear {

--- a/source/vir/src/sst_vars.rs
+++ b/source/vir/src/sst_vars.rs
@@ -46,7 +46,7 @@ pub(crate) fn stm_assign(
         StmX::Call(..)
         | StmX::Assert(..)
         | StmX::AssertBV(..)
-        | StmX::AssertNonLinear { .. }
+        | StmX::AssertQuery { .. }
         | StmX::Assume(_)
         | StmX::Fuel(..) => stm.clone(),
         StmX::Assign { lhs: Dest { dest, is_init }, rhs: _ } => {

--- a/source/vir/src/sst_vars.rs
+++ b/source/vir/src/sst_vars.rs
@@ -114,13 +114,21 @@ pub(crate) fn stm_assign(
             };
             Spanned::new(stm.span.clone(), while_x)
         }
-        StmX::AssertNonLinear{check, assume, vars} => {
+        StmX::AssertNonLinear { requires, ensure, proof, vars } => {
             assert!(vars.len() == 0);
             let mut vars: Vec<(UniqueIdent, Typ)> = Vec::new();
             for (x, typ) in declared.iter() {
                 vars.push((x.clone(), typ.clone()));
             }
-            Spanned::new(stm.span.clone(), StmX::AssertNonLinear{check:check.clone(), assume:assume.clone(), vars:Arc::new(vars)})
+            Spanned::new(
+                stm.span.clone(),
+                StmX::AssertNonLinear {
+                    requires: requires.clone(),
+                    ensure: ensure.clone(),
+                    proof: proof.clone(),
+                    vars: Arc::new(vars),
+                },
+            )
         }
         StmX::OpenInvariant(inv, ident, ty, body_stm, atomicity) => {
             assigned.insert(ident.clone());

--- a/source/vir/src/sst_vars.rs
+++ b/source/vir/src/sst_vars.rs
@@ -114,6 +114,14 @@ pub(crate) fn stm_assign(
             };
             Spanned::new(stm.span.clone(), while_x)
         }
+        StmX::AssertNonLinear{check, assume, vars} => {
+            assert!(vars.len() == 0);
+            let mut vars: Vec<(UniqueIdent, Typ)> = Vec::new();
+            for (x, typ) in declared.iter() {
+                vars.push((x.clone(), typ.clone()));
+            }
+            Spanned::new(stm.span.clone(), StmX::AssertNonLinear{check:check.clone(), assume:assume.clone(), vars:Arc::new(vars)})
+        }
         StmX::OpenInvariant(inv, ident, ty, body_stm, atomicity) => {
             assigned.insert(ident.clone());
             modified.insert(ident.clone());

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -412,7 +412,6 @@ where
         StmX::Assume(_) => f(stm),
         StmX::Assign { .. } => f(stm),
         StmX::AssertBV { .. } => f(stm),
-        StmX::AssertQuery { .. } => f(stm),
         StmX::Fuel(..) => f(stm),
         StmX::DeadEnd(s) => {
             let s = map_stm_visitor(s, f)?;
@@ -441,6 +440,14 @@ where
                     typ_inv_vars: typ_inv_vars.clone(),
                     modified_vars: modified_vars.clone(),
                 },
+            );
+            f(&stm)
+        }
+        StmX::AssertQuery { mode, typ_inv_vars, body } => {
+            let body = map_stm_visitor(body, f)?;
+            let stm = Spanned::new(
+                stm.span.clone(),
+                StmX::AssertQuery { mode: *mode, typ_inv_vars: typ_inv_vars.clone(), body },
             );
             f(&stm)
         }

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -208,6 +208,15 @@ where
             StmX::AssertBV(exp) => {
                 expr_visitor_control_flow!(exp_visitor_dfs(exp, &mut ScopeMap::new(), f))
             }
+            StmX::AssertNonLinear { requires, ensure, proof, vars: _ } => {
+                for r in requires.iter() {
+                    expr_visitor_control_flow!(exp_visitor_dfs(r, &mut ScopeMap::new(), f));
+                }
+                expr_visitor_control_flow!(exp_visitor_dfs(ensure, &mut ScopeMap::new(), f));
+                for p in proof.iter() {
+                    expr_visitor_control_flow!(stm_exp_visitor_dfs(p, f));
+                }
+            }
             StmX::Assume(exp) => {
                 expr_visitor_control_flow!(exp_visitor_dfs(exp, &mut ScopeMap::new(), f))
             }
@@ -236,8 +245,6 @@ where
                 expr_visitor_control_flow!(exp_visitor_dfs(inv, &mut ScopeMap::new(), f))
             }
             StmX::Block(_) => (),
-            // StmX::AssertNonLinear {check, assume, vars} => {expr_visitor_control_flow!(exp_visitor_dfs(check, &mut ScopeMap::new(), f))}
-            StmX::AssertNonLinear { .. } => {}
         }
         VisitorControlFlow::Recurse
     })

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -152,6 +152,7 @@ where
                 | StmX::Assume(_)
                 | StmX::Assign { .. }
                 | StmX::AssertBV { .. }
+                | StmX::AssertNonLinear { .. }
                 | StmX::Fuel(..) => (),
                 StmX::DeadEnd(s) => {
                     expr_visitor_control_flow!(stm_visitor_dfs(s, f));
@@ -235,6 +236,8 @@ where
                 expr_visitor_control_flow!(exp_visitor_dfs(inv, &mut ScopeMap::new(), f))
             }
             StmX::Block(_) => (),
+            // StmX::AssertNonLinear {check, assume, vars} => {expr_visitor_control_flow!(exp_visitor_dfs(check, &mut ScopeMap::new(), f))}
+            StmX::AssertNonLinear{..} => {}
         }
         VisitorControlFlow::Recurse
     })
@@ -408,6 +411,7 @@ where
         StmX::Assume(_) => f(stm),
         StmX::Assign { .. } => f(stm),
         StmX::AssertBV { .. } => f(stm),
+        StmX::AssertNonLinear { .. } => f(stm),
         StmX::Fuel(..) => f(stm),
         StmX::DeadEnd(s) => {
             let s = map_stm_visitor(s, f)?;
@@ -480,6 +484,7 @@ where
                 let rhs = f(rhs);
                 Spanned::new(span, StmX::Assign { lhs: Dest { dest, is_init: *is_init }, rhs })
             }
+            StmX::AssertNonLinear{..} => stm.clone(),
             StmX::Fuel(..) => stm.clone(),
             StmX::DeadEnd(..) => stm.clone(),
             StmX::If(exp, s1, s2) => {

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -237,7 +237,7 @@ where
             }
             StmX::Block(_) => (),
             // StmX::AssertNonLinear {check, assume, vars} => {expr_visitor_control_flow!(exp_visitor_dfs(check, &mut ScopeMap::new(), f))}
-            StmX::AssertNonLinear{..} => {}
+            StmX::AssertNonLinear { .. } => {}
         }
         VisitorControlFlow::Recurse
     })
@@ -484,7 +484,7 @@ where
                 let rhs = f(rhs);
                 Spanned::new(span, StmX::Assign { lhs: Dest { dest, is_init: *is_init }, rhs })
             }
-            StmX::AssertNonLinear{..} => stm.clone(),
+            StmX::AssertNonLinear { .. } => stm.clone(),
             StmX::Fuel(..) => stm.clone(),
             StmX::DeadEnd(..) => stm.clone(),
             StmX::If(exp, s1, s2) => {

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -103,19 +103,19 @@ fn check_one_expr(
                 );
             }
 
-            // let mut referenced = HashSet::new();
-            // for r in requires.iter() {
-            //     referenced.extend(referenced_vars_expr(r).into_iter());
-            // }
-            // referenced.extend(referenced_vars_expr(ensure).into_iter());
+            // TODO? let mut referenced = HashSet::new();
+            // TODO? for r in requires.iter() {
+            // TODO?     referenced.extend(referenced_vars_expr(r).into_iter());
+            // TODO? }
+            // TODO? referenced.extend(referenced_vars_expr(ensure).into_iter());
 
-            // crate::ast_visitor::expr_visitor_check(proof, &mut |e| match &e.x {
-            //     ExprX::Var(x) | ExprX::VarLoc(x) if !referenced.contains(x) => Err(error(
-            //         format!("variable {} not mentioned in requires/ensures", x).as_str(),
-            //         &e.span,
-            //     )),
-            //     _ => Ok(()),
-            // })?;
+            // TODO? crate::ast_visitor::expr_visitor_check(proof, &mut |e| match &e.x {
+            // TODO?     ExprX::Var(x) | ExprX::VarLoc(x) if !referenced.contains(x) => Err(error(
+            // TODO?         format!("variable {} not mentioned in requires/ensures", x).as_str(),
+            // TODO?         &e.span,
+            // TODO?     )),
+            // TODO?     _ => Ok(()),
+            // TODO? })?;
         }
         _ => {}
     }

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -103,19 +103,19 @@ fn check_one_expr(
                 );
             }
 
-            let mut referenced = HashSet::new();
-            for r in requires.iter() {
-                referenced.extend(referenced_vars_expr(r).into_iter());
-            }
-            referenced.extend(referenced_vars_expr(ensure).into_iter());
+            // let mut referenced = HashSet::new();
+            // for r in requires.iter() {
+            //     referenced.extend(referenced_vars_expr(r).into_iter());
+            // }
+            // referenced.extend(referenced_vars_expr(ensure).into_iter());
 
-            crate::ast_visitor::expr_visitor_check(proof, &mut |e| match &e.x {
-                ExprX::Var(x) | ExprX::VarLoc(x) if !referenced.contains(x) => Err(error(
-                    format!("variable {} not mentioned in requires/ensures", x).as_str(),
-                    &e.span,
-                )),
-                _ => Ok(()),
-            })?;
+            // crate::ast_visitor::expr_visitor_check(proof, &mut |e| match &e.x {
+            //     ExprX::Var(x) | ExprX::VarLoc(x) if !referenced.contains(x) => Err(error(
+            //         format!("variable {} not mentioned in requires/ensures", x).as_str(),
+            //         &e.span,
+            //     )),
+            //     _ => Ok(()),
+            // })?;
         }
         _ => {}
     }

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -92,10 +92,10 @@ fn check_one_expr(
             assert_no_early_exit_in_inv_block(&body.span, body)?;
         }
         ExprX::AssertNonLinear { .. } => {
-            if function.x.attrs.non_linear {
+            if function.x.attrs.nonlinear {
                 return err_str(
                     &expr.span,
-                    "assert_by_nonlinear not allowed in #[verifier(non_linear)] functions",
+                    "assert_by_nonlinear not allowed in #[verifier(nonlinear)] functions",
                 );
             }
         }
@@ -251,11 +251,11 @@ fn check_function(ctxt: &Ctxt, function: &Function) -> Result<(), VirErr> {
         }
     }
 
-    if function.x.attrs.non_linear {
+    if function.x.attrs.nonlinear {
         if function.x.mode == Mode::Spec {
             return err_str(
                 &function.span,
-                "#[verifier(non_linear) is only allowed on proof and exec functions",
+                "#[verifier(nonlinear) is only allowed on proof and exec functions",
             );
         }
     }

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -91,6 +91,14 @@ fn check_one_expr(
         ExprX::OpenInvariant(_inv, _binder, body, _atomicity) => {
             assert_no_early_exit_in_inv_block(&body.span, body)?;
         }
+        ExprX::AssertNonLinear { .. } => {
+            if function.x.attrs.non_linear {
+                return err_str(
+                    &expr.span,
+                    "assert_by_nonlinear not allowed in #[verifier(non_linear)] functions",
+                );
+            }
+        }
         _ => {}
     }
     Ok(())
@@ -240,6 +248,15 @@ fn check_function(ctxt: &Ctxt, function: &Function) -> Result<(), VirErr> {
                     );
                 }
             }
+        }
+    }
+
+    if function.x.attrs.non_linear {
+        if function.x.mode == Mode::Spec {
+            return err_str(
+                &function.span,
+                "#[verifier(non_linear) is only allowed on proof and exec functions",
+            );
         }
     }
 


### PR DESCRIPTION
This feature was developed by @channy412.

Also renames `#[verifier(non_linear)]` to `#[verifier(nonlinear)]` for consistency with `assert_nonlinear_by`.

---

* [x] Rlimit exceeded reporting doesn't quite work correctly for `assert_by_forall`, because we don't have a span for it.