### PR TITLE
Emit notes when queries run longer, and set a default rlimit to ~10 seconds

### DIFF
--- a/source/air/src/main.rs
+++ b/source/air/src/main.rs
@@ -116,7 +116,7 @@ pub fn main() {
     let mut count_errors = 0;
     let mut count_verified = 0;
     for command in commands.iter() {
-        let result = air_context.command(&command);
+        let result = air_context.command(&command, Default::default());
         match result {
             ValidityResult::Valid => {
                 if let CommandX::CheckValid(_) = &**command {

--- a/source/air/src/smt_process.rs
+++ b/source/air/src/smt_process.rs
@@ -4,7 +4,7 @@ use std::sync::mpsc::{channel, Receiver, Sender};
 
 pub(crate) struct SmtProcess {
     requests: Sender<Vec<u8>>,
-    smt_pipe_stdout: BufReader<ChildStdout>,
+    smt_pipe_stdout: Option<BufReader<ChildStdout>>,
 }
 
 const DONE: &str = "<<DONE>>";
@@ -37,27 +37,71 @@ impl SmtProcess {
         let child_stdin = child.stdin.take().expect("take stdin");
         let (sender, receiver) = channel();
         std::thread::spawn(move || writer_thread(receiver, child_stdin));
-        SmtProcess { requests: sender, smt_pipe_stdout }
+        SmtProcess { requests: sender, smt_pipe_stdout: Some(smt_pipe_stdout) }
     }
 
     /// Send commands to Z3, wait for Z3 to acknowledge commands, and return responses
     pub(crate) fn send_commands(&mut self, commands: Vec<u8>) -> Vec<String> {
+        self.send_commands_async(commands).wait()
+    }
+
+    /// Send commands to Z3
+    pub(crate) fn send_commands_async<'a>(&'a mut self, commands: Vec<u8>) -> CommandsHandle<'a> {
         // Send request to writer thread
         self.requests.send(commands).expect("internal error: failed to send to writer thread");
 
-        // Loop until we receive the DONE message that we asked Z3 to echo back
-        let mut lines = Vec::new();
-        loop {
-            let mut line = String::new();
-            self.smt_pipe_stdout
-                .read_line(&mut line)
-                // The Z3 process could die unexpectedly.  In that case, we die too:
-                .expect("IO error: failure when receiving data to Z3 process across pipe");
-            line = line.replace("\n", "").replace("\r", "");
-            if line == DONE {
-                return lines;
+        let smt_pipe_stdout =
+            self.smt_pipe_stdout.take().expect("internal error: wait on the CommandsHandle first");
+        let (sender, receiver) = std::sync::mpsc::channel();
+
+        let join_handle = std::thread::spawn(move || {
+            let mut smt_pipe_stdout = smt_pipe_stdout;
+            let mut lines = Vec::new();
+            loop {
+                let mut line = String::new();
+                smt_pipe_stdout
+                    .read_line(&mut line)
+                    // The Z3 process could die unexpectedly.  In that case, we die too:
+                    .expect("IO error: failure when receiving data to Z3 process across pipe");
+                line = line.replace("\n", "").replace("\r", "");
+                if line == DONE {
+                    sender.send(lines).expect("internal error: Z3 reader thread failure");
+                    break smt_pipe_stdout;
+                }
+                lines.push(line);
             }
-            lines.push(line);
+        });
+
+        CommandsHandle { smt_process: self, join_handle, receiver }
+    }
+}
+
+pub struct CommandsHandle<'a> {
+    smt_process: &'a mut SmtProcess,
+    join_handle: std::thread::JoinHandle<BufReader<ChildStdout>>,
+    receiver: std::sync::mpsc::Receiver<Vec<String>>,
+}
+
+impl<'a> CommandsHandle<'a> {
+    pub fn wait(self) -> Vec<String> {
+        let result = self.receiver.recv().expect("internal error: Z3 reader thread failure");
+        self.smt_process.smt_pipe_stdout =
+            Some(self.join_handle.join().expect("internal error: Z3 reader thread failure"));
+        result
+    }
+
+    pub fn wait_timeout(self, timeout: std::time::Duration) -> Result<Vec<String>, Self> {
+        match self.receiver.recv_timeout(timeout) {
+            Ok(result) => {
+                self.smt_process.smt_pipe_stdout = Some(
+                    self.join_handle.join().expect("internal error: Z3 reader thread failure"),
+                );
+                Ok(result)
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => Err(self),
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                panic!("internal error: Z3 reader thread disconnected")
+            }
         }
     }
 }

--- a/source/air/src/smt_verify.rs
+++ b/source/air/src/smt_verify.rs
@@ -114,7 +114,7 @@ pub(crate) fn smt_check_assertion<'ctx>(
     mut infos: Vec<AssertionInfo>,
     air_model: Model,
     only_check_earlier: bool,
-    report_long_running: &mut Option<ReportLongRunning>,
+    report_long_running: Option<&mut ReportLongRunning>,
 ) -> ValidityResult {
     if only_check_earlier {
         // disable all labels that come after the first known error
@@ -303,7 +303,7 @@ pub(crate) fn smt_check_query<'ctx>(
     context: &mut Context,
     query: &Query,
     air_model: Model,
-    report_long_running: &mut Option<ReportLongRunning>,
+    report_long_running: Option<&mut ReportLongRunning>,
 ) -> ValidityResult {
     context.smt_log.log_push();
     context.push_name_scope();

--- a/source/air/src/smt_verify.rs
+++ b/source/air/src/smt_verify.rs
@@ -106,11 +106,15 @@ pub(crate) fn smt_add_decl<'ctx>(context: &mut Context, decl: &Decl) {
     }
 }
 
+pub type ReportLongRunning<'a> =
+    (std::time::Duration, Box<dyn FnMut(std::time::Duration) -> () + 'a>);
+
 pub(crate) fn smt_check_assertion<'ctx>(
     context: &mut Context,
     mut infos: Vec<AssertionInfo>,
     air_model: Model,
     only_check_earlier: bool,
+    report_long_running: &mut Option<ReportLongRunning>,
 ) -> ValidityResult {
     if only_check_earlier {
         // disable all labels that come after the first known error
@@ -148,7 +152,20 @@ pub(crate) fn smt_check_assertion<'ctx>(
     let time0 = std::time::Instant::now();
     let smt_proc = context.smt_manager.get_smt_process();
     let time1 = std::time::Instant::now();
-    let smt_output = smt_proc.send_commands(context.smt_log.take_pipe_data());
+    let mut commands_handle = smt_proc.send_commands_async(context.smt_log.take_pipe_data());
+    let smt_output = if let Some((report_interval, report_fn)) = report_long_running {
+        loop {
+            match commands_handle.wait_timeout(*report_interval) {
+                Ok(smt_output) => break smt_output,
+                Err(handle) => {
+                    report_fn(time1.elapsed());
+                    commands_handle = handle;
+                }
+            }
+        }
+    } else {
+        commands_handle.wait()
+    };
     let time2 = std::time::Instant::now();
     context.time_smt_init += time1 - time0;
     context.time_smt_run += time2 - time1;
@@ -281,6 +298,7 @@ pub(crate) fn smt_check_query<'ctx>(
     context: &mut Context,
     query: &Query,
     air_model: Model,
+    report_long_running: &mut Option<ReportLongRunning>,
 ) -> ValidityResult {
     context.smt_log.log_push();
     context.push_name_scope();
@@ -316,7 +334,7 @@ pub(crate) fn smt_check_query<'ctx>(
     let not_expr = Arc::new(ExprX::Unary(UnaryOp::Not, labeled_assertion));
     context.smt_log.log_decl(&Arc::new(DeclX::Const(str_ident(QUERY), Arc::new(TypX::Bool))));
     context.smt_log.log_assert(&mk_implies(&str_var(QUERY), &not_expr));
-    let result = smt_check_assertion(context, infos, air_model, false);
+    let result = smt_check_assertion(context, infos, air_model, false, report_long_running);
 
     result
 }

--- a/source/air/src/tests.rs
+++ b/source/air/src/tests.rs
@@ -15,7 +15,7 @@ fn run_nodes_as_test(should_typecheck: bool, should_be_valid: bool, nodes: &[Nod
     match Parser::new().nodes_to_commands(&nodes) {
         Ok(commands) => {
             for command in commands.iter() {
-                let result = air_context.command(&command);
+                let result = air_context.command(&command, Default::default());
                 match (&**command, should_typecheck, should_be_valid, result) {
                     (_, false, _, ValidityResult::TypeError(_)) => {}
                     (_, true, _, ValidityResult::TypeError(s)) => {

--- a/source/rust_verify/src/config.rs
+++ b/source/rust_verify/src/config.rs
@@ -1,5 +1,7 @@
 use getopts::Options;
 
+pub const DEFAULT_RLIMIT_SECS: u32 = 10;
+
 #[derive(Debug, Clone, Copy)]
 pub enum ShowTriggers {
     Silent,
@@ -108,7 +110,13 @@ pub fn parse_args(program: &String, args: impl Iterator<Item = String>) -> (Args
         "Do not automatically check recommends after verification failures",
     );
     opts.optflag("", OPT_TIME, "Measure and report time taken");
-    opts.optopt("", OPT_RLIMIT, "Set SMT resource limit (roughly in seconds)", "INTEGER");
+    opts.optopt(
+        "",
+        OPT_RLIMIT,
+        format!("Set SMT resource limit (roughly in seconds). Default: {}.", DEFAULT_RLIMIT_SECS)
+            .as_str(),
+        "INTEGER",
+    );
     opts.optmulti("", OPT_SMT_OPTION, "Set an SMT option (e.g. smt.random_seed=7)", "OPTION=VALUE");
     opts.optopt("", OPT_MULTIPLE_ERRORS, "If 0, look for at most one error per function; if > 0, always find first error in function and make extra queries to find more errors (default: 2)", "INTEGER");
     opts.optopt(
@@ -175,7 +183,7 @@ pub fn parse_args(program: &String, args: impl Iterator<Item = String>) -> (Args
         rlimit: matches
             .opt_get::<u32>(OPT_RLIMIT)
             .unwrap_or_else(|_| error("expected integer after rlimit".to_string()))
-            .unwrap_or(0),
+            .unwrap_or(DEFAULT_RLIMIT_SECS),
         smt_options: matches
             .opt_strs(OPT_SMT_OPTION)
             .iter()

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -623,7 +623,7 @@ impl Verifier {
 
         // air_recommended_options causes AIR to apply a preset collection of Z3 options
         air_context.set_z3_param("air_recommended_options", "true");
-        air_context.set_rlimit(self.args.rlimit.checked_mul(RLIMIT_PER_SECOND).unwrap_or(0));
+        air_context.set_rlimit(self.args.rlimit.saturating_mul(RLIMIT_PER_SECOND));
         for (option, value) in self.args.smt_options.iter() {
             air_context.set_z3_param(&option, &value);
         }

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -23,6 +23,8 @@ use vir::ast_util::{fun_as_rust_dbg, is_visible_to};
 use vir::def::SnapPos;
 use vir::recursion::Node;
 
+const RLIMIT_PER_SECOND: u32 = 3000000;
+
 pub struct VerifierCallbacks {
     pub verifier: Arc<Mutex<Verifier>>,
     pub vir_ready: signalling::Signaller<bool>,
@@ -607,7 +609,7 @@ impl Verifier {
 
         // air_recommended_options causes AIR to apply a preset collection of Z3 options
         air_context.set_z3_param("air_recommended_options", "true");
-        air_context.set_rlimit(self.args.rlimit * 1000000);
+        air_context.set_rlimit(self.args.rlimit.checked_mul(RLIMIT_PER_SECOND).unwrap_or(0));
         for (option, value) in self.args.smt_options.iter() {
             air_context.set_z3_param(&option, &value);
         }


### PR DESCRIPTION
Example output:

```
❯ ./tools/rust-verify.sh --time rust_verify/example/playground.rs
Verifying root module
note: function definition check has been running for 2 seconds
 --> rust_verify/example/playground.rs:7:10
  |
7 | #[proof] fn goodbye_z3() {
  |          ^^^^^^^^^^^^^^^

note: function definition check has been running for 4 seconds
 --> rust_verify/example/playground.rs:7:10
  |
7 | #[proof] fn goodbye_z3() {
  |          ^^^^^^^^^^^^^^^

note: function definition check has been running for 6 seconds
 --> rust_verify/example/playground.rs:7:10
  |
7 | #[proof] fn goodbye_z3() {
  |          ^^^^^^^^^^^^^^^

error: function definition check: rlimit exceeded
 --> rust_verify/example/playground.rs:7:10
  |
7 | #[proof] fn goodbye_z3() {
  |          ^^^^^^^^^^^^^^^

error: aborting due to previous error

Verification results:: verified: 1 errors: 1
```

The two second reporting interval is quite aggressive, but I think aligns with our goal of efficient encoding and fast feedback cycles. We can increase it later (or make it configurable) if it turns out to be too chatty.