### PR TITLE
Disallow arithmetic triggers

### DIFF
--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -28,9 +28,9 @@ use rustc_span::def_id::DefId;
 use rustc_span::Span;
 use std::sync::Arc;
 use vir::ast::{
-    ArithOp, ArmX, AssertQueryMode, BinaryOp, CallTarget, Constant, ExprX, FieldOpr, FunX,
-    HeaderExpr, HeaderExprX, Ident, IntRange, InvAtomicity, Mode, PatternX, SpannedTyped, StmtX,
-    Stmts, Typ, TypX, UnaryOp, UnaryOpr, VarAt, VirErr,
+    ArithOp, ArmX, AssertQueryMode, BinaryOp, BitwiseOp, CallTarget, Constant, ExprX, FieldOpr,
+    FunX, HeaderExpr, HeaderExprX, Ident, IntRange, InvAtomicity, Mode, PatternX, SpannedTyped,
+    StmtX, Stmts, Typ, TypX, UnaryOp, UnaryOpr, VarAt, VirErr,
 };
 use vir::ast_util::{ident_binder, path_as_rust_name};
 use vir::def::positional_field_ident;
@@ -1535,8 +1535,8 @@ pub(crate) fn expr_to_vir_inner<'tcx>(
                 BinOpKind::BitXor => {
                     match ((tc.node_type(lhs.hir_id)).kind(), (tc.node_type(rhs.hir_id)).kind()) {
                         (TyKind::Bool, TyKind::Bool) => BinaryOp::Xor,
-                        (TyKind::Int(_), TyKind::Int(_)) => BinaryOp::BitXor,
-                        (TyKind::Uint(_), TyKind::Uint(_)) => BinaryOp::BitXor,
+                        (TyKind::Int(_), TyKind::Int(_)) => BinaryOp::Bitwise(BitwiseOp::BitXor),
+                        (TyKind::Uint(_), TyKind::Uint(_)) => BinaryOp::Bitwise(BitwiseOp::BitXor),
                         _ => panic!("bitwise XOR for this type not supported"),
                     }
                 }
@@ -1547,8 +1547,8 @@ pub(crate) fn expr_to_vir_inner<'tcx>(
                                 "bitwise AND for bools (i.e., the not-short-circuited version) not supported"
                             );
                         }
-                        (TyKind::Int(_), TyKind::Int(_)) => BinaryOp::BitAnd,
-                        (TyKind::Uint(_), TyKind::Uint(_)) => BinaryOp::BitAnd,
+                        (TyKind::Int(_), TyKind::Int(_)) => BinaryOp::Bitwise(BitwiseOp::BitAnd),
+                        (TyKind::Uint(_), TyKind::Uint(_)) => BinaryOp::Bitwise(BitwiseOp::BitAnd),
                         t => panic!("bitwise AND for this type not supported {:#?}", t),
                     }
                 }
@@ -1559,13 +1559,13 @@ pub(crate) fn expr_to_vir_inner<'tcx>(
                                 "bitwise OR for bools (i.e., the not-short-circuited version) not supported"
                             );
                         }
-                        (TyKind::Int(_), TyKind::Int(_)) => BinaryOp::BitOr,
-                        (TyKind::Uint(_), TyKind::Uint(_)) => BinaryOp::BitOr,
+                        (TyKind::Int(_), TyKind::Int(_)) => BinaryOp::Bitwise(BitwiseOp::BitOr),
+                        (TyKind::Uint(_), TyKind::Uint(_)) => BinaryOp::Bitwise(BitwiseOp::BitOr),
                         _ => panic!("bitwise OR for this type not supported"),
                     }
                 }
-                BinOpKind::Shr => BinaryOp::Shr,
-                BinOpKind::Shl => BinaryOp::Shl,
+                BinOpKind::Shr => BinaryOp::Bitwise(BitwiseOp::Shr),
+                BinOpKind::Shl => BinaryOp::Bitwise(BitwiseOp::Shl),
             };
             let e = mk_expr(ExprX::Binary(vop, vlhs, vrhs));
             match op.node {

--- a/source/rust_verify/tests/triggers.rs
+++ b/source/rust_verify/tests/triggers.rs
@@ -24,3 +24,13 @@ test_verify_one_file! {
 
     } => Err(err) => assert_one_fails(err)
 }
+
+test_verify_one_file! {
+    #[test] test_illegal_arith_trigger code! {
+        fndecl!(fn some_fn(a: nat) -> nat);
+        #[proof] fn quant() {
+            ensures(forall(|a: nat, b: nat| #[trigger] some_fn(a + b) == 10));
+            assume(false);
+        }
+    } => Err(err) => assert_vir_error(err)
+}

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -162,6 +162,16 @@ pub enum ArithOp {
     EuclideanMod,
 }
 
+/// Bitwise operation
+#[derive(Copy, Clone, Debug)]
+pub enum BitwiseOp {
+    BitXor,
+    BitAnd,
+    BitOr,
+    Shr,
+    Shl,
+}
+
 /// Primitive binary operations
 /// (not arbitrary user-defined functions -- these are represented by ExprX::Call)
 /// Note that all integer operations are on mathematic integers (IntRange::Int),
