### PR TITLE
Rc and Arc

### DIFF
--- a/source/rust_verify/src/erase.rs
+++ b/source/rust_verify/src/erase.rs
@@ -617,6 +617,17 @@ fn erase_expr_opt(ctxt: &Ctxt, mctxt: &mut MCtxt, expect: Mode, expr: &Expr) -> 
                     }
                 },
                 ResolvedCall::Spec => return None,
+                ResolvedCall::CompilableOperator => {
+                    if keep_mode(ctxt, expect) {
+                        ExprKind::MethodCall(
+                            m_path.clone(),
+                            vec_map(args, |e| P(erase_expr(ctxt, mctxt, expect, e))),
+                            span.clone(),
+                        )
+                    } else {
+                        return None;
+                    }
+                }
                 _ => panic!("internal error: MethodCall ResolvedCall {:?}", call),
             }
         }

--- a/source/rust_verify/tests/std.rs
+++ b/source/rust_verify/tests/std.rs
@@ -1,0 +1,25 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+test_verify_one_file! {
+    #[test] rc_arc code! {
+        use std::rc::Rc;
+        use std::sync::Arc;
+
+        fn foo() {
+            let x = Rc::new(5);
+            assert_by(*x == 5, {});
+
+            let x1 = x.clone();
+            assert_by(*x1 == 5, {});
+
+            let y = Arc::new(5);
+            assert_by(*y == 5, {});
+
+            let y1 = y.clone();
+            assert_by(*y1 == 5, {});
+        }
+    } => Ok(())
+}


### PR DESCRIPTION
handles the following in the translation to VIR (by skipping them):
 - the type constructors `Arc` and `Rc`
 - `Arc::new`, `Rc::new`
 - `.clone()`

Very special-case-y, let me know if you see a better way to handle anything here