### PR TITLE
Report error on rlimit exceeded instead of panicking

### DIFF
--- a/source/air/src/context.rs
+++ b/source/air/src/context.rs
@@ -32,6 +32,7 @@ pub(crate) struct AxiomInfo {
 pub enum ValidityResult {
     Valid,
     Invalid(Model, Error),
+    Canceled,
     TypeError(TypeError),
     UnexpectedSmtOutput(String),
 }
@@ -42,6 +43,7 @@ pub(crate) enum ContextState {
     ReadyForQuery,
     FoundResult,
     FoundInvalid(Vec<AssertionInfo>, Model),
+    Canceled,
 }
 
 pub struct Context {

--- a/source/air/src/emitter.rs
+++ b/source/air/src/emitter.rs
@@ -100,6 +100,14 @@ impl Emitter {
         }
     }
 
+    pub fn log_get_info(&mut self, param: &str) {
+        if !self.is_none() {
+            self.log_node(&node!(
+                (get-info {Node::Atom(format!(":{}", param))})
+            ));
+        }
+    }
+
     pub fn log_push(&mut self) {
         if !self.is_none() {
             self.log_node(&nodes!(push));

--- a/source/air/src/main.rs
+++ b/source/air/src/main.rs
@@ -133,6 +133,10 @@ pub fn main() {
                     println!("Additional error detail at {}", msg);
                 }
             }
+            ValidityResult::Canceled => {
+                count_errors += 1;
+                println!("Canceled");
+            }
             ValidityResult::UnexpectedSmtOutput(err) => {
                 panic!("Unexpected SMT output: {}", err);
             }


### PR DESCRIPTION
Produces the following error on smt `(unkown)` `(:reason-unknown "canceled")`, i.e. rlimit exceeded.

```
error: function definition check: rlimit exceeded
   --> /Users/andreal/ETH/Src/verified-nrkernel/page-table/spec.rs:512:5
    |
512 |     fn inv_implies_interp_aux_inv(self, i: nat) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```