### PR TITLE
Minor update on `spinoff_z3`

### DIFF
--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -147,7 +147,7 @@ pub(crate) enum Attr {
     // set smt.arith.nl=true
     NonLinear,
     // Use a new dedicated Z3 process just for this query
-    SpinoffZ3,
+    SpinoffProver,
 }
 
 fn get_trigger_arg(span: Span, attr_tree: &AttrTree) -> Result<u64, VirErr> {
@@ -284,8 +284,8 @@ pub(crate) fn parse_attrs(attrs: &[Attribute]) -> Result<Vec<Attr>, VirErr> {
                 Some(box [AttrTree::Fun(_, arg, None)]) if arg == "nonlinear" => {
                     v.push(Attr::NonLinear)
                 }
-                Some(box [AttrTree::Fun(_, arg, None)]) if arg == "spinoff_z3" => {
-                    v.push(Attr::SpinoffZ3)
+                Some(box [AttrTree::Fun(_, arg, None)]) if arg == "spinoff_prover" => {
+                    v.push(Attr::SpinoffProver)
                 }
                 _ => return err_span_str(*span, "unrecognized verifier attribute"),
             },
@@ -377,7 +377,7 @@ pub(crate) struct VerifierAttrs {
     pub(crate) decreases_by: bool,
     pub(crate) check_recommends: bool,
     pub(crate) nonlinear: bool,
-    pub(crate) spinoff_z3: bool,
+    pub(crate) spinoff_prover: bool,
 }
 
 pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, VirErr> {
@@ -401,7 +401,7 @@ pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, V
         decreases_by: false,
         check_recommends: false,
         nonlinear: false,
-        spinoff_z3: false,
+        spinoff_prover: false,
     };
     for attr in parse_attrs(attrs)? {
         match attr {
@@ -426,7 +426,7 @@ pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, V
             Attr::DecreasesBy => vs.decreases_by = true,
             Attr::CheckRecommends => vs.check_recommends = true,
             Attr::NonLinear => vs.nonlinear = true,
-            Attr::SpinoffZ3 => vs.spinoff_z3 = true,
+            Attr::SpinoffProver => vs.spinoff_prover = true,
             _ => {}
         }
     }

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -249,7 +249,7 @@ pub(crate) fn check_item_fn<'tcx>(
         is_decrease_by: vattrs.decreases_by,
         check_recommends: vattrs.check_recommends,
         nonlinear: vattrs.nonlinear,
-        spinoff_z3: vattrs.spinoff_z3,
+        spinoff_prover: vattrs.spinoff_prover,
     };
 
     let mut recommend: Vec<vir::ast::Expr> = (*header.recommend).clone();

--- a/source/rust_verify/tests/z3_restart.rs
+++ b/source/rust_verify/tests/z3_restart.rs
@@ -6,7 +6,7 @@ use common::*;
 test_verify_one_file! {
     #[test] test_with_bitvec_nlarith code! {
         #[proof]
-        #[verifier(spinoff_z3)]
+        #[verifier(spinoff_prover)]
         fn test6(x: u32, y: u32, z:u32) {
             requires(x < 0xfff);
 
@@ -35,7 +35,7 @@ test_verify_one_file! {
         }
 
         #[proof]
-        #[verifier(spinoff_z3)]
+        #[verifier(spinoff_prover)]
         fn one(v: int) {
             let t1 = Thing { a: v };
             let t2 = Thing { a: v };
@@ -52,7 +52,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_with_nlarith code! {
         #[verifier(nonlinear)]
-        #[verifier(spinoff_z3)]
+        #[verifier(spinoff_prover)]
         #[proof]
         fn lemma_div_pos_is_pos(x: int, d: int) {
             requires([
@@ -68,7 +68,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_with_bv code! {
         #[verifier(bit_vector)]
-        #[verifier(spinoff_z3)]
+        #[verifier(spinoff_prover)]
         #[proof]
         fn bit_or32_auto(){
             ensures([
@@ -85,7 +85,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test1_fails code! {
         #[proof]
-        #[verifier(spinoff_z3)]
+        #[verifier(spinoff_prover)]
         fn test6(b: u32, b2: u32) {
             assert_nonlinear_by({
                 ensures(b*b2 == b2*b);
@@ -101,7 +101,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test2_fails code! {
         #[verifier(nonlinear)]
-        #[verifier(spinoff_z3)]
+        #[verifier(spinoff_prover)]
         #[proof]
         fn wrong_lemma_2(x: int, y: int, z: int) {
             requires([
@@ -118,14 +118,14 @@ test_verify_one_file! {
     #[test] multiset_basics code! {
         use crate::pervasive::multiset::*;
 
-        #[proof] #[verifier(spinoff_z3)]
+        #[proof] #[verifier(spinoff_prover)]
         pub fn commutative<V>(a: Multiset<V>, b: Multiset<V>) {
             ensures(equal(a.add(b), b.add(a)));
 
             assert(a.add(b).ext_equal(b.add(a)));
         }
 
-        #[proof] #[verifier(spinoff_z3)]
+        #[proof] #[verifier(spinoff_prover)]
         pub fn associative<V>(a: Multiset<V>, b: Multiset<V>, c: Multiset<V>) {
             ensures(equal(
                 a.add(b.add(c)),
@@ -135,7 +135,7 @@ test_verify_one_file! {
                 a.add(b).add(c)));
         }
 
-        #[proof] #[verifier(spinoff_z3)]
+        #[proof] #[verifier(spinoff_prover)]
         pub fn insert2<V>(a: V, b: V) {
             ensures(equal(
                 Multiset::empty().insert(a).insert(b),
@@ -146,7 +146,7 @@ test_verify_one_file! {
                 Multiset::empty().insert(b).insert(a)));
         }
 
-        #[proof] #[verifier(spinoff_z3)]
+        #[proof] #[verifier(spinoff_prover)]
         pub fn insert2_count<V>(a: V, b: V, c: V) {
             requires(!equal(a, b) && !equal(b, c) && !equal(c, a));
 
@@ -155,14 +155,14 @@ test_verify_one_file! {
             assert(Multiset::empty().insert(a).insert(b).count(c) == 0);
         }
 
-        #[proof] #[verifier(spinoff_z3)]
+        #[proof] #[verifier(spinoff_prover)]
         pub fn add_sub_cancel<V>(a: Multiset<V>, b: Multiset<V>) {
             ensures(equal(a.add(b).sub(b), a));
 
             assert(a.add(b).sub(b).ext_equal(a));
         }
 
-        #[proof] #[verifier(spinoff_z3)]
+        #[proof] #[verifier(spinoff_prover)]
         pub fn sub_add_cancel<V>(a: Multiset<V>, b: Multiset<V>) {
             requires(b.le(a));
             ensures(equal(a.sub(b).add(b), a));

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -463,7 +463,7 @@ pub struct FunctionAttrsX {
     /// set option smt.arith.nl=true
     pub nonlinear: bool,
     /// Use a dedicated Z3 process for this single query
-    pub spinoff_z3: bool,
+    pub spinoff_prover: bool,
 }
 
 /// Function specification of its invariant mask

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -389,7 +389,7 @@ pub struct CommandsWithContextX {
     pub span: air::ast::Span,
     pub desc: String,
     pub commands: Commands,
-    pub spinoff_z3: bool,
+    pub spinoff_prover: bool,
 }
 
 impl CommandsWithContextX {
@@ -397,13 +397,13 @@ impl CommandsWithContextX {
         span: Span,
         desc: String,
         commands: Commands,
-        spinoff_z3: bool,
+        spinoff_prover: bool,
     ) -> CommandsWithContext {
         Arc::new(CommandsWithContextX {
             span: span,
             desc: desc,
             commands: commands,
-            spinoff_z3: spinoff_z3,
+            spinoff_prover: spinoff_prover,
         })
     }
 }

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -701,7 +701,7 @@ pub fn func_def_to_air(
                 function.x.attrs.bit_vector,
                 skip_ensures,
                 function.x.attrs.nonlinear,
-                function.x.attrs.spinoff_z3,
+                function.x.attrs.spinoff_prover,
             );
 
             state.finalize();

--- a/source/vir/src/printer.rs
+++ b/source/vir/src/printer.rs
@@ -413,7 +413,7 @@ fn function_to_node(function: &FunctionX) -> Node {
             is_decrease_by,
             check_recommends,
             nonlinear,
-            spinoff_z3,
+            spinoff_prover,
         } = &**attrs;
 
         let mut nodes = vec![
@@ -449,8 +449,8 @@ fn function_to_node(function: &FunctionX) -> Node {
         if *nonlinear {
             nodes.push(str_to_node("+nonlinear"));
         }
-        if *spinoff_z3 {
-            nodes.push(str_to_node("+spinoff_z3"));
+        if *spinoff_prover {
+            nodes.push(str_to_node("+spinoff_prover"));
         }
 
         Node::List(nodes)

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1317,7 +1317,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
                 span: stm.span.clone(),
                 desc: "while loop".to_string(),
                 commands: Arc::new(vec![Arc::new(CommandX::CheckValid(query))]),
-                spinoff_z3: false,
+                spinoff_prover: false,
             }));
 
             // At original site of while loop, assert invariant, havoc, assume invariant + neg_cond
@@ -1490,7 +1490,7 @@ pub fn body_stm_to_air(
     is_bit_vector_mode: bool,
     skip_ensures: bool,
     is_nonlinear: bool,
-    is_spinoff_z3: bool,
+    is_spinoff_prover: bool,
 ) -> (Vec<CommandsWithContext>, Vec<(Span, SnapPos)>) {
     // Verifying a single function can generate multiple SMT queries.
     // Some declarations (local_shared) are shared among the queries.
@@ -1637,7 +1637,7 @@ pub fn body_stm_to_air(
         func_span.clone(),
         "function body check".to_string(),
         Arc::new(commands),
-        is_spinoff_z3,
+        is_spinoff_prover,
     ));
     (state.commands, state.snap_map)
 }


### PR DESCRIPTION
This pr is a small update for `spinoff_z3` attribute. (As a follow up of  #144)
It removes some code redundancy, and renames `spinoff_z3` into `spinoiff_prover` 