### PR TITLE
Add decreases_when

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -43,6 +43,13 @@ pub fn decreases<A>(_a: A) {
 }
 
 // Can only appear at beginning of function body
+// decrease_when is automatically added to list of recommends
+#[proof]
+pub fn decreases_when(_b: bool) {
+    unimplemented!();
+}
+
+// Can only appear at beginning of function body
 #[proof]
 pub fn decreases_by<F>(_f: F) {
     unimplemented!();

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -382,6 +382,7 @@ fn fn_call_to_vir<'tcx>(
     let is_ensures = f_name == "builtin::ensures";
     let is_invariant = f_name == "builtin::invariant";
     let is_decreases = f_name == "builtin::decreases";
+    let is_decreases_when = f_name == "builtin::decreases_when";
     let is_decreases_by = f_name == "builtin::decreases_by";
     let is_opens_invariants_none = f_name == "builtin::opens_invariants_none";
     let is_opens_invariants_any = f_name == "builtin::opens_invariants_any";
@@ -419,6 +420,7 @@ fn fn_call_to_vir<'tcx>(
         || is_ensures
         || is_invariant
         || is_decreases
+        || is_decreases_when
         || is_decreases_by
         || is_opens_invariants_none
         || is_opens_invariants_any
@@ -762,6 +764,10 @@ fn fn_call_to_vir<'tcx>(
         Ok(mk_expr(ExprX::Header(header)))
     } else if is_decreases {
         let header = Arc::new(HeaderExprX::Decreases(Arc::new(vir_args)));
+        Ok(mk_expr(ExprX::Header(header)))
+    } else if is_decreases_when {
+        unsupported_err_unless!(len == 1, expr.span, "expected decreases_when", &args);
+        let header = Arc::new(HeaderExprX::DecreasesWhen(vir_args[0].clone()));
         Ok(mk_expr(ExprX::Header(header)))
     } else if is_admit {
         unsupported_err_unless!(len == 0, expr.span, "expected admit", args);

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -250,6 +250,13 @@ pub(crate) fn check_item_fn<'tcx>(
         check_recommends: vattrs.check_recommends,
         non_linear: vattrs.non_linear,
     };
