### PR TITLE
disallow `unsafe impl`

### DIFF
--- a/source/pervasive/cell.rs
+++ b/source/pervasive/cell.rs
@@ -17,6 +17,19 @@ pub struct PCell<#[verifier(strictly_positive)] V> {
     ucell: UnsafeCell<MaybeUninit<V>>,
 }
 
+// PCell is always safe to Send/Sync. It's the Permission object where Send/Sync matters.
+// (It doesn't matter if you move the bytes to another thread if you can't access them.)
+
+#[verifier(external_body)]
+unsafe impl<T> Sync for PCell<T> {}
+
+#[verifier(external_body)]
+unsafe impl<T> Send for PCell<T> {}
+
+// Permission<V>, on the other hand, needs to inherit both Send and Sync from the V,
+// which it does by default in the given definition.
+// (Note: this depends on the current behavior that #[spec] fields are still counted for marker traits)
+
 #[proof]
 #[verifier(unforgeable)]
 pub struct Permission<V> {

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -90,6 +90,14 @@ fn check_item<'tcx>(
             )?;
         }
         ItemKind::Impl(impll) => {
+            if impll.unsafety != Unsafety::Normal {
+                let attrs = ctxt.tcx.hir().attrs(item.hir_id());
+                let vattrs = get_verifier_attrs(attrs)?;
+                if !vattrs.external_body {
+                    return err_span_str(item.span, "the verifier does not support `unsafe` here");
+                }
+            }
+
             if let Some(TraitRef { path, hir_ref_id: _ }) = impll.of_trait {
                 let path_name = path_as_rust_name(&def_id_to_vir_path(ctxt.tcx, path.res.def_id()));
                 let ignore = if path_name == "builtin::Structural" {

--- a/source/rust_verify/tests/cell_lib.rs
+++ b/source/rust_verify/tests/cell_lib.rs
@@ -270,3 +270,39 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_one_fails(err)
 }
+
+// Test that cell::Permission<T> correctly inherits the Send and Sync properties of T
+
+test_verify_one_file! {
+    #[test] permission_inherits_sync IMPORTS.to_string() + code_str! {
+        struct Foo {
+            i: u8,
+        }
+
+        impl !Sync for Foo { }
+
+        pub fn f<T: Sync>(t: T) {
+        }
+
+        pub fn foo(r: cell::Permission<Foo>) {
+            f(r);
+        }
+    } => Err(e) => assert_error_msg(e, "the trait `std::marker::Sync` is not implemented for `Foo`")
+}
+
+test_verify_one_file! {
+    #[test] permission_inherits_send IMPORTS.to_string() + code_str! {
+        struct Foo {
+            i: u8,
+        }
+
+        impl !Send for Foo { }
+
+        pub fn f<T: Send>(t: T) {
+        }
+
+        pub fn foo(r: cell::Permission<Foo>) {
+            f(r);
+        }
+    } => Err(e) => assert_error_msg(e, "the trait `std::marker::Send` is not implemented for `Foo`")
+}

--- a/source/rust_verify/tests/impl.rs
+++ b/source/rust_verify/tests/impl.rs
@@ -361,3 +361,13 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] unsafe_impl_fail code! {
+        struct Foo {
+            x: u32,
+        }
+
+        unsafe impl Send for Foo { }
+    } => Err(e) => assert_vir_error_msg(e, "the verifier does not support `unsafe` here")
+}


### PR DESCRIPTION
I was tweaking the marker traits for `cell::Permission` when I noticed that this check was missing.

- disallow `unsafe impl` (except with external_body)
 - add unsafe impls for cell::PCell
 - add tests that it works as expected for cell::Permission