### PR TITLE
Add spec_affirm as a tool to debug spec functions

### DIFF
--- a/source/pervasive/mod.rs
+++ b/source/pervasive/mod.rs
@@ -37,6 +37,30 @@ pub fn affirm(b: bool) {
     requires(b);
 }
 
+/// A tool to check one's reasoning while writing complex spec functions.
+/// Not intended to be used as a mechanism for instantiating quantifiers, `spec_affirm` should
+/// be removed from spec functions once they are complete.
+///
+/// ## Example
+///
+/// ```rust
+/// #[spec(checked)] fn some_predicate(a: nat) -> bool {
+///     recommends(a < 100);
+///     if (a >= 50) {
+///         let _ = spec_affirm(50 <= a && a < 100);
+///         a >= 75
+///     } else {
+///         let _ = spec_affirm(a < 50);
+///         // let _ = spec_affirm(a < 40); would raise a recommends note here
+///         a < 25
+///     }
+/// }
+/// ```
+#[spec] pub fn spec_affirm(b: bool) -> bool {
+    recommends(b);
+    b
+}
+
 /// In spec, all types are inhabited
 #[spec]
 #[verifier(external_body)]

--- a/source/rust_verify/example/recommends.rs
+++ b/source/rust_verify/example/recommends.rs
@@ -33,3 +33,16 @@ fn main() {
     reveal_with_fuel(seq_max_int, 4);
     assert(seq_max_int(s) == 30);
 }
+
+// Usage of `spec_affirm`
+#[spec] fn some_predicate(a: nat) -> bool {
+    recommends(a < 100);
+    if (a >= 50) {
+        let _ = spec_affirm(50 <= a && a < 100);
+        a >= 75
+    } else {
+        let _ = spec_affirm(a < 40); // spec(checked) would raise a recommends note here
+        a < 25
+    }
+}
+


### PR DESCRIPTION
@Chris-Hawblitzel `spec_affirm` instead of `spec_assert` due to its similarity to proof `affirm`.