### PR TITLE
Add `spinoff_z3` attribute

### DIFF
--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -146,6 +146,8 @@ pub(crate) enum Attr {
     CheckRecommends,
     // set smt.arith.nl=true
     NonLinear,
+    // Use a new dedicated Z3 process just for this query
+    SpinoffZ3,
 }
 
 fn get_trigger_arg(span: Span, attr_tree: &AttrTree) -> Result<u64, VirErr> {
@@ -282,6 +284,9 @@ pub(crate) fn parse_attrs(attrs: &[Attribute]) -> Result<Vec<Attr>, VirErr> {
                 Some(box [AttrTree::Fun(_, arg, None)]) if arg == "nonlinear" => {
                     v.push(Attr::NonLinear)
                 }
+                Some(box [AttrTree::Fun(_, arg, None)]) if arg == "spinoff_z3" => {
+                    v.push(Attr::SpinoffZ3)
+                }
                 _ => return err_span_str(*span, "unrecognized verifier attribute"),
             },
             _ => {}
@@ -372,6 +377,7 @@ pub(crate) struct VerifierAttrs {
     pub(crate) decreases_by: bool,
     pub(crate) check_recommends: bool,
     pub(crate) nonlinear: bool,
+    pub(crate) spinoff_z3: bool,
 }
 
 pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, VirErr> {
@@ -395,6 +401,7 @@ pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, V
         decreases_by: false,
         check_recommends: false,
         nonlinear: false,
+        spinoff_z3: false,
     };
     for attr in parse_attrs(attrs)? {
         match attr {
@@ -419,6 +426,7 @@ pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, V
             Attr::DecreasesBy => vs.decreases_by = true,
             Attr::CheckRecommends => vs.check_recommends = true,
             Attr::NonLinear => vs.nonlinear = true,
+            Attr::SpinoffZ3 => vs.spinoff_z3 = true,
             _ => {}
         }
     }

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -249,6 +249,7 @@ pub(crate) fn check_item_fn<'tcx>(
         is_decrease_by: vattrs.decreases_by,
         check_recommends: vattrs.check_recommends,
         nonlinear: vattrs.nonlinear,
+        spinoff_z3: vattrs.spinoff_z3,
     };
 
     let mut recommend: Vec<vir::ast::Expr> = (*header.recommend).clone();

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -398,10 +398,14 @@ impl Verifier {
             commands.iter().map(|x| &**x)
         {
             let context = if *spinoff_z3 {
-                assert!(z3_idx < air_contexts.len());
-                let c2 = &mut air_contexts[z3_idx];
+                if z3_idx >= air_contexts.len() {
+                    panic!("Internal Error: Run out of spunoff Z3")
+                }
+                let spunoff_z3_context = &mut air_contexts[z3_idx];
                 increment(&mut z3_idx);
-                c2
+                spunoff_z3_context.blank_line();
+                spunoff_z3_context.comment(comment);
+                spunoff_z3_context
             } else {
                 &mut *air_context
             };

--- a/source/rust_verify/tests/restart.rs
+++ b/source/rust_verify/tests/restart.rs
@@ -1,0 +1,48 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+test_verify_one_file! {
+    #[test] test_box_unbox_struct code! {
+        #[derive(Eq, PartialEq)]
+        struct Thing<A> {
+            a: A,
+        }
+
+        #[proof]
+        #[verifier(spinoff_z3)]
+        fn one(v: int) {
+            let t1 = Thing { a: v };
+            let t2 = Thing { a: v };
+            let a: int = t2.a;
+        }
+
+        fn two(v: Thing<u8>) {
+            assert(v.a >= 0);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] test_many_queries code! {
+        #[proof]
+        #[verifier(spinoff_z3)]
+        fn test6(x: u32, y: u32, z:u32) {
+            requires(x < 0xfff);
+
+            assert_nonlinear_by({
+                requires(x < 0xfff);
+                ensures(x*x + x == x * (x + 1));
+            });
+            assert(x*x + x == x * (x + 1));
+
+            assert_bit_vector((x < 0xfff) >>= (x&y < 0xfff));
+            assert(x&y < 0xfff);
+
+            assert_nonlinear_by({
+                ensures(x*y*z == y*x*z);
+            });
+        }
+    } => Ok(())
+}

--- a/source/rust_verify/tests/z3_restart.rs
+++ b/source/rust_verify/tests/z3_restart.rs
@@ -4,28 +4,7 @@ mod common;
 use common::*;
 
 test_verify_one_file! {
-    #[test] test_box_unbox_struct code! {
-        #[derive(Eq, PartialEq)]
-        struct Thing<A> {
-            a: A,
-        }
-
-        #[proof]
-        #[verifier(spinoff_z3)]
-        fn one(v: int) {
-            let t1 = Thing { a: v };
-            let t2 = Thing { a: v };
-            let a: int = t2.a;
-        }
-
-        fn two(v: Thing<u8>) {
-            assert(v.a >= 0);
-        }
-    } => Ok(())
-}
-
-test_verify_one_file! {
-    #[test] test_many_queries code! {
+    #[test] test_with_bitvec_nlarith code! {
         #[proof]
         #[verifier(spinoff_z3)]
         fn test6(x: u32, y: u32, z:u32) {
@@ -47,6 +26,62 @@ test_verify_one_file! {
     } => Ok(())
 }
 
+// From https://github.com/secure-foundations/verus/blob/ad92b2a8908a219ec84c277d2bb701934e9a8d9c/source/rust_verify/tests/adts_generics.rs#L1
+test_verify_one_file! {
+    #[test] test_box_unbox_struct code! {
+        #[derive(Eq, PartialEq)]
+        struct Thing<A> {
+            a: A,
+        }
+
+        #[proof]
+        #[verifier(spinoff_z3)]
+        fn one(v: int) {
+            let t1 = Thing { a: v };
+            let t2 = Thing { a: v };
+            let a: int = t2.a;
+        }
+
+        fn two(v: Thing<u8>) {
+            assert(v.a >= 0);
+        }
+    } => Ok(())
+}
+
+// From https://github.com/secure-foundations/verus/blob/826e59f3774927f1cc61dd87e39e015b1ec51abf/source/rust_verify/tests/nonlinear.rs#L46
+test_verify_one_file! {
+    #[test] test_with_nlarith code! {
+        #[verifier(nonlinear)]
+        #[verifier(spinoff_z3)]
+        #[proof]
+        fn lemma_div_pos_is_pos(x: int, d: int) {
+            requires([
+                0 <= x,
+                0 < d,
+            ]);
+            ensures(0 <= x / d);
+        }
+    } => Ok(())
+}
+
+// From https://github.com/secure-foundations/verus/blob/main/source/rust_verify/example/bitvector_basic.rs
+test_verify_one_file! {
+    #[test] test_with_bv code! {
+        #[verifier(bit_vector)]
+        #[verifier(spinoff_z3)]
+        #[proof]
+        fn bit_or32_auto(){
+            ensures([
+                forall(|a: u32, b: u32| #[trigger] (a|b) == b|a),
+                forall(|a: u32, b: u32, c:u32| #[trigger] ((a|b)|c) == a|(b|c)),
+                forall(|a: u32| #[trigger] (a|a) == a),
+                forall(|a: u32| #[trigger] (a|0) == a),
+                forall(|a: u32| #[trigger] (a| 0xffff_ffffu32) == 0xffff_ffffu32),
+            ]);
+        }
+    } => Ok(())
+}
+
 test_verify_one_file! {
     #[test] test1_fails code! {
         #[proof]
@@ -59,5 +94,82 @@ test_verify_one_file! {
             assert_bit_vector(b<<2 == b*4);
             assert(((b<<2) as int) == (b as int) *4);  // FAILS
         }
+    } => Err(err) => assert_one_fails(err)
+}
+
+// From https://github.com/secure-foundations/verus/blob/826e59f3774927f1cc61dd87e39e015b1ec51abf/source/rust_verify/tests/nonlinear.rs#L46
+test_verify_one_file! {
+    #[test] test2_fails code! {
+        #[verifier(nonlinear)]
+        #[verifier(spinoff_z3)]
+        #[proof]
+        fn wrong_lemma_2(x: int, y: int, z: int) {
+            requires([
+                x > y,
+                3 <= z,
+            ]);
+            ensures (y*z > x); // FAILS
+        }
+    } => Err(e) => assert_one_fails(e)
+}
+
+// From https://github.com/secure-foundations/verus/blob/21a4774a6fb18295fe5bbcd6abb3e19c6df1e851/source/rust_verify/tests/multiset.rs#L63
+test_verify_one_file! {
+    #[test] multiset_basics code! {
+        use crate::pervasive::multiset::*;
+
+        #[proof] #[verifier(spinoff_z3)]
+        pub fn commutative<V>(a: Multiset<V>, b: Multiset<V>) {
+            ensures(equal(a.add(b), b.add(a)));
+
+            assert(a.add(b).ext_equal(b.add(a)));
+        }
+
+        #[proof] #[verifier(spinoff_z3)]
+        pub fn associative<V>(a: Multiset<V>, b: Multiset<V>, c: Multiset<V>) {
+            ensures(equal(
+                a.add(b.add(c)),
+                a.add(b).add(c)));
+
+            assert(a.add(b.add(c)).ext_equal(
+                a.add(b).add(c)));
+        }
+
+        #[proof] #[verifier(spinoff_z3)]
+        pub fn insert2<V>(a: V, b: V) {
+            ensures(equal(
+                Multiset::empty().insert(a).insert(b),
+                Multiset::empty().insert(b).insert(a)));
+
+            assert(
+                Multiset::empty().insert(a).insert(b).ext_equal(
+                Multiset::empty().insert(b).insert(a)));
+        }
+
+        #[proof] #[verifier(spinoff_z3)]
+        pub fn insert2_count<V>(a: V, b: V, c: V) {
+            requires(!equal(a, b) && !equal(b, c) && !equal(c, a));
+
+            assert(Multiset::empty().insert(a).insert(b).count(a) == 1);
+            assert(Multiset::empty().insert(a).insert(b).count(b) == 1);
+            assert(Multiset::empty().insert(a).insert(b).count(c) == 0);
+        }
+
+        #[proof] #[verifier(spinoff_z3)]
+        pub fn add_sub_cancel<V>(a: Multiset<V>, b: Multiset<V>) {
+            ensures(equal(a.add(b).sub(b), a));
+
+            assert(a.add(b).sub(b).ext_equal(a));
+        }
+
+        #[proof] #[verifier(spinoff_z3)]
+        pub fn sub_add_cancel<V>(a: Multiset<V>, b: Multiset<V>) {
+            requires(b.le(a));
+            ensures(equal(a.sub(b).add(b), a));
+
+            assert(a.sub(b).add(b).ext_equal(a));
+            assert(false) // FAILS
+        }
+
     } => Err(err) => assert_one_fails(err)
 }

--- a/source/rust_verify/tests/z3_restart.rs
+++ b/source/rust_verify/tests/z3_restart.rs
@@ -46,3 +46,18 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] test1_fails code! {
+        #[proof]
+        #[verifier(spinoff_z3)]
+        fn test6(b: u32, b2: u32) {
+            assert_nonlinear_by({
+                ensures(b*b2 == b2*b);
+            });
+
+            assert_bit_vector(b<<2 == b*4);
+            assert(((b<<2) as int) == (b as int) *4);  // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -450,6 +450,8 @@ pub struct FunctionAttrsX {
     pub check_recommends: bool,
     /// set option smt.arith.nl=true
     pub nonlinear: bool,
+    /// Use a dedicated Z3 process for this single query
+    pub spinoff_z3: bool,
 }
 
 /// Function specification of its invariant mask

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -389,11 +389,22 @@ pub struct CommandsWithContextX {
     pub span: air::ast::Span,
     pub desc: String,
     pub commands: Commands,
+    pub spinoff_z3: bool,
 }
 
 impl CommandsWithContextX {
-    pub fn new(span: Span, desc: String, commands: Commands) -> CommandsWithContext {
-        Arc::new(CommandsWithContextX { span: span, desc: desc, commands: commands })
+    pub fn new(
+        span: Span,
+        desc: String,
+        commands: Commands,
+        spinoff_z3: bool,
+    ) -> CommandsWithContext {
+        Arc::new(CommandsWithContextX {
+            span: span,
+            desc: desc,
+            commands: commands,
+            spinoff_z3: spinoff_z3,
+        })
     }
 }
 

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -700,6 +700,7 @@ pub fn func_def_to_air(
                 function.x.attrs.bit_vector,
                 skip_ensures,
                 function.x.attrs.nonlinear,
+                function.x.attrs.spinoff_z3,
             );
 
             state.finalize();

--- a/source/vir/src/printer.rs
+++ b/source/vir/src/printer.rs
@@ -410,6 +410,7 @@ fn function_to_node(function: &FunctionX) -> Node {
             is_decrease_by,
             check_recommends,
             nonlinear,
+            spinoff_z3,
         } = &**attrs;
 
         let mut nodes = vec![
@@ -444,6 +445,9 @@ fn function_to_node(function: &FunctionX) -> Node {
         }
         if *nonlinear {
             nodes.push(str_to_node("+nonlinear"));
+        }
+        if *spinoff_z3 {
+            nodes.push(str_to_node("+spinoff_z3"));
         }
 
         Node::List(nodes)

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -373,6 +373,7 @@ pub(crate) fn check_termination_exp(
         false,
         false,
         false,
+        false,
     );
 
     assert_eq!(commands.len(), 1);

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1136,6 +1136,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
                             Arc::new(CommandX::CheckValid(query)),
                             mk_option_command("smt.arith.nl", "false"),
                         ]),
+                        true,
                     ));
                 }
             }
