### PR TITLE
allow new syntax inside state machine macro

### DIFF
--- a/source/rust_verify/example/state_machines/flat_combine.rs
+++ b/source/rust_verify/example/state_machines/flat_combine.rs
@@ -363,7 +363,7 @@ tokenized_state_machine!{
                 let response_opt = pre.combiner.get_Responding_elems().index(j);
 
                 // The response we return has to have the right request ID
-                require(equal(response_opt, Option::Some(response.rid)));
+                require(response_opt === Option::Some(response.rid));
 
                 // Set the slot back to false
                 remove slots -= [j => cur_slot];

--- a/source/rust_verify/tests/state_machines.rs
+++ b/source/rust_verify/tests/state_machines.rs
@@ -918,6 +918,52 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] wrong_mode_inv IMPORTS.to_string() + code_str! {
+        tokenized_state_machine!{ X {
+            fields {
+                #[sharding(variable)] pub t: int,
+            }
+
+            init!{
+                tr(x: int) {
+                    init t = x;
+                }
+            }
+
+            #[invariant]
+            pub proof fn the_inv(self) -> bool {
+                true
+            }
+        }}
+    } => Err(e) => assert_error_msg(e, "an invariant function should be `spec`")
+}
+
+test_verify_one_file! {
+    #[test] wrong_mode_inductive IMPORTS.to_string() + code_str! {
+        tokenized_state_machine!{ X {
+            fields {
+                #[sharding(variable)] pub t: int,
+            }
+
+            init!{
+                tr(x: int) {
+                    init t = x;
+                }
+            }
+
+            #[invariant]
+            pub fn the_inv(self) -> bool {
+                true
+            }
+
+            #[inductive(tr)]
+            pub spec fn lemma_tr1(post: Self, x: int) {
+            }
+        }}
+    } => Err(e) => assert_error_msg(e, "an inductiveness lemma should be `proof`")
+}
+
+test_verify_one_file! {
     #[test] explicit_mode_field IMPORTS.to_string() + code_str! {
         tokenized_state_machine!{ X {
             fields {
@@ -948,7 +994,7 @@ test_verify_one_file! {
             #[inductive(tr)]
             #[proof]
             pub fn lemma_tr1(post: Self, x: int) {
-            } // FAILS
+            }
         }}
     } => Err(e) => assert_error_msg(e, "should not be explicitly labelled")
 }
@@ -2678,8 +2724,8 @@ test_verify_one_file! {
 
             #[inductive(initialize)]
             fn inductive_init(post: Self) {
-                #[proof] let (inst, token) = X::Instance::initialize();
-                inst.ro(&token);
+                #[proof] let tracked (inst, token) = X::Instance::initialize();
+                tracked inst.ro(&token);
                 // this should derive a contradiction if not for the recursion checking
             }
         }}

--- a/source/state_machines_macros/Cargo.toml
+++ b/source/state_machines_macros/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-syn = { version = "1.0", features = ["full", "visit-mut"] }
+syn_verus = { git = "https://github.com/secure-foundations/syn", rev = "2af2bf9", features = ["full", "visit", "visit-mut"] }
 quote = "1.0"
 proc-macro2 = "1.0"
 

--- a/source/state_machines_macros/src/ast.rs
+++ b/source/state_machines_macros/src/ast.rs
@@ -1,7 +1,7 @@
 use proc_macro2::Span;
 use std::rc::Rc;
