### PR TITLE
verusdoc

### DIFF
--- a/source/Cargo.toml
+++ b/source/Cargo.toml
@@ -7,4 +7,5 @@ members = [
   "rust_verify",
   "rust_verify_test_macros",
   "state_machines_macros",
+  "verusdoc",
 ]

--- a/source/builtin_macros/Cargo.toml
+++ b/source/builtin_macros/Cargo.toml
@@ -13,3 +13,4 @@ quote = "1.0"
 synstructure = "0.12"
 syn = "1.0"
 syn_verus = { git = "https://github.com/secure-foundations/syn", rev = "42ae850", features = ["full", "visit-mut", "extra-traits"] }
+prettyplease_verus = { git = "https://github.com/secure-foundations/prettyplease", rev = "4b09394f" }

--- a/source/builtin_macros/src/lib.rs
+++ b/source/builtin_macros/src/lib.rs
@@ -1,8 +1,11 @@
 #![feature(box_patterns)]
 #![feature(proc_macro_span)]
+#![feature(proc_macro_tracked_env)]
+
 use synstructure::{decl_attribute, decl_derive};
 mod fndecl;
 mod is_variant;
+mod rustdoc;
 mod structural;
 mod syntax;
 

--- a/source/builtin_macros/src/rustdoc.rs
+++ b/source/builtin_macros/src/rustdoc.rs
@@ -1,0 +1,208 @@
+// Here, we modify each function item by appending rustdoc
+// containing information about the Verus signature that we want to appear
+// in auto-generated rustdoc. For example, we add information about
+// 'requires' and 'ensures' clauses, and we also add 'mode' information.
+// This information would be absent if we tried to run rustdoc without any
+// processing.
+//
+// The flow is:
+//  - the verus! macro (this file) adds extra information into a rustdoc comment
+//  - rustdoc (unmodified) generates the rustdoc HTML
+//  - we run a postprocessor (verusdoc crate) to present the information in a nice way.
+//
+// Specifically, we add "attributes" in a kinda-silly format that the post-processing
+// step can recognize.  The format is:
+//
+//     ```rust
+//     // verusdoc_special_attr $ATTR_NAME
+//     $ATTR_VALUE
+//     ```
+//
+// The ATTR_NAME can be requires, ensures, recommends or modes.
+//
+// The reason we use a codeblock here is that so rustdoc will perform syntax highlighting
+// on the value which is applicable if it's an expression. For example, if it's a
+// requires, ensures, or recommends attribute then ATTR_VALUE will be a (pretty-printed)
+// boolean expression.
+//
+// The other type, 'modes', is a bit more complicated: the value is a JSON blob with
+// some data explaining the function mode, param modes, and return mode.
+
+use proc_macro2::Span;
+use proc_macro2::TokenTree;
+use std::iter::FromIterator;
+use syn_verus::punctuated::Punctuated;
+use syn_verus::spanned::Spanned;
+use syn_verus::token;
+use syn_verus::{
+    AttrStyle, Attribute, Expr, FnMode, Ident, ImplItemMethod, ItemFn, Path, PathArguments,
+    PathSegment, Publish, ReturnType, Signature, TraitItemMethod,
+};
+
+/// Check if VERUSDOC=1.
+
+pub fn env_rustdoc() -> bool {
+    match proc_macro::tracked_env::var("VERUSDOC") {
+        Err(_) => false, // VERUSDOC key not present in environment
+        Ok(s) => s == "1",
+    }
+}
+
+// Main hooks for the verus! macro to manipulate ItemFn, etc.
+
+pub fn process_item_fn(item: &mut ItemFn) {
+    match attr_for_sig(&item.sig) {
+        Some(attr) => item.attrs.insert(0, attr),
+        None => {}
+    }
+}
+
+pub fn process_impl_item_method(item: &mut ImplItemMethod) {
+    match attr_for_sig(&item.sig) {
+        Some(attr) => item.attrs.insert(0, attr),
+        None => {}
+    }
+}
+
+pub fn process_trait_item_method(item: &mut TraitItemMethod) {
+    match attr_for_sig(&item.sig) {
+        Some(attr) => item.attrs.insert(0, attr),
+        None => {}
+    }
+}
+
+/// Process a signature to get all the information, apply the codeblock
+/// formatting tricks, and then package it all up into a #[doc = "..."] attribute
+/// (as a syn_verus::Attribute object) that we can apply to the item.
+
+fn attr_for_sig(sig: &Signature) -> Option<Attribute> {
+    let mut v = vec![];
+
+    v.push(encoded_mode_info(sig));
+
+    match &sig.requires {
+        Some(es) => {
+            for expr in es.exprs.exprs.iter() {
+                v.push(encoded_expr("requires", expr));
+            }
+        }
+        None => {}
+    }
+    match &sig.recommends {
+        Some(es) => {
+            for expr in es.exprs.exprs.iter() {
+                v.push(encoded_expr("recommends", expr));
+            }
+        }
+        None => {}
+    }
+    match &sig.ensures {
+        Some(es) => {
+            for expr in es.exprs.exprs.iter() {
+                v.push(encoded_expr("ensures", expr));
+            }
+        }
+        None => {}
+    }
+
+    if v.len() == 0 { None } else { Some(doc_attr_from_string(&v.join("\n\n"), sig.span())) }
+}
+
+fn fn_mode_to_string(mode: &FnMode, publish: &Publish) -> String {
+    match mode {
+        FnMode::Spec(_) | FnMode::SpecChecked(_) => match publish {
+            Publish::Closed(_) => "closed spec".to_string(),
+            Publish::Open(_) => "open spec".to_string(),
+            Publish::OpenRestricted(res) => {
+                "open(".to_string() + &module_path_to_string(&res.path) + ") spec"
+            }
+            Publish::Default => "spec".to_string(),
+        },
+        FnMode::Proof(_) => "proof".to_string(),
+        FnMode::Exec(_) => "exec".to_string(),
+        FnMode::Default => "exec".to_string(),
+    }
+}
+
+fn module_path_to_string(p: &Path) -> String {
+    // path is for a module; we can ignore type arguments
+
+    let lead = if p.leading_colon.is_some() { "::" } else { "" };
+    let main = p
+        .segments
+        .iter()
+        .map(|path_seg| path_seg.ident.to_string())
+        .collect::<Vec<String>>()
+        .join("::");
+    lead.to_string() + &main
+}
+
+fn encoded_mode_info(sig: &Signature) -> String {
+    let fn_mode = fn_mode_to_string(&sig.mode, &sig.publish);
+    let ret_mode = match &sig.output {
+        ReturnType::Default => "Default",
+        ReturnType::Type(_, tracked_token, _, _) => {
+            if tracked_token.is_some() {
+                "Tracked"
+            } else {
+                "Default"
+            }
+        }
+    };
+
+    let param_modes = sig
+        .inputs
+        .iter()
+        .map(|fn_arg| if fn_arg.tracked.is_some() { "\"Tracked\"" } else { "\"Default\"" })
+        .collect::<Vec<&str>>();
+    let param_modes = param_modes.join(",");
+
+    // JSON blob is parsed by the verusdoc post-processor into a `DocModeInfo` object.
+    // I decided not to pull in serde as a dependency for builtin_macros,
+    // but if serialization gets too complicated, we should probably do that instead.
+
+    // We put it in a comment to avoid extra syntax highlighting or anything that would
+    // complicate the post-processing.
+
+    let info = format!(
+        r#"// {{ "fn_mode": "{fn_mode:}", "ret_mode": "{ret_mode:}", "param_modes": [{param_modes:}] }}"#
+    );
+
+    encoded_str("modes", &info)
+}
+
+/// Pretty print the expression, then wrap in a code block.
+
+fn encoded_expr(kind: &str, code: &Expr) -> String {
+    let s = prettyplease_verus::unparse_expr(&code);
+    let s = format!("{s:},");
+    encoded_str(kind, &s)
+}
+
+/// Wrap the given string into a code block,
+/// into the format that the postprocessor will recognize.
+
+fn encoded_str(kind: &str, data: &str) -> String {
+    "```rust\n// verusdoc_special_attr ".to_string() + kind + "\n" + data + "\n```"
+}
+
+/// Create an attr that looks like #[doc = "doc_str"]
+
+fn doc_attr_from_string(doc_str: &str, span: Span) -> Attribute {
+    Attribute {
+        pound_token: token::Pound { spans: [span] },
+        style: AttrStyle::Outer,
+        bracket_token: token::Bracket { span },
+        path: Path {
+            leading_colon: None,
+            segments: Punctuated::from_iter(vec![PathSegment {
+                ident: Ident::new("doc", span),
+                arguments: PathArguments::None,
+            }]),
+        },
+        tokens: proc_macro2::TokenStream::from_iter(vec![
+            TokenTree::Punct(proc_macro2::Punct::new('=', proc_macro2::Spacing::Alone)),
+            TokenTree::Literal(proc_macro2::Literal::string(doc_str)),
+        ]),
+    }
+}