@@ -1165,6 +1166,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
                     Arc::new(CommandX::CheckValid(query)),
                     mk_option_command("smt.case_split", "3"),
                 ]),
+                true,
             ));
 
             vec![Arc::new(StmtX::Assume(exp_to_expr(ctx, &expr, expr_ctxt)))]
@@ -1323,6 +1325,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
                 span: stm.span.clone(),
                 desc: "while loop".to_string(),
                 commands: Arc::new(vec![Arc::new(CommandX::CheckValid(query))]),
+                spinoff_z3: false,
             }));
 
             // At original site of while loop, assert invariant, havoc, assume invariant + neg_cond
@@ -1495,6 +1498,7 @@ pub fn body_stm_to_air(
     is_bit_vector_mode: bool,
     skip_ensures: bool,
     is_nonlinear: bool,
+    is_spinoff_z3: bool,
 ) -> (Vec<CommandsWithContext>, Vec<(Span, SnapPos)>) {
     // Verifying a single function can generate multiple SMT queries.
     // Some declarations (local_shared) are shared among the queries.
@@ -1641,6 +1645,7 @@ pub fn body_stm_to_air(
         func_span.clone(),
         "function body check".to_string(),
         Arc::new(commands),
+        is_bit_vector_mode || is_nonlinear || is_spinoff_z3,
     ));
     (state.commands, state.snap_map)
 }

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1136,7 +1136,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
                             Arc::new(CommandX::CheckValid(query)),
                             mk_option_command("smt.arith.nl", "false"),
                         ]),
-                        true,
+                        false,
                     ));
                 }
             }
@@ -1166,7 +1166,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
                     Arc::new(CommandX::CheckValid(query)),
                     mk_option_command("smt.case_split", "3"),
                 ]),
-                true,
+                false,
             ));
 
             vec![Arc::new(StmtX::Assume(exp_to_expr(ctx, &expr, expr_ctxt)))]
@@ -1645,7 +1645,7 @@ pub fn body_stm_to_air(
         func_span.clone(),
         "function body check".to_string(),
         Arc::new(commands),
-        is_bit_vector_mode || is_nonlinear || is_spinoff_z3,
+        is_spinoff_z3,
     ));
     (state.commands, state.snap_map)
 }


### PR DESCRIPTION
When a function is annotated with `verifier(spinoff_z3)`, a dedicated Z3 process is spawned for that function's query only. 
Z3 is restarted at every module boundary by default, and this `spinoff_z3` attribute can be used for further separation.
The spun-off Z3 process imports prelude, as well as the current module's whole context. 

  
Not included in this pr:
We might consider Non-linear/bit-vector queries to be spinoff automatically. 
We might consider pruning out the current module's context for the dedicated new Z3.

- [x] Add more testcases