### PR TITLE
have verus ignore an impl block entirely if marked with external_body

### DIFF
--- a/source/pervasive/cell.rs
+++ b/source/pervasive/cell.rs
@@ -20,10 +20,10 @@ pub struct PCell<#[verifier(strictly_positive)] V> {
 // PCell is always safe to Send/Sync. It's the Permission object where Send/Sync matters.
 // (It doesn't matter if you move the bytes to another thread if you can't access them.)
 
-#[verifier(external_body)]
+#[verifier(external)]
 unsafe impl<T> Sync for PCell<T> {}
 
-#[verifier(external_body)]
+#[verifier(external)]
 unsafe impl<T> Send for PCell<T> {}
 
 // Permission<V>, on the other hand, needs to inherit both Send and Sync from the V,

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -90,12 +90,14 @@ fn check_item<'tcx>(
             )?;
         }
         ItemKind::Impl(impll) => {
+            let attrs = ctxt.tcx.hir().attrs(item.hir_id());
+            let vattrs = get_verifier_attrs(attrs)?;
+
+            if vattrs.external {
+                return Ok(());
+            }
             if impll.unsafety != Unsafety::Normal {
-                let attrs = ctxt.tcx.hir().attrs(item.hir_id());
-                let vattrs = get_verifier_attrs(attrs)?;
-                if !vattrs.external_body {
-                    return err_span_str(item.span, "the verifier does not support `unsafe` here");
-                }
+                return err_span_str(item.span, "the verifier does not support `unsafe` here");
             }
 
             if let Some(TraitRef { path, hir_ref_id: _ }) = impll.of_trait {


### PR DESCRIPTION
to help with #169