--- a/source/lib.rs
+++ b/source/lib.rs
@@ -1,0 +1,3 @@
+// Serves as a root module for ./tools/doc.sh
+
+pub mod pervasive;

--- a/source/pervasive/atomic_ghost.rs
+++ b/source/pervasive/atomic_ghost.rs
@@ -6,10 +6,6 @@ use crate::pervasive::invariant::*;
 use crate::pervasive::atomic::*;
 use crate::pervasive::modes::*;
 
-#[doc(hidden)]
-#[spec]
-//const ATOMIC_MEM_NAMESPACE: int = 0;
-
 macro_rules! declare_atomic_type {
     ($at_ident:ident, $patomic_ty:ident, $perm_ty:ty, $value_ty: ty) => {
         pub struct $at_ident<#[verifier(maybe_negative)] G> {

--- a/source/pervasive/map.rs
+++ b/source/pervasive/map.rs
@@ -176,6 +176,8 @@ impl<K, V> Map<K, V> {
         unimplemented!();
     }
 
+    /// todo fill in documentation
+
     #[verifier(external_body)]
     pub proof fn proof_remove(tracked &mut self, key: K) -> (tracked v: V)
         requires

--- a/source/pervasive/thread.rs
+++ b/source/pervasive/thread.rs
@@ -3,18 +3,18 @@
 #[allow(unused_imports)] use crate::pervasive::*;
 #[allow(unused_imports)] use crate::pervasive::result::*;
 
-pub trait Spawnable<Ret: Sized> : Sized {
-    #[spec]
-    fn pre(self) -> bool { no_method_body() }
+verus!{
 
-    #[spec]
-    fn post(self, ret: Ret) -> bool { no_method_body() }
+pub trait Spawnable<Ret: Sized> : Sized {
+    spec fn pre(self) -> bool;
+
+    spec fn post(self, ret: Ret) -> bool;
     
-    fn run(self) -> Ret {
-        requires(self.pre());
-        ensures(|r: Ret| self.post(r));
-        no_method_body()
-    }
+    exec fn run(self) -> (r: Ret)
+        requires self.pre(),
+        ensures self.post(r);
+}
+
 }
 
 #[verifier(external_body)]

--- a/source/state_machines_macros/Cargo.toml
+++ b/source/state_machines_macros/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-syn_verus = { git = "https://github.com/secure-foundations/syn", rev = "42ae850", features = ["full", "visit", "visit-mut"] }
+syn_verus = { git = "https://github.com/secure-foundations/syn", rev = "42ae850", features = ["full", "visit", "visit-mut", "extra-traits"] }
 quote = "1.0"
 proc-macro2 = "1.0"
 

--- a/source/tools/docs.sh
+++ b/source/tools/docs.sh
@@ -1,0 +1,5 @@
+#! /bin/bash
+
+VERUSDOC=1 VERUS_Z3_PATH=/Users/thance/verus/source/z3 DYLD_LIBRARY_PATH=../rust/install/lib/rustlib/x86_64-apple-darwin/lib LD_LIBRARY_PATH=../rust/install/lib/rustlib/x86_64-unknown-linux-gnu/lib ../rust/install/bin/rustdoc --extern builtin=../rust/install/bin/libbuiltin.rlib --extern builtin_macros=../rust/install/bin/libbuiltin_macros.dylib --extern state_machines_macros=../rust/install/bin/libstate_machines_macros.dylib --edition=2018 -Zenable_feature=stmt_expr_attributes -Zenable_feature=box_syntax -Zenable_feature=box_patterns -Zenable_feature=negative_impls ./lib.rs
+
+./target/debug/verusdoc

--- a/source/tools/docs.sh
+++ b/source/tools/docs.sh
@@ -1,5 +1,16 @@
 #! /bin/bash
 
-VERUSDOC=1 VERUS_Z3_PATH=/Users/thance/verus/source/z3 DYLD_LIBRARY_PATH=../rust/install/lib/rustlib/x86_64-apple-darwin/lib LD_LIBRARY_PATH=../rust/install/lib/rustlib/x86_64-unknown-linux-gnu/lib ../rust/install/bin/rustdoc --extern builtin=../rust/install/bin/libbuiltin.rlib --extern builtin_macros=../rust/install/bin/libbuiltin_macros.dylib --extern state_machines_macros=../rust/install/bin/libstate_machines_macros.dylib --edition=2018 -Zenable_feature=stmt_expr_attributes -Zenable_feature=box_syntax -Zenable_feature=box_patterns -Zenable_feature=negative_impls ./lib.rs
+TEMPD=$(mktemp -d)
 
+cp -r pervasive $TEMPD
+echo "#[allow(rustdoc::invalid_rust_codeblocks)] pub mod pervasive;" >> $TEMPD/lib.rs
+
+echo "Running rustdoc..."
+VERUSDOC=1 VERUS_Z3_PATH=/Users/thance/verus/source/z3 DYLD_LIBRARY_PATH=../rust/install/lib/rustlib/x86_64-apple-darwin/lib LD_LIBRARY_PATH=../rust/install/lib/rustlib/x86_64-unknown-linux-gnu/lib ../rust/install/bin/rustdoc --extern builtin=../rust/install/bin/libbuiltin.rlib --extern builtin_macros=../rust/install/bin/libbuiltin_macros.dylib --extern state_machines_macros=../rust/install/bin/libstate_machines_macros.dylib --edition=2018 -Zenable_feature=stmt_expr_attributes -Zenable_feature=box_syntax -Zenable_feature=box_patterns -Zenable_feature=negative_impls $TEMPD/lib.rs
+
+rm -rf $TEMPD
+
+echo "Running post-processor..."
 ./target/debug/verusdoc
+
+echo "Documentation generated at ./doc/lib/index.html"

--- a/source/verusdoc/Cargo.toml
+++ b/source/verusdoc/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "verusdoc"
+version = "0.1.0"
+authors = ["Chris Hawblitzel <Chris.Hawblitzel@microsoft.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+walkdir = "2.3.2"
+kuchiki = "0.8.1"
+serde_json = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+html5ever = "0.25.2"

--- a/source/verusdoc/src/main.rs
+++ b/source/verusdoc/src/main.rs
@@ -296,14 +296,30 @@ fn update_mode_info(docblock_elem: &NodeRef, info: &DocModeInfo) {
     // Then we add the content.
 
     let mut summary = docblock_elem.previous_sibling().unwrap();
-    let mut full_text = summary.text_contents();
 
-    if full_text == "Expand description" {
+    if summary.text_contents() == "Expand description" {
         // This is applicable to pages devoted to a single fn not inside an impl
         let details = summary.parent().unwrap();
         summary = details.previous_sibling().unwrap();
-        full_text = summary.text_contents();
     }
+
+    let code_header = summary.select_first(".code-header");
+    match code_header {
+        Ok(ch) => {
+            summary = ch.as_node().clone();
+        }
+        Err(_) => {
+            let code_block = summary.select_first("code");
+            match code_block {
+                Ok(cb) => {
+                    summary = cb.as_node().clone();
+                }
+                Err(_) => {}
+            }
+        }
+    }
+
+    let full_text = summary.text_contents();
 
     let mut splices: Vec<(usize, String)> = vec![];
 

--- a/source/verusdoc/src/main.rs
+++ b/source/verusdoc/src/main.rs
@@ -1,0 +1,474 @@
+// HTML Postprocessor for verusdoc.
+// The 'other half' to this mechanism is in builtin_macros/src/rustdoc.rs
+// which has more high-level details.
+
+use html5ever::{local_name, namespace_url, ns, QualName};
+use kuchiki::traits::TendrilSink;
+use kuchiki::NodeRef;
+use serde::{Deserialize, Serialize};
+use std::io::Write;
+use std::path::Path;
+use walkdir::WalkDir;
+
+#[derive(Serialize, Deserialize)]
+pub enum ParamMode {
+    Tracked,
+    Default,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct DocModeInfo {
+    pub fn_mode: String,
+    pub ret_mode: ParamMode,
+    pub param_modes: Vec<ParamMode>,
+}
+
+enum VerusDocAttr {
+    ModeInfo(DocModeInfo),
+    Specification(String, NodeRef),
+}
+
+// Types of spec clauses we handle.
+static SPEC_NAMES: [&str; 3] = ["requires", "ensures", "recommends"];
+
+fn main() {
+    // Manipulate the auto-generated files in `doc/` to clean them up to make
+    // the more presentable.
+
+    // First modify the main .css file to add the CSS rules for the classes we're going to use
+
+    write_css(Path::new("doc"));
+
+    // Process every documentation HTML file in the directory.
+
+    for entry in WalkDir::new("doc").into_iter().filter_map(|e| e.ok()) {
+        if entry.path().extension().map(|s| s == "html").unwrap_or(false) {
+            process_file(entry.path())
+        }
+    }
+}
+
+fn process_file(path: &Path) {
+    let filename = path.file_name().unwrap();
+    if filename.to_string_lossy().starts_with("fn.") {
+        return;
+    }
+
+    let html = std::fs::read_to_string(path).expect("read file");
+
+    if !html.contains("verusdoc_special_attr") {
+        return;
+    }
+
+    let document = kuchiki::parse_html().one(html);
+
+    // Rustdoc generates HTML for an ImplItem that looks like this:
+    //
+    //   <summary>signature here (fn foo(...) -> ...)</summary>
+    //   <div class="docblock">
+    //
+    //     <div class="example-wrap">     // This encapsulates a single "verusdoc attribute"
+    //       <pre class="rust rust-example-rendered">
+    //         <code>
+    //           <span class="comment">// verusdoc_special_attr modes</span>
+    //           ... additional content here
+    //         </code>
+    //       </pre>
+    //     </div>
+    //
+    //     ... possibly more blocks here
+    //   </div>
+    //
+    // Our plan is:
+    //
+    //   1. Collect all <div class="docblock"> elements
+    //
+    //   2. Check for <pre> elements that use our special format.
+    //      Parse the information inside and remove them.
+    //
+    //   3. For the 'modes' information, we parse the modes information, then annotate
+    //      the signature line with the mode information
+    //
+    //   4. For the requires/ensures/reocmmends information, we collect the
+    //      syntax-highlighted HTML and add that HTML back in a nicely-formatted way.
+
+    for docblock_elem in document.select(".docblock").expect("code selector") {
+        let docblock_elem: &NodeRef = docblock_elem.as_node();
+
+        // Iterate over elements. For each one, check if it is a
+        // verusdoc_special_attr block. If so, remove it.
+
+        let mut child_opt = docblock_elem.first_child();
+        let mut attrs: Vec<VerusDocAttr> = vec![];
+        while child_opt.is_some() {
+            let child = child_opt.unwrap();
+
+            match interpret_as_verusdoc_attribute(&child) {
+                None => {
+                    child_opt = child.next_sibling();
+                }
+                Some(attr) => {
+                    attrs.push(attr);
+                    child_opt = child.next_sibling();
+                    child.detach();
+                }
+            }
+        }
+
+        // Now add content based on the data we just collected.
+
+        update_docblock(&docblock_elem, &attrs);
+    }
+
+    document.serialize_to_file(path).expect("serialize_to_file");
+}
+
+fn interpret_as_verusdoc_attribute(node: &NodeRef) -> Option<VerusDocAttr> {
+    let pre_node = get_single_child(node)?;
+    if !is_element(&pre_node, "pre") {
+        return None;
+    }
+
+    let code_node = get_single_child(&pre_node)?;
+    if !is_element(&code_node, "code") {
+        return None;
+    }
+
+    let span_node = code_node.first_child()?;
+    if !is_element(&span_node, "span") {
+        return None;
+    }
+
+    let text_node = get_single_child(&span_node)?;
+    let text_ref = text_node.as_text()?;
+    let text: &String = &text_ref.borrow();
+
+    let attr_name = text.strip_prefix("// verusdoc_special_attr ")?;
+
+    if attr_name == "modes" {
+        let node1 = span_node.next_sibling().unwrap();
+        let node2 = node1.next_sibling().unwrap();
+        let json_text_node = get_single_child(&node2).unwrap();
+
+        let text_ref = json_text_node.as_text().unwrap();
+        let text: &String = &text_ref.borrow();
+
+        let json_text = text.strip_prefix("// ").unwrap();
+
+        let doc_mode_info: DocModeInfo = serde_json::from_str(json_text).unwrap();
+
+        Some(VerusDocAttr::ModeInfo(doc_mode_info))
+    } else if SPEC_NAMES.contains(&attr_name) {
+        let next_text_node = span_node.next_sibling().expect("expected newline");
+        let next_text_refcell = next_text_node.as_text().expect("expected newline");
+
+        if *next_text_refcell.borrow() == "\n" {
+            next_text_node.detach();
+        } else if next_text_refcell.borrow().starts_with("\n") {
+            let mut m = next_text_refcell.borrow_mut();
+            *m = (*m)[1..].to_string();
+        }
+
+        text_node.detach();
+        pre_node.detach();
+
+        Some(VerusDocAttr::Specification(attr_name.to_string(), pre_node))
+    } else {
+        panic!("unrecognized attr_name: {:}", attr_name);
+    }
+}
+
+/// If this node has a single child, return it. Otherwise, None.
+
+fn get_single_child(node: &NodeRef) -> Option<NodeRef> {
+    let child = node.first_child()?;
+    if child.next_sibling().is_some() {
+        return None;
+    }
+    Some(child)
+}
+
+/// Check if the node is an element with the given tag name
+
+fn is_element(node: &NodeRef, name: &str) -> bool {
+    match node.as_element() {
+        None => false,
+        Some(data) => data.name.local == name.to_string(),
+    }
+}
+
+/// Returns node that looks like
+///     <span class="verus-spec-keyword">requires</span>
+/// (the inner text is given by `spec_name`
+
+fn mk_spec_keyword_node(spec_name: &str) -> NodeRef {
+    let t = NodeRef::new_text(spec_name);
+
+    let qual_name = QualName::new(None, ns!(html), local_name!("span"));
+    let nr = NodeRef::new_element(qual_name, vec![]);
+    set_class_attribute(&nr, "verus-spec-keyword");
+    nr.append(t);
+
+    nr
+}
+
+/// <span class="verus-sig-keyword">{spec name}</span>
+
+fn mk_sig_keyword_node(spec_name: &str) -> NodeRef {
+    let t = NodeRef::new_text(spec_name);
+
+    let qual_name = QualName::new(None, ns!(html), local_name!("span"));
+    let nr = NodeRef::new_element(qual_name, vec![]);
+    set_class_attribute(&nr, "verus-sig-keyword");
+    nr.append(t);
+
+    nr
+}
+
+/// <div class="verus-spec"></div>
+
+fn mk_spec_node() -> NodeRef {
+    let qual_name = QualName::new(None, ns!(html), local_name!("div"));
+    let nr = NodeRef::new_element(qual_name, vec![]);
+    set_class_attribute(&nr, "verus-spec");
+
+    nr
+}
+
+fn set_class_attribute(nr: &NodeRef, value: &str) {
+    let el = nr.as_element().unwrap();
+    let mut attr_ref = el.attributes.borrow_mut();
+    attr_ref.insert(local_name!("class"), value.to_string());
+}
+
+fn update_docblock(docblock_elem: &NodeRef, attrs: &Vec<VerusDocAttr>) {
+    let mut elems: Vec<NodeRef> = vec![];
+
+    // Add code that looks like
+    // <div class="verus-spec">
+    //   <span class="verus-spec-keyword">requires</span>
+    //   <pre class="... verus-spec-code">...</pre>
+    //   <span class="verus-spec-keyword">ensures</span>
+    //   <pre class="... verus-spec-code">...</pre>
+    // </div>
+
+    for spec_name in SPEC_NAMES.iter() {
+        let code_blocks: Vec<NodeRef> = attrs
+            .iter()
+            .filter_map(|a| match a {
+                VerusDocAttr::Specification(s, nr) if s == spec_name => Some(nr.clone()),
+                _ => None,
+            })
+            .collect();
+
+        if code_blocks.len() > 0 {
+            elems.push(mk_spec_keyword_node(spec_name));
+        }
+
+        for code_block in code_blocks.into_iter() {
+            set_class_attribute(&code_block, "rust rest-example-rendered verus-spec-code");
+            elems.push(code_block);
+        }
+    }
+
+    if elems.len() > 0 {
+        let spec_node = mk_spec_node();
+        for elem in elems.into_iter() {
+            spec_node.append(elem);
+        }
+        docblock_elem.prepend(spec_node);
+    }
+
+    // Add mode info to the signature
+
+    for attr in attrs.iter() {
+        match attr {
+            VerusDocAttr::ModeInfo(doc_mode_info) => {
+                update_mode_info(docblock_elem, doc_mode_info);
+                break;
+            }
+            _ => {}
+        }
+    }
+}
+
+fn update_mode_info(docblock_elem: &NodeRef, info: &DocModeInfo) {
+    // The signature is a dom tree with special formatting for syntax highlighting and such.
+    // We first collect it as pure text, to get a string like
+    //    pub fn foo<...>(...) -> ...
+    // We identify the locations where content needs to be inserted,
+    // collected all in the 'splices' vec.
+    // Then we add the content.
+
+    let summary = docblock_elem.previous_sibling().unwrap();
+    let full_text = summary.text_contents();
+
+    let mut splices: Vec<(usize, String)> = vec![];
+
+    let fn_idx = full_text.find("fn").unwrap();
+    let fn_mode = format!("{:} ", info.fn_mode);
+    splices.push((fn_idx, fn_mode.clone()));
+
+    let arg0_idx = get_arg0_idx(&full_text, fn_idx);
+
+    let mut arg_idx = arg0_idx;
+
+    for i in 0..info.param_modes.len() {
+        match info.param_modes[i] {
+            ParamMode::Default => {}
+            ParamMode::Tracked => {
+                splices.push((arg_idx, "tracked ".to_string()));
+            }
+        }
+
+        arg_idx = next_comma_or_rparen(&full_text, arg_idx);
+
+        // skip of the comma and space
+        arg_idx += 2;
+    }
+
+    match info.ret_mode {
+        ParamMode::Default => {}
+        ParamMode::Tracked => {
+            let arrow_idx = full_text[arg_idx..].find("->").unwrap() + arg_idx;
+            let type_idx = arrow_idx + 3;
+            splices.push((type_idx, "tracked ".to_string()));
+        }
+    }
+
+    // Reverse order since inserting text should invalidate later indices
+    for (idx, s) in splices.into_iter().rev() {
+        let mut idx = idx;
+        let new_node = mk_sig_keyword_node(&s);
+        do_text_splice(&summary, &new_node, &mut idx, true);
+    }
+}
+
+// traverse a dom tree, counting characters, to insert the given node at the right spot
+fn do_text_splice(elem: &NodeRef, inserted: &NodeRef, idx: &mut usize, root: bool) -> bool {
+    match elem.as_text() {
+        Some(text_ref) => {
+            let t: &mut String = &mut text_ref.borrow_mut();
+
+            if *idx == 0 {
+                elem.insert_before(inserted.clone());
+                true
+            } else if *idx == t.len() && root {
+                elem.insert_after(inserted.clone());
+                true
+            } else if *idx < t.len() {
+                let second_text_node = NodeRef::new_text(&t[*idx..]);
+                *t = t[..*idx].to_string();
+                elem.insert_after(second_text_node);
+                elem.insert_after(inserted.clone());
+                true
+            } else {
+                *idx -= t.len();
+                false
+            }
+        }
+        None => {
+            if *idx == 0 {
+                elem.prepend(inserted.clone());
+                return true;
+            }
+
+            let mut child_opt = elem.first_child();
+            while let Some(c) = child_opt {
+                let done = do_text_splice(&c, inserted, idx, false);
+                if done {
+                    return true;
+                }
+
+                child_opt = c.next_sibling();
+
+                if *idx == 0 && (child_opt.is_some() || root) {
+                    c.append(inserted.clone());
+                    return true;
+                }
+            }
+
+            false
+        }
+    }
+}
+
+fn get_arg0_idx(s: &str, i: usize) -> usize {
+    let s: &[u8] = s.as_bytes();
+
+    let mut depth: usize = 0;
+    let mut i = i;
+    loop {
+        if depth == 0 && s[i] == b'(' {
+            return i + 1;
+        } else if s[i] == b'(' || s[i] == b'[' || s[i] == b'{' || s[i] == b'<' {
+            depth += 1;
+        } else if s[i] == b')' || s[i] == b']' || s[i] == b'}' || (s[i] == b'>' && s[i - 1] != b'-')
+        {
+            depth -= 1;
+        }
+
+        i += 1;
+    }
+}
+
+fn next_comma_or_rparen(s: &str, i: usize) -> usize {
+    let s: &[u8] = s.as_bytes();
+
+    let mut depth: usize = 0;
+    let mut i = i;
+    loop {
+        if s[i] == b'(' || s[i] == b'[' || s[i] == b'{' || s[i] == b'<' {
+            depth += 1;
+        } else if depth == 0 && (s[i] == b',' || s[i] == b')') {
+            return i;
+        } else if s[i] == b')' || s[i] == b']' || s[i] == b'}' || (s[i] == b'>' && s[i - 1] != b'-')
+        {
+            depth -= 1;
+        }
+
+        i += 1;
+    }
+}
+
+fn write_css(dir_path: &Path) {
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .append(true)
+        .open(dir_path.join("rustdoc.css"))
+        .unwrap();
+    file.write_all(
+        r#"
+.verus-spec-code {
+  padding: 0px !important;
+  background-color: #ffffff !important;
+  margin: 0px;
+  font-size: 14px;
+}
+
+.verus-spec-code code {
+  background-color: #ffffff !important;
+  margin-left: 40px !important;
+}
+
+.verus-spec-keyword {
+  font-family: "Source Code Pro", monospace;
+  color: #006400;
+  font-size: 14px;
+}
+
+.verus-sig-keyword {
+  font-family: "Source Code Pro", monospace;
+  color: #006400;
+}
+
+.verus-spec {
+    margin-top: -8px;
+    padding-bottom: 18px;
+    margin-left: 16px;
+}
+"#
+        .as_bytes(),
+    )
+    .expect("write css file");
+}

--- a/source/verusdoc/src/main.rs
+++ b/source/verusdoc/src/main.rs
@@ -49,11 +49,6 @@ fn main() {
 }
 
 fn process_file(path: &Path) {
-    let filename = path.file_name().unwrap();
-    if filename.to_string_lossy().starts_with("fn.") {
-        return;
-    }
-
     let html = std::fs::read_to_string(path).expect("read file");
 
     if !html.contains("verusdoc_special_attr") {
@@ -300,8 +295,15 @@ fn update_mode_info(docblock_elem: &NodeRef, info: &DocModeInfo) {
     // collected all in the 'splices' vec.
     // Then we add the content.
 
-    let summary = docblock_elem.previous_sibling().unwrap();
-    let full_text = summary.text_contents();
+    let mut summary = docblock_elem.previous_sibling().unwrap();
+    let mut full_text = summary.text_contents();
+
+    if full_text == "Expand description" {
+        // This is applicable to pages devoted to a single fn not inside an impl
+        let details = summary.parent().unwrap();
+        summary = details.previous_sibling().unwrap();
+        full_text = summary.text_contents();
+    }
 
     let mut splices: Vec<(usize, String)> = vec![];
 


### PR DESCRIPTION
includes:

 - addition to the `verus!` macro that adds verus-specific signature content to the rustdoc body
 - an html postprocessor to manipulate that content and make it look pretty
 - a script to run both these things on the pervasive lib

step 1 requires an expression pretty-printer, which syn on its own doesn't have. I forked `prettyplease` and updated it to support `syn_verus`, which was fairly easy, though be aware it's 1 more thing that needs to stay in sync with our syn fork :| 