+
+    let mut recommend: Vec<vir::ast::Expr> = (*header.recommend).clone();
+    if let Some(decrease_when) = &header.decrease_when {
+        // Automatically add decrease_when to recommends
+        recommend.push(decrease_when.clone());
+    }
+
     let func = FunctionX {
         name: name.clone(),
         kind,
@@ -259,9 +266,10 @@ pub(crate) fn check_item_fn<'tcx>(
         typ_bounds,
         params,
         ret,
-        require: if mode == Mode::Spec { header.recommend } else { header.require },
+        require: if mode == Mode::Spec { Arc::new(recommend) } else { header.require },
         ensure: header.ensure,
         decrease: header.decrease,
+        decrease_when: header.decrease_when,
         decrease_by: header.decrease_by,
         mask_spec: header.invariant_mask,
         is_const: false,
@@ -323,6 +331,7 @@ pub(crate) fn check_item_const<'tcx>(
         require: Arc::new(vec![]),
         ensure: Arc::new(vec![]),
         decrease: Arc::new(vec![]),
+        decrease_when: None,
         decrease_by: None,
         mask_spec: MaskSpec::NoSpec,
         is_const: true,
@@ -388,6 +397,7 @@ pub(crate) fn check_foreign_item_fn<'tcx>(
         require: Arc::new(vec![]),
         ensure: Arc::new(vec![]),
         decrease: Arc::new(vec![]),
+        decrease_when: None,
         decrease_by: None,
         mask_spec: MaskSpec::NoSpec,
         is_const: false,

--- a/source/rust_verify/tests/recursion.rs
+++ b/source/rust_verify/tests/recursion.rs
@@ -654,6 +654,7 @@ test_verify_one_file! {
         #[spec]
         fn arith_sum(i: int) -> int {
             decreases(i);
+            decreases_when(i >= 0);
             decreases_by(check_arith_sum);
 
             if i == 0 { 0 } else { i + arith_sum(i - 1) }
@@ -661,7 +662,6 @@ test_verify_one_file! {
 
         #[proof] #[verifier(decreases_by)]
         fn check_arith_sum(i: int) {
-            requires(i >= 0);
         }
     } => Ok(())
 }
@@ -682,6 +682,7 @@ test_verify_one_file! {
         #[spec]
         fn arith_sum(i: int) -> int {
             decreases(i);
+            decreases_when(i >= 0);
             decreases_by(check_arith_sum);
 
             if i == 0 { 0 } else { i + arith_sum(i - 1) }
@@ -689,7 +690,6 @@ test_verify_one_file! {
 
         #[proof] #[verifier(decreases_by)]
         fn check_arith_sum(i: int) {
-            requires(i >= 0);
         }
 
         #[proof]
@@ -704,6 +704,7 @@ test_verify_one_file! {
         #[spec]
         fn arith_sum(i: int) -> int {
             decreases(i);
+            decreases_when(i >= 0);
             decreases_by(check_arith_sum);
 
             if i == 0 { 0 } else { i + arith_sum(i - 1) }
@@ -711,7 +712,6 @@ test_verify_one_file! {
 
         #[proof] //#[verifier(decreases_by)]
         fn check_arith_sum(i: int) {
-            requires(i >= 0);
         }
     } => Err(err) => assert_vir_error(err)
 }
@@ -721,6 +721,7 @@ test_verify_one_file! {
         #[spec]
         fn arith_sum(i: int) -> int {
             decreases(i);
+            decreases_when(i >= 0);
             //decreases_by(check_arith_sum);
 
             if i == 0 { 0 } else { i + arith_sum(i - 1) }
@@ -728,7 +729,6 @@ test_verify_one_file! {
 
         #[proof] #[verifier(decreases_by)]
         fn check_arith_sum(i: int) {
-            requires(i >= 0);
         }
     } => Err(err) => assert_vir_error(err)
 }
@@ -738,6 +738,7 @@ test_verify_one_file! {
         #[spec]
         fn arith_sum(i: int) -> int {
             decreases(i);
+            decreases_when(i >= 0);
             decreases_by(check_arith_sum);
 
             if i == 0 { 0 } else { i + arith_sum(i - 1) }
@@ -745,14 +746,13 @@ test_verify_one_file! {
 
         #[proof] #[verifier(decreases_by)]
         fn check_arith_sum(i: int) {
-            requires(i >= 0);
             decreases(i);
         }
     } => Err(err) => assert_vir_error(err)
 }
 
 test_verify_one_file! {
-    #[test] basic_decreases_by_int_fail6 code! {
+    #[test] basic_decreases_by_int_fail6_requires code! {
         #[spec]
         fn arith_sum(i: int) -> int {
             decreases(i);
@@ -764,6 +764,22 @@ test_verify_one_file! {
         #[proof] #[verifier(decreases_by)]
         fn check_arith_sum(i: int) {
             requires(i >= 0);
+        }
+    } => Err(err) => assert_vir_error(err)
+}
+
+test_verify_one_file! {
+    #[test] basic_decreases_by_int_fail6_ensures code! {
+        #[spec]
+        fn arith_sum(i: int) -> int {
+            decreases(i);
+            decreases_by(check_arith_sum);
+
+            if i == 0 { 0 } else { i + arith_sum(i - 1) }
+        }
+
+        #[proof] #[verifier(decreases_by)]
+        fn check_arith_sum(i: int) {
             ensures(i >= 0);
         }
     } => Err(err) => assert_vir_error(err)
@@ -774,6 +790,7 @@ test_verify_one_file! {
         #[spec]
         fn arith_sum(i: int) -> int {
             decreases(i);
+            decreases_when(i >= 0);
             decreases_by(check_arith_sum);
 
             if i == 0 { 0 } else { i + arith_sum(i - 1) }
@@ -781,7 +798,6 @@ test_verify_one_file! {
 
         #[proof] #[verifier(decreases_by)]
         fn check_arith_sum(i: nat) {
-            requires(i >= 0);
         }
     } => Err(err) => assert_vir_error(err)
 }
@@ -791,6 +807,7 @@ test_verify_one_file! {
         #[spec]
         fn arith_sum(i: int) -> int {
             decreases(i);
+            decreases_when(i >= 0);
             decreases_by(check_arith_sum);
 
             if i == 0 { 0 } else { i + arith_sum(i - 1) }
@@ -798,7 +815,6 @@ test_verify_one_file! {
 
         #[proof] #[verifier(decreases_by)]
         fn check_arith_sum(j: int) {
-            requires(j >= 0);
         }
     } => Err(err) => assert_vir_error(err)
 }
@@ -808,6 +824,7 @@ test_verify_one_file! {
         #[spec]
         fn arith_sum<A, B>(a: A, b: B, i: int) -> int {
             decreases(i);
+            decreases_when(i >= 0);
             decreases_by(check_arith_sum::<int, int>);
 
             if i == 0 { 0 } else { i + arith_sum(a, b, i - 1) }
@@ -815,7 +832,6 @@ test_verify_one_file! {
 
         #[proof] #[verifier(decreases_by)]
         fn check_arith_sum<B, A>(a: A, b: B, i: int) {
-            requires(i >= 0);
         }
     } => Err(err) => assert_vir_error(err)
 }
@@ -825,6 +841,7 @@ test_verify_one_file! {
         #[spec]
         fn arith_sum(i: int) -> int {
             decreases(i);
+            decreases_when(i >= 0);
             decreases_by(check_arith_sum);
 
             if i == 0 { 0 } else { i + arith_sum(i - 1) }
@@ -832,7 +849,6 @@ test_verify_one_file! {
 
         #[proof] #[verifier(decreases_by)]
         fn check_arith_sum(i: int) {
-            requires(i >= 0);
             if false {
                 check_arith_sum(i);
             }
@@ -845,6 +861,7 @@ test_verify_one_file! {
         #[spec]
         fn arith_sum(i: int) -> int {
             decreases(i);
+            decreases_when(i >= 0);
             decreases_by(check_arith_sum);
 
             if i == 0 { 0 } else { i + arith_sum(i - 1) }
@@ -852,7 +869,6 @@ test_verify_one_file! {
 
         #[proof] #[verifier(decreases_by)]
         fn check_arith_sum(i: int) {
-            requires(i >= 0);
         }
 
         #[proof]
@@ -906,6 +922,7 @@ test_verify_one_file! {
         #[proof]
         fn arith_sum(i: int) -> int {
             decreases(i);
+            decreases_when(i >= 0);
             decreases_by(check_arith_sum);
 
             if i == 0 { 0 } else { i + arith_sum(i - 1) }
@@ -913,7 +930,6 @@ test_verify_one_file! {
 
         #[proof] #[verifier(decreases_by)]
         fn check_arith_sum(i: int) {
-            requires(i >= 0);
         }
     } => Err(err) => assert_vir_error(err)
 }
@@ -945,6 +961,7 @@ test_verify_one_file! {
         #[spec]
         fn arith_sum(i: int) -> int {
             decreases(id(i));
+            decreases_when(i >= 0);
             decreases_by(check_arith_sum);
 
             if i == 0 { 0 } else { i + arith_sum(i - 1) }
@@ -952,7 +969,6 @@ test_verify_one_file! {
 
         #[proof] #[verifier(decreases_by)]
         fn check_arith_sum(i: int) {
-            requires(i >= 0);
             reveal(id);
         }
     } => Ok(())
@@ -969,6 +985,7 @@ test_verify_one_file! {
         #[spec]
         fn arith_sum(i: int) -> int {
             decreases(id(i));
+            decreases_when(i >= 0);
             decreases_by(check_arith_sum);
 
             if i == 0 { 0 } else { i + arith_sum(i - 1) }
@@ -976,7 +993,6 @@ test_verify_one_file! {
 
         #[proof] #[verifier(decreases_by)]
         fn check_arith_sum(i: int) {
-            requires(i >= 0);
             reveal_id(i);
             reveal_id(i - 1);
         }
@@ -1000,6 +1016,7 @@ test_verify_one_file! {
         #[spec]
         fn arith_sum(i: int) -> int {
             decreases(id(i));
+            decreases_when(i >= 0);
             decreases_by(check_arith_sum);
 
             if i == 0 { 0 } else { i + arith_sum(i - 1) } // FAILS
@@ -1007,7 +1024,6 @@ test_verify_one_file! {
 
         #[proof] #[verifier(decreases_by)]
         fn check_arith_sum(i: int) {
-            requires(i >= 0);
         }
     } => Err(err) => assert_one_fails(err)
 }
@@ -1019,6 +1035,7 @@ test_verify_one_file! {
         impl A {
             #[spec] fn count(self) -> int {
                 decreases(self.i);
+                decreases_when(self.i >= 0);
                 decreases_by(Self::check_count);
 
                 if self.i == 0 { 0 } else { 1 + A { i: self.i - 1}.count() } // FAILS
@@ -1026,8 +1043,54 @@ test_verify_one_file! {
 
             #[proof] #[verifier(decreases_by)]
             fn check_count(self) {
-                requires(self.i >= 0);
             }
         }
     } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] proof_decreases_when_ok code! {
+        #[spec]
+        fn f(i: int) -> int {
+            decreases(i);
+            decreases_when(i >= 0);
+
+            if i == 0 {
+                0
+            } else {
+                i + f(i - 1)
+            }
+        }
+
+        #[proof]
+        fn test() {
+            assert(f(0) == 0);
+            assert(f(1) == 1);
+            assert(f(2) == 3);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] proof_decreases_when_fail code! {
+        #[spec]
+        fn f(i: int) -> int {
+            decreases(i);
+            decreases_when(i >= 0);
+
+            if i == 0 {
+                0
+            } else {
+                i + f(i - 1)
+            }
+        }
+
+        #[proof]
+        fn test() {
+            assert(f(0) == 0);
+            assert(f(1) == 1);
+            assert(f(2) == 3);
+            assert(f(-1) == (-1) + f(-2)); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
 }

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -219,6 +219,8 @@ pub enum HeaderExprX {
     Invariant(Exprs),
     /// Decreases clauses for functions (possibly also for while loops, but this isn't implemented yet)
     Decreases(Exprs),
+    /// Recursive function is uninterpreted when Expr is false
+    DecreasesWhen(Expr),
     /// Proof function to prove termination for recursive functions
     DecreasesBy(Fun),
     /// The function might open the following invariants
@@ -499,6 +501,10 @@ pub struct FunctionX {
     /// decrease.len() == 0 means no decreases clause
     /// decrease.len() >= 1 means list of expressions, interpreted in lexicographic order
     pub decrease: Exprs,
+    /// If Expr is true for the arguments to the function,
+    /// the function is defined according to the function body and the decreases clauses must hold.
+    /// If Expr is false, the function is uninterpreted, the body and decreases clauses are ignored.
+    pub decrease_when: Option<Expr>,
     /// Prove termination with a separate proof function
     pub decrease_by: Option<Fun>,
     /// MaskSpec that specifies what invariants the function is allowed to open

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -359,6 +359,7 @@ where
         require,
         ensure,
         decrease,
+        decrease_when,
         decrease_by: _,
         mask_spec,
         is_const: _,
@@ -374,6 +375,9 @@ where
         expr_visitor_control_flow!(expr_visitor_dfs(e, map, mf));
     }
     for e in decrease.iter() {
+        expr_visitor_control_flow!(expr_visitor_dfs(e, map, mf));
+    }
+    if let Some(e) = decrease_when {
         expr_visitor_control_flow!(expr_visitor_dfs(e, map, mf));
     }
     match mask_spec {
@@ -704,6 +708,7 @@ where
         require,
         ensure,
         decrease,
+        decrease_when,
         decrease_by,
         mask_spec,
         is_const,
@@ -762,6 +767,12 @@ where
 
     let decrease =
         Arc::new(vec_map_result(decrease, |e| map_expr_visitor_env(e, map, env, fe, fs, ft))?);
+    let decrease_when = decrease_when
+        .as_ref()
+        .map(|e| map_expr_visitor_env(e, map, env, fe, fs, ft))
+        .transpose()?;
+    let decrease_by = decrease_by.clone();
+
     let mask_spec = match mask_spec {
         MaskSpec::NoSpec => MaskSpec::NoSpec,
         MaskSpec::InvariantOpens(es) => {
@@ -775,7 +786,6 @@ where
             })?))
         }
     };
-    let decrease_by = decrease_by.clone();
     let attrs = attrs.clone();
     let extra_dependencies = extra_dependencies.clone();
     let is_const = *is_const;
@@ -794,6 +804,7 @@ where
         require,
         ensure,
         decrease,
+        decrease_when,
         decrease_by,
         mask_spec,
         is_const,

--- a/source/vir/src/headers.rs
+++ b/source/vir/src/headers.rs
@@ -12,6 +12,7 @@ pub struct Header {
     pub ensure: Exprs,
     pub invariant: Exprs,
     pub decrease: Exprs,
+    pub decrease_when: Option<Expr>,
     pub decrease_by: Option<Fun>,
     pub invariant_mask: MaskSpec,
     pub extra_dependencies: Vec<Fun>,
@@ -25,6 +26,7 @@ fn read_header_block(block: &mut Vec<Stmt>) -> Result<Header, VirErr> {
     let mut recommend: Option<Exprs> = None;
     let mut invariant: Option<Exprs> = None;
     let mut decrease: Option<Exprs> = None;
+    let mut decrease_when: Option<Expr> = None;
     let mut decrease_by: Option<Fun> = None;
     let mut invariant_mask = MaskSpec::NoSpec;
     let mut n = 0;
@@ -82,6 +84,15 @@ fn read_header_block(block: &mut Vec<Stmt>) -> Result<Header, VirErr> {
                             );
                         }
                         decrease = Some(es.clone());
+                    }
+                    HeaderExprX::DecreasesWhen(e) => {
+                        if decrease_when.is_some() {
+                            return err_str(
+                                &stmt.span,
+                                "only one if decrease_when expression currently supported",
+                            );
+                        }
+                        decrease_when = Some(e.clone());
                     }
                     HeaderExprX::DecreasesBy(path) => {
                         if decrease_by.is_some() {
@@ -141,6 +152,7 @@ fn read_header_block(block: &mut Vec<Stmt>) -> Result<Header, VirErr> {
         ensure,
         invariant,
         decrease,
+        decrease_when,
         decrease_by,
         invariant_mask,
         extra_dependencies,

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -531,6 +531,7 @@ fn poly_function(ctx: &Ctx, function: &Function) -> Function {
         require,
         ensure,
         decrease,
+        decrease_when,
         decrease_by,
         mask_spec,
         is_const,
@@ -591,6 +592,8 @@ fn poly_function(ctx: &Ctx, function: &Function) -> Function {
     state.types.pop_scope();
 
     let decrease = native_exprs(&mut state, decrease);
+    let decrease_when =
+        decrease_when.as_ref().map(|e| coerce_expr_to_native(ctx, &poly_expr(ctx, &mut state, e)));
 
     let mask_spec = match mask_spec {
         MaskSpec::InvariantOpens(es) => MaskSpec::InvariantOpens(native_exprs(&mut state, es)),
@@ -625,6 +628,7 @@ fn poly_function(ctx: &Ctx, function: &Function) -> Function {
         require,
         ensure,
         decrease,
+        decrease_when,
         decrease_by: decrease_by.clone(),
         mask_spec,
         is_const: *is_const,

--- a/source/vir/src/printer.rs
+++ b/source/vir/src/printer.rs
@@ -151,6 +151,7 @@ fn header_expr_to_node(header_expr: &HeaderExprX) -> Node {
         HeaderExprX::Recommends(exprs) => nodes!(recommends {exprs_to_node(exprs)}),
         HeaderExprX::Invariant(exprs) => nodes!(invariant {exprs_to_node(exprs)}),
         HeaderExprX::Decreases(exprs) => nodes!(decreases {exprs_to_node(exprs)}),
+        HeaderExprX::DecreasesWhen(expr) => nodes!(decreases_when {expr_to_node(expr)}),
         HeaderExprX::DecreasesBy(path) => nodes!(decreases_by {fun_to_node(path)}),
         HeaderExprX::InvariantOpens(exprs) => nodes!(invariantOpens {exprs_to_node(exprs)}),
         HeaderExprX::InvariantOpensExcept(exprs) => {
@@ -360,6 +361,7 @@ fn function_to_node(function: &FunctionX) -> Node {
         require,
         ensure,
         decrease,
+        decrease_when,
         decrease_by,
         mask_spec,
         is_const,
@@ -492,6 +494,10 @@ fn function_to_node(function: &FunctionX) -> Node {
         str_to_node(":decrease"),
         exprs_to_node(decrease),
     ];
+    if let Some(decrease_when) = &decrease_when {
+        nodes.push(str_to_node(":decrease_when"));
+        nodes.push(expr_to_node(decrease_when));
+    }
     if let Some(decrease_by) = &decrease_by {
         nodes.push(str_to_node(":decrease_by"));
         nodes.push(fun_to_node(decrease_by));

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -156,11 +156,32 @@ fn check_function(ctxt: &Ctxt, function: &Function) -> Result<(), VirErr> {
                 "decreases_by function cannot have its own decreases clause",
             );
         }
+        if function.x.require.len() != 0 {
+            return err_str(
+                &function.span,
+                "decreases_by function cannot have requires clauses (use decreases_when in the spec function instead)",
+            );
+        }
         if function.x.ensure.len() != 0 {
             return err_str(&function.span, "decreases_by function cannot have ensures clauses");
         }
         if function.x.has_return() {
             return err_str(&function.span, "decreases_by function cannot have a return value");
+        }
+    }
+
+    if function.x.decrease_when.is_some() {
+        if function.x.mode != Mode::Spec {
+            return err_str(
+                &function.span,
+                "only spec functions can use decreases_when (use requires for proof/exec functions)",
+            );
+        }
+        if function.x.decrease.len() == 0 {
+            return err_str(
+                &function.span,
+                "decreases_when can only be used when there is a decreases clause (use recommends(...) for nonrecursive functions)",
+            );
         }
     }
 


### PR DESCRIPTION
- For decreases_by, move "requires" from proof function to spec function, renaming it "decreases_when"
- Allow decreases_when to be used even when there is no decreases_by
- Automatically add decreases_when condition to list of recommends clauses.

Example:
```
        #[spec]
        fn f(i: int) -> int {
            decreases(i);
            decreases_when(i >= 0);

            if i == 0 {
                0
            } else {
                i + f(i - 1)
            }
        }

        #[proof]
        fn test() {
            assert(f(0) == 0);
            assert(f(1) == 1);
            assert(f(2) == 3);
            assert(f(-1) == (-1) + f(-2)); // FAILS
        }
```
