### PR TITLE
Run some of the missing rustc checks that are currently skipped for spec or all code

### DIFF
--- a/source/rust_verify/example/state_machines/conditional.rs
+++ b/source/rust_verify/example/state_machines/conditional.rs
@@ -6,7 +6,7 @@ use pervasive::*;
 use state_machines_macros::tokenized_state_machine;
 
 #[spec]
-enum Foo {
+pub enum Foo {
     Bar(int),
     Qax(int),
     Duck(int),

--- a/source/rust_verify/example/state_machines/flat_combine.rs
+++ b/source/rust_verify/example/state_machines/flat_combine.rs
@@ -15,24 +15,24 @@ use state_machines_macros::tokenized_state_machine;
 // rather complicated to use, and it wasn't necessary.
 // Now, I expect storage to be a lot easier to use, easier than the alternative.
 
-struct Request {
+pub struct Request {
     pub rid: int,
     pub req: int,
 }
 
-struct Response {
+pub struct Response {
     pub rid: int,
     pub resp: int,
 }
 
 #[is_variant]
-enum Client {
+pub enum Client {
     Idle,
     Waiting {rid: int},
 }
 
 #[is_variant]
-enum Combiner {
+pub enum Combiner {
     Collecting {elems: Seq<Option<int>>},
     Responding {elems: Seq<Option<int>>, idx: nat},
 }

--- a/source/rust_verify/example/state_machines/refinement.rs
+++ b/source/rust_verify/example/state_machines/refinement.rs
@@ -90,6 +90,9 @@ fn next_refines_next(pre: A::State, post: A::State) {
 
             B::show::add(interp(pre), interp(post), 2 * n);
         }
+        A::Step::dummy_to_use_type_params(_) => {
+            assume(false); // TODO
+        }
     }
 }
 

--- a/source/rust_verify/example/state_machines/rwlock.rs
+++ b/source/rust_verify/example/state_machines/rwlock.rs
@@ -10,7 +10,7 @@ use pervasive::cell::*;
 use state_machines_macros::tokenized_state_machine;
 
 // TODO make T generic
-struct T {
+pub struct T {
     t: u8,
 }
 

--- a/source/rust_verify/example/summer_school/chapter-6-1.rs
+++ b/source/rust_verify/example/summer_school/chapter-6-1.rs
@@ -11,10 +11,10 @@ use state_machines_macros::case_on_next;
 use state_machines_macros::case_on_init;
 
 #[verifier(external_body)]
-struct Key { }
+pub struct Key { }
 
 #[verifier(external_body)]
-struct Value { }
+pub struct Value { }
 
 #[verifier(external_body)]
 #[spec]

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -811,6 +811,13 @@ impl Verifier {
                 return Ok(false);
             }
         }
+
+        tcx.hir().par_body_owners(|def_id| tcx.ensure().check_match(def_id.to_def_id()));
+        tcx.ensure().check_private_in_public(());
+        tcx.hir().par_for_each_module(|module| {
+            tcx.ensure().check_mod_privacy(module);
+        });
+
         let autoviewed_call_typs =
             autoviewed_call_typs.lock().expect("get autoviewed_call_typs").clone();
 

--- a/source/rust_verify/tests/adts.rs
+++ b/source/rust_verify/tests/adts.rs
@@ -692,7 +692,7 @@ const ENUM_S: &str = code_str! {
 };
 
 test_verify_one_file! {
-    #[ignore] #[test] test_match_exhaustiveness_regression_127 ENUM_S.to_string() + code_str! {
+    #[test] test_match_exhaustiveness_regression_127 ENUM_S.to_string() + code_str! {
         fn f(s: S) {
             match s {
                 S::V1 => assert(true),

--- a/source/rust_verify/tests/lifetime.rs
+++ b/source/rust_verify/tests/lifetime.rs
@@ -40,7 +40,7 @@ test_verify_one_file! {
             unimplemented!();
         }
 
-        struct Foo<'a, T: 'a> {
+        pub struct Foo<'a, T: 'a> {
             #[proof] pub t: &'a T,
         }
 

--- a/source/rust_verify/tests/state_machines.rs
+++ b/source/rust_verify/tests/state_machines.rs
@@ -16,7 +16,7 @@ const IMPORTS: &str = code_str! {
 
     #[spec]
     #[is_variant]
-    enum Foo {
+    pub enum Foo {
         Bar(int),
         Qax(int),
         Duck(int),


### PR DESCRIPTION
because they are in stages that are after where we stop rustc.

This breaks a lot of tests/examples. It may also be that it overrides some of our typechecking changes, so it may not be mergeable right now. However critical because it may uncover unsoundness.

* [x] try to fix tests