### PR TITLE
adjust the specifiction of Vec::pop

### DIFF
--- a/source/pervasive/vec.rs
+++ b/source/pervasive/vec.rs
@@ -37,7 +37,10 @@ impl<A> Vec<A> {
     #[verifier(external_body)]
     pub fn pop(&mut self) -> A {
         requires(old(self).len() > 0);
-        ensures(|value| equal(self.view().push(value), old(self).view()));
+        ensures(|value| [
+            equal(value, old(self).view().index(old(self).view().len() as int - 1)),
+            equal(self.view(), old(self).view().subrange(0, old(self).view().len() as int - 1))
+        ]);
         self.vec.pop().unwrap_unchecked()  // Safe to unwrap given the precondition above
     }
 

--- a/source/rust_verify/example/vectors.rs
+++ b/source/rust_verify/example/vectors.rs
@@ -77,6 +77,23 @@ fn pusher() -> Vec<u64> {
     v
 }
 
+#[spec]
+#[verifier(external_body)]
+fn uninterp_fn(x: u64) -> bool { unimplemented!() }
+
+fn pop_test(t: Vec<u64>) {
+    requires([
+        t.view().len() > 0,
+        forall(|i: int| 0 <= i && i < t.view().len() >>= uninterp_fn(t.view().index(i))),
+    ]);
+
+    let mut t = t;
+    let x = t.pop();
+
+    assert(uninterp_fn(x));
+    assert(forall(|i: int| 0 <= i && i < t.view().len() >>= uninterp_fn(t.view().index(i))));
+}
+
 #[verifier(external)]
 fn main() {
     let mut v = Vec{vec: vec![0, 10, 20, 30, 40, 50, 60, 70, 80, 90]};


### PR DESCRIPTION
change the `ensures` to compute the outputs in terms of the inputs, rather than vice versa. This has better trigger properties, e.g., both these asserts now go through automatically, where they didn't before:

```rust
fn pop_test(t: Vec<u64>) {
    requires([
        t.view().len() > 0,
        forall(|i: int| 0 <= i && i < t.view().len() >>= uninterp_fn(t.view().index(i))),
    ]);

    let mut t = t;
    let x = t.pop();

    assert(uninterp_fn(x));
    assert(forall(|i: int| 0 <= i && i < t.view().len() >>= uninterp_fn(t.view().index(i))));
}
```