### PR TITLE
adjust trigger for `axiom_seq_push_index_same`

### DIFF
--- a/source/pervasive/seq.rs
+++ b/source/pervasive/seq.rs
@@ -93,8 +93,9 @@ pub fn axiom_seq_push_len<A>(s: Seq<A>, a: A) {
 #[proof]
 #[verifier(external_body)]
 #[verifier(broadcast_forall)]
-pub fn axiom_seq_push_index_same<A>(s: Seq<A>, a: A) {
-    ensures(equal(#[trigger] s.push(a).index(s.len()), a));
+pub fn axiom_seq_push_index_same<A>(s: Seq<A>, a: A, i: int) {
+    requires(i == s.len());
+    ensures(equal(#[trigger] s.push(a).index(i), a));
 }
 
 #[proof]

--- a/source/rust_verify/example/vectors.rs
+++ b/source/rust_verify/example/vectors.rs
@@ -94,6 +94,20 @@ fn pop_test(t: Vec<u64>) {
     assert(forall(|i: int| 0 <= i && i < t.view().len() >>= uninterp_fn(t.view().index(i))));
 }
 
+fn pust_test(t: Vec<u64>, y: u64) {
+    requires([
+        forall(|i: int| 0 <= i && i < t.view().len() >>= uninterp_fn(t.view().index(i))),
+        uninterp_fn(y),
+    ]);
+
+    let mut t = t;
+    t.push(y);
+
+    assert(
+        forall(|i: int| 0 <= i && i < t.view().len() >>= uninterp_fn(t.view().index(i))),
+    );
+}
+
 #[verifier(external)]
 fn main() {
     let mut v = Vec{vec: vec![0, 10, 20, 30, 40, 50, 60, 70, 80, 90]};


### PR DESCRIPTION
`s.push(a).index(s.len())` as a trigger seems a little too specific, specifically, this fails:

```rust
fn pust_test(t: Vec<u64>, y: u64) {
    requires([
        forall(|i: int| 0 <= i && i < t.view().len() >>= uninterp_fn(t.view().index(i))),
        uninterp_fn(y),
    ]);

    let mut t = t;
    t.push(y);

    assert(
        forall(|i: int| 0 <= i && i < t.view().len() >>= uninterp_fn(t.view().index(i))),
    );
}
```