@@ -194,11 +204,7 @@ pub enum BinaryOp {
     /// IntRange operations that may require overflow or divide-by zero checks
     Arith(ArithOp, InferMode),
     /// Bit Vector Operators
-    BitXor,
-    BitAnd,
-    BitOr,
-    Shr,
-    Shl,
+    Bitwise(BitwiseOp),
 }
 
 /// Ghost annotations on functions and while loops; must appear at the beginning of function body

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -343,7 +343,7 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
                 And | Or | Xor | Implies | Le | Ge | Lt | Gt => true,
                 Arith(..) => true,
                 Eq(_) | Ne => false,
-                BitXor | BitAnd | BitOr | Shr | Shl => true,
+                Bitwise(..) => true,
             };
             if native {
                 let e1 = coerce_expr_to_native(ctx, &e1);

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -34,12 +34,7 @@ fn check_trigger_expr(exp: &Exp, free_vars: &mut HashSet<Ident>) -> Result<(), V
         | ExpX::UnaryOpr(UnaryOpr::Field { .. }, _)
         | ExpX::Unary(UnaryOp::Trigger(_), _) => {}
         // allow triggers for bitvector operators
-        ExpX::Binary(BinaryOp::BitAnd, _, _)
-        | ExpX::Binary(BinaryOp::BitOr, _, _)
-        | ExpX::Binary(BinaryOp::BitXor, _, _)
-        | ExpX::Binary(BinaryOp::Shr, _, _)
-        | ExpX::Binary(BinaryOp::Shl, _, _)
-        | ExpX::Unary(UnaryOp::BitNot, _) => {}
+        ExpX::Binary(BinaryOp::Bitwise(_), _, _) | ExpX::Unary(UnaryOp::BitNot, _) => {}
         // REVIEW: Z3 allows some arithmetic, but it's not clear we want to allow it
         _ => {
             return err_str(&exp.span, "trigger must be a function call or a field access");
@@ -95,7 +90,7 @@ fn check_trigger_expr(exp: &Exp, free_vars: &mut HashSet<Ident>) -> Result<(), V
                     }
                     Le | Ge | Lt | Gt => Ok(()),
                     Arith(..) => Ok(()),
-                    BitXor | BitAnd | BitOr | Shr | Shl => Ok(()),
+                    Bitwise(..) => Ok(()),
                 }
             }
             ExpX::If(_, _, _) => err_str(&exp.span, "triggers cannot contain if/else"),

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -35,7 +35,6 @@ fn check_trigger_expr(exp: &Exp, free_vars: &mut HashSet<Ident>) -> Result<(), V
         | ExpX::Unary(UnaryOp::Trigger(_), _) => {}
         // allow triggers for bitvector operators
         ExpX::Binary(BinaryOp::Bitwise(_), _, _) | ExpX::Unary(UnaryOp::BitNot, _) => {}
-        // REVIEW: Z3 allows some arithmetic, but it's not clear we want to allow it
         _ => {
             return err_str(&exp.span, "trigger must be a function call or a field access");
         }
@@ -89,7 +88,7 @@ fn check_trigger_expr(exp: &Exp, free_vars: &mut HashSet<Ident>) -> Result<(), V
                         err_str(&exp.span, "triggers cannot contain boolean operators")
                     }
                     Le | Ge | Lt | Gt => Ok(()),
-                    Arith(..) => Ok(()),
+                    Arith(..) => err_str(&exp.span, "triggers cannot contain integer arithmetic"),
                     Bitwise(..) => Ok(()),
                 }
             }

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -1,5 +1,6 @@
 use crate::ast::{
-    BinaryOp, Constant, FieldOpr, Fun, Ident, Path, Typ, TypX, UnaryOp, UnaryOpr, VarAt, VirErr,
+    BinaryOp, BitwiseOp, Constant, FieldOpr, Fun, Ident, Path, Typ, TypX, UnaryOp, UnaryOpr, VarAt,
+    VirErr,
 };
 use crate::ast_util::{err_str, path_as_rust_name};
 use crate::context::{ChosenTriggers, Ctx, FunctionCtx};
@@ -335,19 +336,18 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
             let depth = match op {
                 And | Or | Xor | Implies | Eq(_) => 0,
                 Ne | Le | Ge | Lt | Gt | Arith(..) => 1,
-                BitXor | BitAnd | BitOr | Shr | Shl => 1,
+                Bitwise(..) => 1,
             };
             let (_, term1) = gather_terms(ctxt, ctx, e1, depth);
             let (_, term2) = gather_terms(ctxt, ctx, e2, depth);
             match op {
-                BitXor | BitAnd | BitOr | Shr | Shl => {
-                    let bop = match op {
-                        BitXor => BitOpName::BitXor,
-                        BitAnd => BitOpName::BitAnd,
-                        Shr => BitOpName::Shr,
-                        Shl => BitOpName::Shl,
-                        BitOr => BitOpName::BitOr,
-                        _ => unreachable!(),
+                Bitwise(bp) => {
+                    let bop = match bp {
+                        BitwiseOp::BitXor => BitOpName::BitXor,
+                        BitwiseOp::BitAnd => BitOpName::BitAnd,
+                        BitwiseOp::Shr => BitOpName::Shr,
+                        BitwiseOp::Shl => BitOpName::Shl,
+                        BitwiseOp::BitOr => BitOpName::BitOr,
                     };
                     (true, Arc::new(TermX::App(App::BitOp(bop), Arc::new(vec![term1, term2]))))
                 }


### PR DESCRIPTION
Also group binary bitwise operators in an enum to simplify matches.