-use syn::token;
-use syn::{Block, Expr, FieldsNamed, Generics, Ident, ImplItemMethod, Pat, Type};
+use syn_verus::token;
+use syn_verus::{Block, Expr, FieldsNamed, Generics, Ident, ImplItemMethod, Pat, Type};
 
 #[derive(Clone, Debug)]
 pub struct SM {

--- a/source/state_machines_macros/src/case_macro.rs
+++ b/source/state_machines_macros/src/case_macro.rs
@@ -1,11 +1,11 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::parse;
-use syn::parse::{Parse, ParseStream};
-use syn::parse_macro_input;
-use syn::punctuated::Punctuated;
-use syn::token;
-use syn::{braced, parenthesized, Expr, ExprBlock, Ident, Path, Token};
+use syn_verus::parse;
+use syn_verus::parse::{Parse, ParseStream};
+use syn_verus::parse_macro_input;
+use syn_verus::punctuated::Punctuated;
+use syn_verus::token;
+use syn_verus::{braced, parenthesized, Expr, ExprBlock, Ident, Path, Token};
 
 pub fn case_on(input: proc_macro::TokenStream, is_init: bool) -> proc_macro::TokenStream {
     let (pre_post, name, arms) = if is_init {

--- a/source/state_machines_macros/src/check_bind_stmts.rs
+++ b/source/state_machines_macros/src/check_bind_stmts.rs
@@ -1,5 +1,5 @@
 use crate::ast::{MonoidElt, MonoidStmtType, SplitKind, TransitionStmt, SM};
-use syn::parse::Error;
+use syn_verus::parse::Error;
 
 pub fn check_bind_stmts(sm: &SM, ts: &mut TransitionStmt, errors: &mut Vec<Error>) {
     match ts {

--- a/source/state_machines_macros/src/check_birds_eye.rs
+++ b/source/state_machines_macros/src/check_birds_eye.rs
@@ -1,5 +1,5 @@
 use crate::ast::{LetKind, SpecialOp, SplitKind, Transition, TransitionKind, TransitionStmt};
-use syn::parse::Error;
+use syn_verus::parse::Error;
 
 // Here we check the following rules related to `birds_eye` let-bindings:
 //

--- a/source/state_machines_macros/src/concurrency_tokens.rs
+++ b/source/state_machines_macros/src/concurrency_tokens.rs
@@ -23,10 +23,10 @@ use proc_macro2::TokenStream;
 use quote::{quote, quote_spanned};
 use std::collections::HashMap;
 use std::collections::HashSet;
-use syn::parse;
-use syn::parse::Error;
-use syn::spanned::Spanned;
-use syn::{Expr, Ident, Pat, Type};
+use syn_verus::parse;
+use syn_verus::parse::Error;
+use syn_verus::spanned::Spanned;
+use syn_verus::{Expr, Ident, Pat, Type};
 
 // Misc. definitions for various identifiers we use
 // Note that everything is going to be inside a module, so for example,

--- a/source/state_machines_macros/src/field_access_visitor.rs
+++ b/source/state_machines_macros/src/field_access_visitor.rs
@@ -36,12 +36,12 @@ use crate::ast::{
 };
 use proc_macro2::Span;
 use std::collections::{HashMap, HashSet};
-use syn::parse;
-use syn::parse::Error;
-use syn::spanned::Spanned;
-use syn::visit_mut;
-use syn::visit_mut::VisitMut;
-use syn::{Expr, ExprField, ExprPath, Ident, Member};
+use syn_verus::parse;
+use syn_verus::parse::Error;
+use syn_verus::spanned::Spanned;
+use syn_verus::visit_mut;
+use syn_verus::visit_mut::VisitMut;
+use syn_verus::{Expr, ExprField, ExprPath, Ident, Member};
 
 /// Given a (Rust AST) Expr `e`, visits the subexpressions of the form
 /// `pre.foo` where `foo` is a state machine field, and calls the given

--- a/source/state_machines_macros/src/ident_visitor.rs
+++ b/source/state_machines_macros/src/ident_visitor.rs
@@ -3,10 +3,10 @@ use crate::ast::{
 };
 use crate::simplification::UPDATE_TMP_PREFIX;
 use crate::util::combine_errors_or_ok;
-use syn::parse;
-use syn::spanned::Spanned;
-use syn::visit::Visit;
-use syn::{Error, Expr, ExprMacro, Ident, Macro, Pat, PatIdent, Path, Type};
+use syn_verus::parse;
+use syn_verus::spanned::Spanned;
+use syn_verus::visit::Visit;
+use syn_verus::{Error, Expr, ExprMacro, Ident, Macro, Pat, PatIdent, Path, Type};
 
 /// Error if any identifiers conflict with reserved IDs used by macro expanion.
 ///

--- a/source/state_machines_macros/src/inherent_safety_conditions.rs
+++ b/source/state_machines_macros/src/inherent_safety_conditions.rs
@@ -1,7 +1,7 @@
 use crate::ast::{MonoidStmtType, ShardableType, SpecialOp, SplitKind, TransitionStmt, SM};
 use proc_macro2::Span;
-use syn::parse;
-use syn::parse::Error;
+use syn_verus::parse;
+use syn_verus::parse::Error;
 
 /// Many of the "special ops" have inherent safety conditions.
 /// (That is, they contain an 'assert' when expanded out.)

--- a/source/state_machines_macros/src/lemmas.rs
+++ b/source/state_machines_macros/src/lemmas.rs
@@ -3,11 +3,11 @@ use crate::parse_token_stream::SMBundle;
 use proc_macro2::Span;
 use quote::{quote, ToTokens};
 use std::collections::{HashMap, HashSet};
-use syn::parse;
-use syn::punctuated::Punctuated;
-use syn::spanned::Spanned;
-use syn::token;
-use syn::{
+use syn_verus::parse;
+use syn_verus::punctuated::Punctuated;
+use syn_verus::spanned::Spanned;
+use syn_verus::token;
+use syn_verus::{
     Error, Expr, ExprCall, ExprPath, FnArg, Ident, Pat, PatIdent, PatType, ReturnType, Stmt, Type,
 };
 

--- a/source/state_machines_macros/src/lib.rs
+++ b/source/state_machines_macros/src/lib.rs
@@ -27,7 +27,7 @@ use case_macro::case_on;
 use lemmas::check_lemmas;
 use parse_token_stream::{parse_result_to_smir, ParseResult};
 use proc_macro::TokenStream;
-use syn::parse_macro_input;
+use syn_verus::parse_macro_input;
 use to_token_stream::output_token_stream;
 
 fn construct_state_machine(input: TokenStream, concurrent: bool) -> TokenStream {

--- a/source/state_machines_macros/src/parse_token_stream.rs
+++ b/source/state_machines_macros/src/parse_token_stream.rs
@@ -9,12 +9,12 @@ use crate::self_type_visitor::replace_self_sm;
 use crate::to_token_stream::shardable_type_to_type;
 use crate::transitions::check_transitions;
 use proc_macro2::Span;
-use syn::buffer::Cursor;
-use syn::parse;
-use syn::parse::{Parse, ParseStream};
-use syn::spanned::Spanned;
-use syn::Token;
-use syn::{
+use syn_verus::buffer::Cursor;
+use syn_verus::parse;
+use syn_verus::parse::{Parse, ParseStream};
+use syn_verus::spanned::Spanned;
+use syn_verus::Token;
+use syn_verus::{
     braced, AttrStyle, Attribute, Error, FieldsNamed, FnArg, GenericArgument, GenericParam,
     Generics, Ident, ImplItem, ImplItemMethod, Meta, MetaList, NestedMeta, PathArguments, Receiver,
     ReturnType, Type, TypePath, Visibility, WhereClause,

--- a/source/state_machines_macros/src/parse_transition.rs
+++ b/source/state_machines_macros/src/parse_transition.rs
@@ -8,14 +8,14 @@ use crate::util::{expr_from_tokens, pat_from_tokens};
 use proc_macro2::Span;
 use quote::{quote, quote_spanned};
 use std::rc::Rc;
-use syn::parse;
-use syn::parse::{Parse, ParseStream};
-use syn::parse2;
-use syn::punctuated::Punctuated;
-use syn::spanned::Spanned;
-use syn::token;
-use syn::visit::Visit;
-use syn::{
+use syn_verus::parse;
+use syn_verus::parse::{Parse, ParseStream};
+use syn_verus::parse2;
+use syn_verus::punctuated::Punctuated;
+use syn_verus::spanned::Spanned;
+use syn_verus::token;
+use syn_verus::visit::Visit;
+use syn_verus::{
     braced, bracketed, parenthesized, Block, Error, Expr, ExprBlock, ExprLet, Ident, Macro, Pat,
     PatIdent, PatOr, Token, Type,
 };

--- a/source/state_machines_macros/src/safety_conditions.rs
+++ b/source/state_machines_macros/src/safety_conditions.rs
@@ -118,10 +118,10 @@ pub fn safety_condition_body_simpl(sop: &SimplStmt, let_skip_brace: bool) -> Opt
         SimplStmt::Assert(span, e, AssertProof { proof: Some(proof), error_msg }) => {
             let assert_fn = Ident::new(error_msg, *span);
             Some(Expr::Verbatim(quote_spanned! {*span =>
-                ::builtin::assert_by(#e, {
+                assert(#e) by {
                     #proof
                     crate::pervasive::state_machine_internal::#assert_fn(#e);
-                });
+                };
             }))
         }
         SimplStmt::Assign(..) => {

--- a/source/state_machines_macros/src/safety_conditions.rs
+++ b/source/state_machines_macros/src/safety_conditions.rs
@@ -1,7 +1,7 @@
 use crate::ast::{AssertProof, SimplStmt, SplitKind};
 use crate::to_relation::emit_match;
 use quote::{quote, quote_spanned};
-use syn::{Expr, Ident};
+use syn_verus::{Expr, Ident};
 
 // Given a transition, we convert it into a lemma that will create the correct
 // verification conditions for its 'assert' statement.

--- a/source/state_machines_macros/src/self_type_visitor.rs
+++ b/source/state_machines_macros/src/self_type_visitor.rs
@@ -2,11 +2,11 @@ use crate::ast::{
     MonoidElt, ShardableType, SpecialOp, SplitKind, SubIdx, Transition, TransitionStmt, SM,
 };
 use crate::to_token_stream::get_self_ty_turbofish_path;
-use syn::punctuated::Punctuated;
-use syn::token;
-use syn::visit_mut;
-use syn::visit_mut::VisitMut;
-use syn::{Expr, Ident, Pat, Path, PathSegment, Type};
+use syn_verus::punctuated::Punctuated;
+use syn_verus::token;
+use syn_verus::visit_mut;
+use syn_verus::visit_mut::VisitMut;
+use syn_verus::{Expr, Ident, Pat, Path, PathSegment, Type};
 
 /// If the user ever uses 'Self' in a transition, then change it out for the explicit
 /// self type so that it's safe to use these expressions and types in other places

--- a/source/state_machines_macros/src/simplification.rs
+++ b/source/state_machines_macros/src/simplification.rs
@@ -9,8 +9,8 @@ use crate::transitions::get_field;
 use crate::util::is_definitely_irrefutable;
 use proc_macro2::Span;
 use quote::{quote, quote_spanned};
-use syn::spanned::Spanned;
-use syn::{Expr, Ident, Pat, Type};
+use syn_verus::spanned::Spanned;
+use syn_verus::{Expr, Ident, Pat, Type};
 
 /// Simplify out `update` statements, including `add_element` etc.
 ///

--- a/source/state_machines_macros/src/simplify_assigns.rs
+++ b/source/state_machines_macros/src/simplify_assigns.rs
@@ -2,9 +2,9 @@ use crate::ast::{SimplStmt, SM};
 use proc_macro2::{TokenStream, TokenTree};
 use quote::quote;
 use std::collections::HashSet;
-use syn::visit;
-use syn::visit::Visit;
-use syn::{Expr, Ident, Pat};
+use syn_verus::visit;
+use syn_verus::visit::Visit;
+use syn_verus::{Expr, Ident, Pat};
 
 /// Returns an equivalent SimplStmt sequence that has no 'assign' statements in it.
 

--- a/source/state_machines_macros/src/to_relation.rs
+++ b/source/state_machines_macros/src/to_relation.rs
@@ -2,8 +2,8 @@ use crate::ast::{Arm, SimplStmt, SplitKind, TransitionStmt};
 use proc_macro2::Span;
 use proc_macro2::TokenStream;
 use quote::{quote, quote_spanned};
-use syn::spanned::Spanned;
-use syn::Expr;
+use syn_verus::spanned::Spanned;
+use syn_verus::Expr;
 
 /// Converts a transition description into a relation between `pre` and `post`.
 /// Overall, this process has two steps:

--- a/source/state_machines_macros/src/to_token_stream.rs
+++ b/source/state_machines_macros/src/to_token_stream.rs
@@ -24,9 +24,9 @@ use syn_verus::punctuated::Punctuated;
 use syn_verus::spanned::Spanned;
 use syn_verus::token;
 use syn_verus::{
-    AngleBracketedGenericArguments, Attribute, Block, Expr, ExprBlock, FnArg, GenericArgument,
-    GenericParam, Generics, Ident, ImplItemMethod, Meta, MetaList, Pat, Path, PathArguments,
-    PathSegment, Stmt, Type, TypePath,
+    AngleBracketedGenericArguments, Attribute, Block, Expr, ExprBlock, FnArg, FnArgKind, FnMode,
+    GenericArgument, GenericParam, Generics, Ident, ImplItemMethod, Meta, MetaList, ModeProof, Pat,
+    Path, PathArguments, PathSegment, Signature, Stmt, Type, TypePath,
 };
 
 pub fn output_token_stream(bundle: SMBundle, concurrent: bool) -> parse::Result<TokenStream> {
@@ -55,14 +55,16 @@ pub fn output_token_stream(bundle: SMBundle, concurrent: bool) -> parse::Result<
     let sm_name = &bundle.sm.name;
 
     let final_code = quote! {
-        #[allow(unused_parens)]
-        mod #sm_name {
-            use super::*;
+        ::builtin_macros::verus!{
+            #[allow(unused_parens)]
+            mod #sm_name {
+                use super::*;
 
-            #root_stream
+                #root_stream
 
-            #impl_decl {
-                #impl_stream
+                #impl_decl {
+                    #impl_stream
+                }
             }
         }
     };
@@ -211,6 +213,17 @@ pub fn fix_attrs(attrs: &mut Vec<Attribute>) {
     }
 }
 
+pub fn set_mode_proof(sig: &mut Signature, span: Span) {
+    match &sig.mode {
+        FnMode::Proof(_mode_proof) => {
+            return;
+        }
+        _ => {}
+    }
+
+    sig.mode = FnMode::Proof(ModeProof { proof_token: token::Proof { span } });
+}
+
 pub fn output_primary_stuff(
     root_stream: &mut TokenStream,
     impl_stream: &mut TokenStream,
@@ -316,8 +329,7 @@ pub fn output_primary_stuff(
                 None => TokenStream::new(),
             };
             impl_stream.extend(quote! {
-                #[proof]
-                pub fn #name(#params) {
+                pub proof fn #name(#params) {
                     crate::pervasive::assume(pre.invariant());
                     #b
                 }
@@ -686,9 +698,10 @@ fn output_other_fns(
     }
 
     for lemma in lemmas {
-        impl_stream.extend(quote! { #[proof] });
         let mut f = lemma.func.clone();
         lemma_update_body(bundle, lemma, &mut f);
+        let span = f.sig.span(); // TODO better span choice
+        set_mode_proof(&mut f.sig, span);
         fix_attrs(&mut f.attrs);
         f.to_tokens(impl_stream);
     }
@@ -698,9 +711,9 @@ fn output_other_fns(
 }
 
 fn left_of_colon<'a>(fn_arg: &'a FnArg) -> &'a Pat {
-    match fn_arg {
-        FnArg::Receiver(_) => panic!("should have been ruled out by lemma well-formedness"),
-        FnArg::Typed(pat_type) => &pat_type.pat,
+    match &fn_arg.kind {
+        FnArgKind::Receiver(_) => panic!("should have been ruled out by lemma well-formedness"),
+        FnArgKind::Typed(pat_type) => &pat_type.pat,
     }
 }
 

--- a/source/state_machines_macros/src/to_token_stream.rs
+++ b/source/state_machines_macros/src/to_token_stream.rs
@@ -19,11 +19,11 @@ use proc_macro2::TokenStream;
 use quote::{quote, quote_spanned, ToTokens};
 use std::collections::HashMap;
 use std::mem::swap;
-use syn::parse;
-use syn::punctuated::Punctuated;
-use syn::spanned::Spanned;
-use syn::token;
-use syn::{
+use syn_verus::parse;
+use syn_verus::punctuated::Punctuated;
+use syn_verus::spanned::Spanned;
+use syn_verus::token;
+use syn_verus::{
     AngleBracketedGenericArguments, Attribute, Block, Expr, ExprBlock, FnArg, GenericArgument,
     GenericParam, Generics, Ident, ImplItemMethod, Meta, MetaList, Pat, Path, PathArguments,
     PathSegment, Stmt, Type, TypePath,

--- a/source/state_machines_macros/src/token_transition_checks.rs
+++ b/source/state_machines_macros/src/token_transition_checks.rs
@@ -2,8 +2,8 @@
 //! concurrency_tokens.rs
 
 use crate::ast::{SplitKind, TransitionStmt, SM};
-use syn::parse;
-use syn::parse::Error;
+use syn_verus::parse;
+use syn_verus::parse::Error;
 
 /// Check if any SpecialOp is inside a conditional, which is currently unsupported.
 /// e.g., this is disallowed:

--- a/source/state_machines_macros/src/transitions.rs
+++ b/source/state_machines_macros/src/transitions.rs
@@ -8,9 +8,9 @@ use crate::ident_visitor::validate_idents_transition;
 use crate::inherent_safety_conditions::check_inherent_conditions;
 use crate::util::{combine_errors_or_ok, combine_results};
 use proc_macro2::Span;
-use syn::parse;
-use syn::spanned::Spanned;
-use syn::{Error, Ident};
+use syn_verus::parse;
+use syn_verus::spanned::Spanned;
+use syn_verus::{Error, Ident};
 
 pub fn fields_contain(fields: &Vec<Field>, ident: &Ident) -> bool {
     for f in fields {

--- a/source/state_machines_macros/src/util.rs
+++ b/source/state_machines_macros/src/util.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
-use syn::parse;
-use syn::parse2;
-use syn::{Error, Expr, Pat, PatIdent, PatTuple};
+use syn_verus::parse;
+use syn_verus::parse2;
+use syn_verus::{Error, Expr, Pat, PatIdent, PatTuple};
 
 // If there is at least one error, combine them all into one
 // Else, return Ok(())


### PR DESCRIPTION
Let me know if you'd prefer to hold off on this for any reason.

- update the dependency to syn_verus
- wrap all generated code in the verus! macro
- use new syntax where it seems necessary (but nowhere else)
- update some of the old sanity checks that previously just checked attributes