### PR TITLE
Remove dependence on special type checking for int/nat

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -508,6 +508,36 @@ pub trait SpecEuclideanMod<Rhs = Self> {
     fn spec_euclidean_mod(self, rhs: Rhs) -> Self::Output;
 }
 
+pub trait SpecBitAnd<Rhs = Self> {
+    type Output;
+    #[spec]
+    fn spec_bitand(self, rhs: Rhs) -> Self::Output;
+}
+
+pub trait SpecBitOr<Rhs = Self> {
+    type Output;
+    #[spec]
+    fn spec_bitor(self, rhs: Rhs) -> Self::Output;
+}
+
+pub trait SpecBitXor<Rhs = Self> {
+    type Output;
+    #[spec]
+    fn spec_bitxor(self, rhs: Rhs) -> Self::Output;
+}
+
+pub trait SpecShl<Rhs = Self> {
+    type Output;
+    #[spec]
+    fn spec_shl(self, rhs: Rhs) -> Self::Output;
+}
+
+pub trait SpecShr<Rhs = Self> {
+    type Output;
+    #[spec]
+    fn spec_shr(self, rhs: Rhs) -> Self::Output;
+}
+
 // Chained inequalities x <= y < z
 pub struct SpecChain {
     data: std::marker::PhantomData<int>,
@@ -685,6 +715,32 @@ impl_binary_op_rhs!(SpecEuclideanDiv, spec_euclidean_div, Self, int, [
 
 impl_binary_op_rhs!(SpecEuclideanMod, spec_euclidean_mod, Self, Self, [
     int nat
+    usize u8 u16 u32 u64 u128
+    isize i8 i16 i32 i64 i128
+]);
+
+impl_binary_op_rhs!(SpecBitAnd, spec_bitand, Self, Self, [
+    usize u8 u16 u32 u64 u128
+    isize i8 i16 i32 i64 i128
+]);
+
+impl_binary_op_rhs!(SpecBitOr, spec_bitor, Self, Self, [
+    usize u8 u16 u32 u64 u128
+    isize i8 i16 i32 i64 i128
+]);
+
+impl_binary_op_rhs!(SpecBitXor, spec_bitxor, Self, Self, [
+    bool
+    usize u8 u16 u32 u64 u128
+    isize i8 i16 i32 i64 i128
+]);
+
+impl_binary_op_rhs!(SpecShl, spec_shl, Self, Self, [
+    usize u8 u16 u32 u64 u128
+    isize i8 i16 i32 i64 i128
+]);
+
+impl_binary_op_rhs!(SpecShr, spec_shr, Self, Self, [
     usize u8 u16 u32 u64 u128
     isize i8 i16 i32 i64 i128
 ]);

--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -496,6 +496,18 @@ pub trait SpecMul<Rhs = Self> {
     fn spec_mul(self, rhs: Rhs) -> Self::Output;
 }
 
+pub trait SpecEuclideanDiv<Rhs = Self> {
+    type Output;
+    #[spec]
+    fn spec_euclidean_div(self, rhs: Rhs) -> Self::Output;
+}
+
+pub trait SpecEuclideanMod<Rhs = Self> {
+    type Output;
+    #[spec]
+    fn spec_euclidean_mod(self, rhs: Rhs) -> Self::Output;
+}
+
 // Chained inequalities x <= y < z
 pub struct SpecChain {
     data: std::marker::PhantomData<int>,
@@ -609,6 +621,18 @@ impl_binary_op!(SpecSub, spec_sub, int, [
 ]);
 
 impl_binary_op!(SpecMul, spec_mul, int, [
+    int nat
+    usize u8 u16 u32 u64 u128
+    isize i8 i16 i32 i64 i128
+]);
+
+impl_binary_op!(SpecEuclideanDiv, spec_euclidean_div, Self, [
+    int nat
+    usize u8 u16 u32 u64 u128
+    isize i8 i16 i32 i64 i128
+]);
+
+impl_binary_op!(SpecEuclideanMod, spec_euclidean_mod, Self, [
     int nat
     usize u8 u16 u32 u64 u128
     isize i8 i16 i32 i64 i128

--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -168,40 +168,6 @@ pub fn old<A>(_: A) -> A {
     unimplemented!();
 }
 
-pub struct Chain {
-    data: std::marker::PhantomData<int>,
-}
-
-#[spec]
-pub fn chained_value(_a: int) -> Chain {
-    unimplemented!()
-}
-
-#[spec]
-pub fn chained_le(_left: Chain, _right: int) -> Chain {
-    unimplemented!()
-}
-
-#[spec]
-pub fn chained_lt(_left: Chain, _right: int) -> Chain {
-    unimplemented!()
-}
-
-#[spec]
-pub fn chained_ge(_left: Chain, _right: int) -> Chain {
-    unimplemented!()
-}
-
-#[spec]
-pub fn chained_gt(_left: Chain, _right: int) -> Chain {
-    unimplemented!()
-}
-
-#[spec]
-pub fn chained_cmp(_chain: Chain) -> bool {
-    unimplemented!()
-}
-
 #[proof]
 pub fn assert_by(_: bool, _: ()) {
     unimplemented!();
@@ -231,6 +197,8 @@ pub fn internal_arbitrary<A>(_: u64) -> A {
 #[allow(non_camel_case_types)]
 pub struct int;
 
+// TODO: we should eventually be able to remove this and other int/nat ops,
+// since we now have SpecAdd, etc.
 impl std::ops::Add for int {
     type Output = Self;
     fn add(self, _other: Self) -> Self::Output {
@@ -414,3 +382,298 @@ pub struct SyncSendIfSend<T> {
 
 unsafe impl<T: Send> Sync for SyncSendIfSend<T> {}
 unsafe impl<T: Send> Send for SyncSendIfSend<T> {}
+
+// Marker for integer types (i8 ... u128, isize, usize, nat, int)
+// so that we get reasonable type error messages when someone uses a non-Integer type
+// in an arithmetic operation.
+pub trait Integer {}
+impl Integer for u8 {}
+impl Integer for u16 {}
+impl Integer for u32 {}
+impl Integer for u64 {}
+impl Integer for u128 {}
+impl Integer for usize {}
+impl Integer for i8 {}
+impl Integer for i16 {}
+impl Integer for i32 {}
+impl Integer for i64 {}
+impl Integer for i128 {}
+impl Integer for isize {}
+impl Integer for int {}
+impl Integer for nat {}
+
+// spec literals of the form "33", which could have any Integer type
+#[allow(non_camel_case_types)]
+#[spec]
+pub fn spec_literal_integer<
+    hint_please_add_suffix_on_literal_like_100u32_or_100int_or_100nat: Integer,
+>(
+    _s: &str,
+) -> hint_please_add_suffix_on_literal_like_100u32_or_100int_or_100nat {
+    unimplemented!()
+}
+
+// spec literals of the form "33int",
+// or spec literals in positions syntactically expected to be int (e.g. in "x + 33")
+#[spec]
+pub fn spec_literal_int(_s: &str) -> int {
+    unimplemented!()
+}
+
+// spec literals of the form "33nat"
+#[spec]
+pub fn spec_literal_nat(_s: &str) -> nat {
+    unimplemented!()
+}
+
+// Fixed-width add
+#[spec]
+pub fn add<IntegerType: Integer>(_left: IntegerType, _right: IntegerType) -> IntegerType {
+    unimplemented!()
+}
+
+// Fixed-width sub
+#[spec]
+pub fn sub<IntegerType: Integer>(_left: IntegerType, _right: IntegerType) -> IntegerType {
+    unimplemented!()
+}
+
+// Fixed-width mul
+#[spec]
+pub fn mul<IntegerType: Integer>(_left: IntegerType, _right: IntegerType) -> IntegerType {
+    unimplemented!()
+}
+
+// represent "expr as typ", including converting to and from int and nat
+#[spec]
+pub fn spec_cast_integer<From: Integer, To: Integer>(_from: From) -> To {
+    unimplemented!()
+}
+
+/*
+pub trait SpecEq<Rhs = Self> {
+    #[spec]
+    fn spec_eq(self, other: Rhs) -> bool;
+    #[spec]
+    fn spec_ne(self, other: Rhs) -> bool;
+}
+*/
+
+#[spec]
+pub fn spec_eq<Lhs: Structural, Rhs: Structural>(_lhs: Lhs, _rhs: Rhs) -> bool {
+    unimplemented!()
+}
+
+pub trait SpecOrd<Rhs = Self> {
+    #[spec]
+    fn spec_lt(self, rhs: Rhs) -> bool;
+    #[spec]
+    fn spec_le(self, rhs: Rhs) -> bool;
+    #[spec]
+    fn spec_gt(self, rhs: Rhs) -> bool;
+    #[spec]
+    fn spec_ge(self, rhs: Rhs) -> bool;
+}
+
+pub trait SpecIndex<Idx> {
+    type Output;
+    #[spec]
+    fn index(self, index: Idx) -> Self::Output;
+}
+
+pub trait SpecNeg {
+    type Output;
+    #[spec]
+    fn spec_neg(self) -> Self::Output;
+}
+
+pub trait SpecAdd<Rhs = Self> {
+    type Output;
+    #[spec]
+    fn spec_add(self, rhs: Rhs) -> Self::Output;
+}
+
+pub trait SpecSub<Rhs = Self> {
+    type Output;
+    #[spec]
+    fn spec_sub(self, rhs: Rhs) -> Self::Output;
+}
+
+pub trait SpecMul<Rhs = Self> {
+    type Output;
+    #[spec]
+    fn spec_mul(self, rhs: Rhs) -> Self::Output;
+}
+
+/*
+pub trait SpecEuclideanDiv<Rhs = Self> {
+    type Output;
+    #[spec]
+    fn spec_euclidean_div(self, rhs: Rhs) -> Self::Output;
+}
+
+pub trait SpecEuclideanMod<Rhs = Self> {
+    type Output;
+    #[spec]
+    fn spec_euclidean_mod(self, rhs: Rhs) -> Self::Output;
+}
+*/
+
+// Chained inequalities x <= y < z
+pub struct SpecChain {
+    data: std::marker::PhantomData<int>,
+}
+
+#[spec]
+pub fn spec_chained_value<IntegerType: Integer>(_a: IntegerType) -> SpecChain {
+    unimplemented!()
+}
+
+#[spec]
+pub fn spec_chained_le<IntegerType: Integer>(_left: SpecChain, _right: IntegerType) -> SpecChain {
+    unimplemented!()
+}
+
+#[spec]
+pub fn spec_chained_lt<IntegerType: Integer>(_left: SpecChain, _right: IntegerType) -> SpecChain {
+    unimplemented!()
+}
+
+#[spec]
+pub fn spec_chained_ge<IntegerType: Integer>(_left: SpecChain, _right: IntegerType) -> SpecChain {
+    unimplemented!()
+}
+
+#[spec]
+pub fn spec_chained_gt<IntegerType: Integer>(_left: SpecChain, _right: IntegerType) -> SpecChain {
+    unimplemented!()
+}
+
+#[spec]
+pub fn spec_chained_cmp(_chain: SpecChain) -> bool {
+    unimplemented!()
+}
+
+/*
+macro_rules! impl_eq {
+    ([$($t:ty)*]) => {
+        $(
+            impl<Rhs: Integer> SpecEq<Rhs> for $t {
+                #[spec]
+                fn spec_eq(self, _rhs: Rhs) -> bool {
+                    unimplemented!()
+                }
+                #[spec]
+                fn spec_ne(self, _rhs: Rhs) -> bool {
+                    unimplemented!()
+                }
+            }
+        )*
+    }
+}
+*/
+
+macro_rules! impl_ord {
+    ([$($t:ty)*]) => {
+        $(
+            impl<Rhs: Integer> SpecOrd<Rhs> for $t {
+                #[spec]
+                fn spec_lt(self, _rhs: Rhs) -> bool {
+                    unimplemented!()
+                }
+                #[spec]
+                fn spec_le(self, _rhs: Rhs) -> bool {
+                    unimplemented!()
+                }
+                #[spec]
+                fn spec_gt(self, _rhs: Rhs) -> bool {
+                    unimplemented!()
+                }
+                #[spec]
+                fn spec_ge(self, _rhs: Rhs) -> bool {
+                    unimplemented!()
+                }
+            }
+        )*
+    }
+}
+
+macro_rules! impl_unary_op {
+    ($trt:ident, $fun:ident, $ret:ty, [$($t:ty)*]) => {
+        $(
+            impl $trt for $t {
+                type Output = $ret;
+                #[spec]
+                fn $fun(self) -> Self::Output {
+                    unimplemented!()
+                }
+            }
+        )*
+    }
+}
+
+macro_rules! impl_binary_op {
+    ($trt:ident, $fun:ident, $ret:ty, [$($t:ty)*]) => {
+        $(
+            impl<Rhs: Integer> $trt<Rhs> for $t {
+                type Output = $ret;
+                #[spec]
+                fn $fun(self, _rhs: Rhs) -> Self::Output {
+                    unimplemented!()
+                }
+            }
+        )*
+    }
+}
+
+/*
+impl_eq!([
+    int nat
+    usize u8 u16 u32 u64 u128
+    isize i8 i16 i32 i64 i128
+]);
+*/
+
+impl_ord!([
+    int nat
+    usize u8 u16 u32 u64 u128
+    isize i8 i16 i32 i64 i128
+]);
+
+impl_unary_op!(SpecNeg, spec_neg, int, [
+    int nat
+    usize u8 u16 u32 u64 u128
+    isize i8 i16 i32 i64 i128
+]);
+
+impl_binary_op!(SpecAdd, spec_add, int, [
+    int nat
+    usize u8 u16 u32 u64 u128
+    isize i8 i16 i32 i64 i128
+]);
+
+impl_binary_op!(SpecSub, spec_sub, int, [
+    int nat
+    usize u8 u16 u32 u64 u128
+    isize i8 i16 i32 i64 i128
+]);
+
+impl_binary_op!(SpecMul, spec_mul, int, [
+    int nat
+    usize u8 u16 u32 u64 u128
+    isize i8 i16 i32 i64 i128
+]);
+
+/*
+impl_binary_op!(SpecEuclideanDiv, spec_euclidean_div, int, [
+    int nat
+    usize u8 u16 u32 u64 u128
+    isize i8 i16 i32 i64 i128
+]);
+
+impl_binary_op!(SpecEuclideanMod, spec_euclidean_mod, int, [
+    int nat
+    usize u8 u16 u32 u64 u128
+    isize i8 i16 i32 i64 i128
+]);
+*/

--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -596,6 +596,20 @@ macro_rules! impl_binary_op {
     }
 }
 
+macro_rules! impl_binary_op_nat {
+    ($trt:ident, $fun:ident, $ret:ty, [$($t:ty)*]) => {
+        $(
+            impl $trt<$t> for nat {
+                type Output = $ret;
+                #[spec]
+                fn $fun(self, _rhs: $t) -> Self::Output {
+                    unimplemented!()
+                }
+            }
+        )*
+    }
+}
+
 macro_rules! impl_binary_op_rhs {
     ($trt:ident, $fun:ident, $rhs: ty, $ret:ty, [$($t:ty)*]) => {
         $(
@@ -623,8 +637,18 @@ impl_unary_op!(SpecNeg, spec_neg, int, [
 ]);
 
 impl_binary_op!(SpecAdd, spec_add, int, [
-    int nat
+    int
     usize u8 u16 u32 u64 u128
+    isize i8 i16 i32 i64 i128
+]);
+
+impl_binary_op_nat!(SpecAdd, spec_add, nat, [
+    nat
+    usize u8 u16 u32 u64 u128
+]);
+
+impl_binary_op_nat!(SpecAdd, spec_add, int, [
+    int
     isize i8 i16 i32 i64 i128
 ]);
 
@@ -635,8 +659,18 @@ impl_binary_op!(SpecSub, spec_sub, int, [
 ]);
 
 impl_binary_op!(SpecMul, spec_mul, int, [
-    int nat
+    int
     usize u8 u16 u32 u64 u128
+    isize i8 i16 i32 i64 i128
+]);
+
+impl_binary_op_nat!(SpecMul, spec_mul, nat, [
+    nat
+    usize u8 u16 u32 u64 u128
+]);
+
+impl_binary_op_nat!(SpecMul, spec_mul, int, [
+    int
     isize i8 i16 i32 i64 i128
 ]);
 

--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -450,15 +450,6 @@ pub fn spec_cast_integer<From: Integer, To: Integer>(_from: From) -> To {
     unimplemented!()
 }
 
-/*
-pub trait SpecEq<Rhs = Self> {
-    #[spec]
-    fn spec_eq(self, other: Rhs) -> bool;
-    #[spec]
-    fn spec_ne(self, other: Rhs) -> bool;
-}
-*/
-
 #[spec]
 pub fn spec_eq<Lhs: Structural, Rhs: Structural>(_lhs: Lhs, _rhs: Rhs) -> bool {
     unimplemented!()
@@ -505,20 +496,6 @@ pub trait SpecMul<Rhs = Self> {
     fn spec_mul(self, rhs: Rhs) -> Self::Output;
 }
 
-/*
-pub trait SpecEuclideanDiv<Rhs = Self> {
-    type Output;
-    #[spec]
-    fn spec_euclidean_div(self, rhs: Rhs) -> Self::Output;
-}
-
-pub trait SpecEuclideanMod<Rhs = Self> {
-    type Output;
-    #[spec]
-    fn spec_euclidean_mod(self, rhs: Rhs) -> Self::Output;
-}
-*/
-
 // Chained inequalities x <= y < z
 pub struct SpecChain {
     data: std::marker::PhantomData<int>,
@@ -553,25 +530,6 @@ pub fn spec_chained_gt<IntegerType: Integer>(_left: SpecChain, _right: IntegerTy
 pub fn spec_chained_cmp(_chain: SpecChain) -> bool {
     unimplemented!()
 }
-
-/*
-macro_rules! impl_eq {
-    ([$($t:ty)*]) => {
-        $(
-            impl<Rhs: Integer> SpecEq<Rhs> for $t {
-                #[spec]
-                fn spec_eq(self, _rhs: Rhs) -> bool {
-                    unimplemented!()
-                }
-                #[spec]
-                fn spec_ne(self, _rhs: Rhs) -> bool {
-                    unimplemented!()
-                }
-            }
-        )*
-    }
-}
-*/
 
 macro_rules! impl_ord {
     ([$($t:ty)*]) => {
@@ -626,14 +584,6 @@ macro_rules! impl_binary_op {
     }
 }
 
-/*
-impl_eq!([
-    int nat
-    usize u8 u16 u32 u64 u128
-    isize i8 i16 i32 i64 i128
-]);
-*/
-
 impl_ord!([
     int nat
     usize u8 u16 u32 u64 u128
@@ -663,17 +613,3 @@ impl_binary_op!(SpecMul, spec_mul, int, [
     usize u8 u16 u32 u64 u128
     isize i8 i16 i32 i64 i128
 ]);
-
-/*
-impl_binary_op!(SpecEuclideanDiv, spec_euclidean_div, int, [
-    int nat
-    usize u8 u16 u32 u64 u128
-    isize i8 i16 i32 i64 i128
-]);
-
-impl_binary_op!(SpecEuclideanMod, spec_euclidean_mod, int, [
-    int nat
-    usize u8 u16 u32 u64 u128
-    isize i8 i16 i32 i64 i128
-]);
-*/

--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -596,6 +596,20 @@ macro_rules! impl_binary_op {
     }
 }
 
+macro_rules! impl_binary_op_rhs {
+    ($trt:ident, $fun:ident, $rhs: ty, $ret:ty, [$($t:ty)*]) => {
+        $(
+            impl $trt<$rhs> for $t {
+                type Output = $ret;
+                #[spec]
+                fn $fun(self, _rhs: $rhs) -> Self::Output {
+                    unimplemented!()
+                }
+            }
+        )*
+    }
+}
+
 impl_ord!([
     int nat
     usize u8 u16 u32 u64 u128
@@ -626,13 +640,16 @@ impl_binary_op!(SpecMul, spec_mul, int, [
     isize i8 i16 i32 i64 i128
 ]);
 
-impl_binary_op!(SpecEuclideanDiv, spec_euclidean_div, Self, [
+impl_binary_op_rhs!(SpecEuclideanDiv, spec_euclidean_div, Self, Self, [
     int nat
     usize u8 u16 u32 u64 u128
+]);
+
+impl_binary_op_rhs!(SpecEuclideanDiv, spec_euclidean_div, Self, int, [
     isize i8 i16 i32 i64 i128
 ]);
 
-impl_binary_op!(SpecEuclideanMod, spec_euclidean_mod, Self, [
+impl_binary_op_rhs!(SpecEuclideanMod, spec_euclidean_mod, Self, Self, [
     int nat
     usize u8 u16 u32 u64 u128
     isize i8 i16 i32 i64 i128

--- a/source/builtin_macros/src/lib.rs
+++ b/source/builtin_macros/src/lib.rs
@@ -18,7 +18,17 @@ pub fn fndecl(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
 #[proc_macro]
 pub fn verus(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    syntax::rewrite_items(input)
+    syntax::rewrite_items(input, false)
+}
+
+#[proc_macro]
+pub fn verus1(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    syntax::rewrite_items(input, false)
+}
+
+#[proc_macro]
+pub fn verus2(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    syntax::rewrite_items(input, true)
 }
 
 #[proc_macro]

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -481,10 +481,16 @@ impl VisitMut for Visitor {
                                 *expr = parse_quote_spanned!(span => ::builtin::spec_literal_integer(#n));
                                 expr.replace_attrs(attrs);
                             }
-                            InsideArith::Widen => {
+                            InsideArith::Widen if n.starts_with("-") => {
                                 // Use int inside +, -, etc., since these promote to int anyway
                                 *expr =
                                     parse_quote_spanned!(span => ::builtin::spec_literal_int(#n));
+                                expr.replace_attrs(attrs);
+                            }
+                            InsideArith::Widen => {
+                                // Use int inside +, -, etc., since these promote to int anyway
+                                *expr =
+                                    parse_quote_spanned!(span => ::builtin::spec_literal_nat(#n));
                                 expr.replace_attrs(attrs);
                             }
                             InsideArith::Fixed => {

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -462,7 +462,12 @@ impl VisitMut for Visitor {
                     | BinOp::Sub(..)
                     | BinOp::Mul(..)
                     | BinOp::Div(..)
-                    | BinOp::Rem(..),
+                    | BinOp::Rem(..)
+                    | BinOp::BitAnd(..)
+                    | BinOp::BitOr(..)
+                    | BinOp::BitXor(..)
+                    | BinOp::Shl(..)
+                    | BinOp::Shr(..),
                 ..
             }) if use_spec_traits => (true, false),
             Expr::Assume(..) | Expr::Assert(..) | Expr::AssertForall(..) => (true, false),
@@ -655,6 +660,21 @@ impl VisitMut for Visitor {
                         BinOp::Rem(..) => {
                             *expr =
                                 parse_quote_spanned!(span => (#left).spec_euclidean_mod(#right));
+                        }
+                        BinOp::BitAnd(..) => {
+                            *expr = parse_quote_spanned!(span => (#left).spec_bitand(#right));
+                        }
+                        BinOp::BitOr(..) => {
+                            *expr = parse_quote_spanned!(span => (#left).spec_bitor(#right));
+                        }
+                        BinOp::BitXor(..) => {
+                            *expr = parse_quote_spanned!(span => (#left).spec_bitxor(#right));
+                        }
+                        BinOp::Shl(..) => {
+                            *expr = parse_quote_spanned!(span => (#left).spec_shl(#right));
+                        }
+                        BinOp::Shr(..) => {
+                            *expr = parse_quote_spanned!(span => (#left).spec_shr(#right));
                         }
                         _ => panic!("binary"),
                     }

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -299,7 +299,7 @@ impl VisitMut for Visitor {
                 | BinOp::Le(..)
                 | BinOp::Gt(..)
                 | BinOp::Ge(..) => InsideArith::Widen,
-                BinOp::Div(..) | BinOp::Rem(..) => InsideArith::Fixed,
+                BinOp::Div(..) | BinOp::Rem(..) => InsideArith::None,
                 BinOp::BitXor(..)
                 | BinOp::BitAnd(..)
                 | BinOp::BitOr(..)

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -153,22 +153,22 @@ impl Visitor {
         let decreases = std::mem::take(&mut sig.decreases);
         // TODO: wrap specs inside ghost blocks
         if let Some(Requires { token, exprs }) = requires {
-            stmts.push(parse_quote_spanned!(token.span => builtin::requires([#exprs]);));
+            stmts.push(parse_quote_spanned!(token.span => ::builtin::requires([#exprs]);));
         }
         if let Some(Recommends { token, exprs }) = recommends {
-            stmts.push(parse_quote_spanned!(token.span => builtin::recommends([#exprs]);));
+            stmts.push(parse_quote_spanned!(token.span => ::builtin::recommends([#exprs]);));
         }
         if let Some(Ensures { token, exprs }) = ensures {
             if let Some((p, ty)) = ret_pat {
                 stmts.push(
-                    parse_quote_spanned!(token.span => builtin::ensures(|#p: #ty| [#exprs]);),
+                    parse_quote_spanned!(token.span => ::builtin::ensures(|#p: #ty| [#exprs]);),
                 );
             } else {
-                stmts.push(parse_quote_spanned!(token.span => builtin::ensures([#exprs]);));
+                stmts.push(parse_quote_spanned!(token.span => ::builtin::ensures([#exprs]);));
             }
         }
         if let Some(Decreases { token, exprs }) = decreases {
-            stmts.push(parse_quote_spanned!(token.span => builtin::decreases((#exprs));));
+            stmts.push(parse_quote_spanned!(token.span => ::builtin::decreases((#exprs));));
         }
         sig.publish = Publish::Default;
         sig.mode = FnMode::Default;
@@ -472,13 +472,13 @@ impl VisitMut for Visitor {
                             InsideArith::None => {
                                 // We don't know which integer type to use,
                                 // so defer the decision to type inference.
-                                *expr =
-                                    parse_quote_spanned!(span => builtin::spec_literal_integer(#n));
+                                *expr = parse_quote_spanned!(span => ::builtin::spec_literal_integer(#n));
                                 expr.replace_attrs(attrs);
                             }
                             InsideArith::Widen => {
                                 // Use int inside +, -, etc., since these promote to int anyway
-                                *expr = parse_quote_spanned!(span => builtin::spec_literal_int(#n));
+                                *expr =
+                                    parse_quote_spanned!(span => ::builtin::spec_literal_int(#n));
                                 expr.replace_attrs(attrs);
                             }
                             InsideArith::Fixed => {
@@ -488,10 +488,10 @@ impl VisitMut for Visitor {
                             }
                         }
                     } else if lit.suffix() == "int" {
-                        *expr = parse_quote_spanned!(span => builtin::spec_literal_int(#n));
+                        *expr = parse_quote_spanned!(span => ::builtin::spec_literal_int(#n));
                         expr.replace_attrs(attrs);
                     } else if lit.suffix() == "nat" {
-                        *expr = parse_quote_spanned!(span => builtin::spec_literal_nat(#n));
+                        *expr = parse_quote_spanned!(span => ::builtin::spec_literal_nat(#n));
                         expr.replace_attrs(attrs);
                     } else {
                         // Has a native Rust integer suffix, so leave it as a native Rust literal
@@ -505,7 +505,7 @@ impl VisitMut for Visitor {
                     let attrs = cast.attrs;
                     let ty = cast.ty;
                     *expr =
-                        parse_quote_spanned!(span => builtin::spec_cast_integer::<_, #ty>(#src));
+                        parse_quote_spanned!(span => ::builtin::spec_cast_integer::<_, #ty>(#src));
                     expr.replace_attrs(attrs);
                 }
                 Expr::Unary(unary) if quant => {
@@ -674,16 +674,16 @@ impl VisitMut for Visitor {
                                 parse_quote_spanned!(span => ::builtin::assert_bit_vector(#arg));
                         }
                         (Some(_), Some((_, id)), None) if id.to_string() == "nonlinear_arith" => {
-                            *expr = parse_quote_spanned!(span => ::builtin::assert_nonlinear_by({builtin::ensures(#arg);}));
+                            *expr = parse_quote_spanned!(span => ::builtin::assert_nonlinear_by({::builtin::ensures(#arg);}));
                         }
                         (Some(_), Some((_, id)), Some(box (requires, mut block)))
                             if id.to_string() == "nonlinear_arith" =>
                         {
                             let mut stmts: Vec<Stmt> = Vec::new();
                             if let Some(Requires { token, exprs }) = requires {
-                                stmts.push(parse_quote_spanned!(token.span => builtin::requires([#exprs]);));
+                                stmts.push(parse_quote_spanned!(token.span => ::builtin::requires([#exprs]);));
                             }
-                            stmts.push(parse_quote_spanned!(span => builtin::ensures(#arg);));
+                            stmts.push(parse_quote_spanned!(span => ::builtin::ensures(#arg);));
                             block.stmts.splice(0..0, stmts);
                             *expr = parse_quote_spanned!(span => {::builtin::assert_nonlinear_by(#block);});
                         }
@@ -705,10 +705,10 @@ impl VisitMut for Visitor {
                     let mut block = assert.body;
                     let mut stmts: Vec<Stmt> = Vec::new();
                     if let Some((_, rhs)) = assert.implies {
-                        stmts.push(parse_quote_spanned!(span => builtin::requires(#arg);));
-                        stmts.push(parse_quote_spanned!(span => builtin::ensures(#rhs);));
+                        stmts.push(parse_quote_spanned!(span => ::builtin::requires(#arg);));
+                        stmts.push(parse_quote_spanned!(span => ::builtin::ensures(#rhs);));
                     } else {
-                        stmts.push(parse_quote_spanned!(span => builtin::ensures(#arg);));
+                        stmts.push(parse_quote_spanned!(span => ::builtin::ensures(#arg);));
                     }
                     block.stmts.splice(0..0, stmts);
                     *expr = parse_quote_spanned!(span => {::builtin::assert_forall_by(|#inputs| #block);});
@@ -725,10 +725,10 @@ impl VisitMut for Visitor {
         let mut stmts: Vec<Stmt> = Vec::new();
         // TODO: wrap specs inside ghost blocks
         if let Some(Invariant { token, exprs }) = invariants {
-            stmts.push(parse_quote_spanned!(token.span => builtin::invariant([#exprs]);));
+            stmts.push(parse_quote_spanned!(token.span => ::builtin::invariant([#exprs]);));
         }
         if let Some(Decreases { token, exprs }) = decreases {
-            stmts.push(parse_quote_spanned!(token.span => builtin::decreases((#exprs));));
+            stmts.push(parse_quote_spanned!(token.span => ::builtin::decreases((#exprs));));
         }
         expr_while.body.stmts.splice(0..0, stmts);
         visit_expr_while_mut(self, expr_while);
@@ -742,16 +742,16 @@ impl VisitMut for Visitor {
         let mut stmts: Vec<Stmt> = Vec::new();
         // TODO: wrap specs inside ghost blocks
         if let Some(Requires { token, exprs }) = requires {
-            stmts.push(parse_quote_spanned!(token.span => builtin::requires([#exprs]);));
+            stmts.push(parse_quote_spanned!(token.span => ::builtin::requires([#exprs]);));
         }
         if let Some(Invariant { token, exprs }) = invariants {
-            stmts.push(parse_quote_spanned!(token.span => builtin::invariant([#exprs]);));
+            stmts.push(parse_quote_spanned!(token.span => ::builtin::invariant([#exprs]);));
         }
         if let Some(Ensures { token, exprs }) = ensures {
-            stmts.push(parse_quote_spanned!(token.span => builtin::ensures([#exprs]);));
+            stmts.push(parse_quote_spanned!(token.span => ::builtin::ensures([#exprs]);));
         }
         if let Some(Decreases { token, exprs }) = decreases {
-            stmts.push(parse_quote_spanned!(token.span => builtin::decreases((#exprs));));
+            stmts.push(parse_quote_spanned!(token.span => ::builtin::decreases((#exprs));));
         }
         expr_loop.body.stmts.splice(0..0, stmts);
         visit_expr_loop_mut(self, expr_loop);

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -9,10 +9,10 @@ use syn_verus::visit_mut::{
 };
 use syn_verus::{
     braced, bracketed, parenthesized, parse_macro_input, parse_quote_spanned, Attribute, BinOp,
-    Block, DataMode, Decreases, Ensures, Expr, ExprBinary, ExprCall, ExprLoop, ExprTuple,
-    ExprUnary, ExprWhile, Field, FnArgKind, FnMode, ImplItemMethod, Invariant, Item, ItemEnum,
-    ItemFn, ItemStruct, Local, ModeSpec, ModeSpecChecked, Path, Publish, Recommends, Requires,
-    ReturnType, Signature, Stmt, Token, TraitItemMethod, UnOp, Visibility,
+    Block, DataMode, Decreases, Ensures, Expr, ExprBinary, ExprCall, ExprLit, ExprLoop, ExprPath,
+    ExprTuple, ExprUnary, ExprWhile, Field, FnArgKind, FnMode, ImplItemMethod, Invariant, Item,
+    ItemEnum, ItemFn, ItemStruct, Lit, Local, ModeSpec, ModeSpecChecked, Path, Publish, Recommends,
+    Requires, ReturnType, Signature, Stmt, Token, TraitItemMethod, UnOp, Visibility,
 };
 
 fn take_expr(expr: &mut Expr) -> Expr {
@@ -20,9 +20,27 @@ fn take_expr(expr: &mut Expr) -> Expr {
     std::mem::replace(expr, dummy)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InsideArith {
+    None,
+    Widen,
+    Fixed,
+}
+
 struct Visitor {
+    // TODO: this should always be true
+    use_spec_traits: bool,
     // inside_ghost > 0 means we're currently visiting ghost code
     inside_ghost: u32,
+    // Widen means we're a direct subexpression in an arithmetic expression that will widen the result.
+    // (e.g. "x" or "3" in x + 3 or in x < (3), but not in f(x) + g(3)).
+    // When we see a constant in inside_arith, we preemptively give it type "int" rather than
+    // asking Rust to infer an integer type, since the inference would usually fail.
+    // We also use Widen inside "... as typ".
+    // It is inherited through parentheses, if/else, match, and blocks.
+    // Fixed is used for bitwise operations, where we use Rust's native integer literals
+    // rather than an int literal.
+    inside_arith: InsideArith,
 }
 
 fn data_mode_attrs(mode: &DataMode) -> Vec<Attribute> {
@@ -135,20 +153,22 @@ impl Visitor {
         let decreases = std::mem::take(&mut sig.decreases);
         // TODO: wrap specs inside ghost blocks
         if let Some(Requires { token, exprs }) = requires {
-            stmts.push(parse_quote_spanned!(token.span => requires([#exprs]);));
+            stmts.push(parse_quote_spanned!(token.span => builtin::requires([#exprs]);));
         }
         if let Some(Recommends { token, exprs }) = recommends {
-            stmts.push(parse_quote_spanned!(token.span => recommends([#exprs]);));
+            stmts.push(parse_quote_spanned!(token.span => builtin::recommends([#exprs]);));
         }
         if let Some(Ensures { token, exprs }) = ensures {
             if let Some((p, ty)) = ret_pat {
-                stmts.push(parse_quote_spanned!(token.span => ensures(|#p: #ty| [#exprs]);));
+                stmts.push(
+                    parse_quote_spanned!(token.span => builtin::ensures(|#p: #ty| [#exprs]);),
+                );
             } else {
-                stmts.push(parse_quote_spanned!(token.span => ensures([#exprs]);));
+                stmts.push(parse_quote_spanned!(token.span => builtin::ensures([#exprs]);));
             }
         }
         if let Some(Decreases { token, exprs }) = decreases {
-            stmts.push(parse_quote_spanned!(token.span => decreases((#exprs));));
+            stmts.push(parse_quote_spanned!(token.span => builtin::decreases((#exprs));));
         }
         sig.publish = Publish::Default;
         sig.mode = FnMode::Default;
@@ -184,10 +204,10 @@ fn chain_operators(expr: &mut Expr) {
         if let Expr::Binary(binary) = take_expr(expr) {
             let span = binary.span();
             let op = match binary.op {
-                BinOp::Le(_) => parse_quote_spanned!(span => ::builtin::chained_le),
-                BinOp::Lt(_) => parse_quote_spanned!(span => ::builtin::chained_lt),
-                BinOp::Ge(_) => parse_quote_spanned!(span => ::builtin::chained_ge),
-                BinOp::Gt(_) => parse_quote_spanned!(span => ::builtin::chained_gt),
+                BinOp::Le(_) => parse_quote_spanned!(span => ::builtin::spec_chained_le),
+                BinOp::Lt(_) => parse_quote_spanned!(span => ::builtin::spec_chained_lt),
+                BinOp::Ge(_) => parse_quote_spanned!(span => ::builtin::spec_chained_ge),
+                BinOp::Gt(_) => parse_quote_spanned!(span => ::builtin::spec_chained_gt),
                 _ => panic!("chain_operators"),
             };
             rights.push((*binary.right, op, span));
@@ -202,13 +222,13 @@ fn chain_operators(expr: &mut Expr) {
     //   expr = e0
     //   rights = [e3, e2, e1]
     // goal:
-    //   chained_cmp(chained_le(chained_le(chained_le(chained_value(e0), e1), e2), e3))
+    //   spec_chained_cmp(spec_chained_le(spec_chained_le(spec_chained_le(spec_chained_value(e0), e1), e2), e3))
     let span = expr.span();
-    *expr = parse_quote_spanned!(span => ::builtin::chained_value(#expr));
+    *expr = parse_quote_spanned!(span => ::builtin::spec_chained_value(#expr));
     while let Some((right, op, span)) = rights.pop() {
         *expr = parse_quote_spanned!(span => #op(#expr, #right));
     }
-    *expr = parse_quote_spanned!(span => ::builtin::chained_cmp(#expr));
+    *expr = parse_quote_spanned!(span => ::builtin::spec_chained_cmp(#expr));
 }
 
 impl VisitMut for Visitor {
@@ -240,14 +260,80 @@ impl VisitMut for Visitor {
             None
         };
 
+        let ghost_intrinsic = match &expr {
+            Expr::Call(ExprCall {
+                func: box Expr::Path(syn_verus::ExprPath { path: Path { segments, .. }, .. }),
+                ..
+            }) if segments.len() == 2 => {
+                if segments.first().unwrap().ident.to_string() == "builtin" {
+                    match segments.last().unwrap().ident.to_string().as_str() {
+                        "requires" | "ensures" | "recommends" | "decreases" | "invariant" => true,
+                        _ => false,
+                    }
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        };
+
+        let sub_inside_arith = match expr {
+            Expr::Paren(..) | Expr::If(..) | Expr::Match(..) | Expr::Block(..) => self.inside_arith,
+            Expr::Cast(..) => InsideArith::Widen,
+            Expr::Unary(unary) => match unary.op {
+                UnOp::Neg(..) => InsideArith::Widen,
+                UnOp::Not(..) => InsideArith::Fixed,
+                _ => InsideArith::None,
+            },
+            Expr::Binary(binary) => match binary.op {
+                BinOp::Add(..)
+                | BinOp::Sub(..)
+                | BinOp::Mul(..)
+                | BinOp::Eq(..)
+                | BinOp::Ne(..)
+                | BinOp::Lt(..)
+                | BinOp::Le(..)
+                | BinOp::Gt(..)
+                | BinOp::Ge(..) => InsideArith::Widen,
+                BinOp::Div(..) | BinOp::Rem(..) => InsideArith::Fixed,
+                BinOp::BitXor(..)
+                | BinOp::BitAnd(..)
+                | BinOp::BitOr(..)
+                | BinOp::Shl(..)
+                | BinOp::Shr(..) => InsideArith::Fixed,
+                _ => InsideArith::None,
+            },
+            Expr::Call(ExprCall {
+                func: box Expr::Path(ExprPath { path: Path { segments, .. }, .. }),
+                ..
+            }) if segments.len() == 2 => {
+                if segments.first().unwrap().ident.to_string() == "builtin" {
+                    match segments.last().unwrap().ident.to_string().as_str() {
+                        "spec_chained_value" | "spec_chained_cmp" | "spec_chained_le"
+                        | "spec_chained_lt" | "spec_chained_ge" | "spec_chained_gt" => {
+                            InsideArith::Widen
+                        }
+                        _ => InsideArith::None,
+                    }
+                } else {
+                    InsideArith::None
+                }
+            }
+            _ => InsideArith::None,
+        };
+
         let is_inside_ghost = self.inside_ghost > 0;
-        if mode_block.is_some() {
+        let is_inside_arith = self.inside_arith;
+        let use_spec_traits = self.use_spec_traits && is_inside_ghost;
+        if mode_block.is_some() || ghost_intrinsic {
             self.inside_ghost += 1;
         }
+        self.inside_arith = sub_inside_arith;
         visit_expr_mut(self, expr);
-        if mode_block.is_some() {
+        if mode_block.is_some() || ghost_intrinsic {
             self.inside_ghost -= 1;
         }
+        self.inside_arith = is_inside_arith;
 
         if let Expr::Unary(unary) = expr {
             use syn_verus::spanned::Spanned;
@@ -354,14 +440,74 @@ impl VisitMut for Visitor {
         }
 
         let (do_replace, quant) = match &expr {
+            Expr::Lit(ExprLit { lit: Lit::Int(..), .. }) if use_spec_traits => (true, false),
+            Expr::Cast(..) if use_spec_traits => (true, false),
             Expr::Unary(ExprUnary { op: UnOp::Forall(..), .. }) => (true, true),
             Expr::Unary(ExprUnary { op: UnOp::Exists(..), .. }) => (true, true),
             Expr::Unary(ExprUnary { op: UnOp::Choose(..), .. }) => (true, true),
+            Expr::Unary(ExprUnary { op: UnOp::Neg(..), .. }) if use_spec_traits => (true, false),
+            Expr::Binary(ExprBinary {
+                op:
+                    BinOp::Eq(..)
+                    | BinOp::Ne(..)
+                    | BinOp::Le(..)
+                    | BinOp::Lt(..)
+                    | BinOp::Ge(..)
+                    | BinOp::Gt(..)
+                    | BinOp::Add(..)
+                    | BinOp::Sub(..)
+                    | BinOp::Mul(..),
+                ..
+            }) if use_spec_traits => (true, false),
             Expr::Assume(..) | Expr::Assert(..) | Expr::AssertForall(..) => (true, false),
             _ => (false, false),
         };
         if do_replace {
             match take_expr(expr) {
+                Expr::Lit(ExprLit { lit: Lit::Int(lit), attrs }) => {
+                    let span = lit.span();
+                    let n = lit.base10_digits().to_string();
+                    if lit.suffix() == "" {
+                        match is_inside_arith {
+                            InsideArith::None => {
+                                // We don't know which integer type to use,
+                                // so defer the decision to type inference.
+                                *expr =
+                                    parse_quote_spanned!(span => builtin::spec_literal_integer(#n));
+                                expr.replace_attrs(attrs);
+                            }
+                            InsideArith::Widen => {
+                                // Use int inside +, -, etc., since these promote to int anyway
+                                *expr = parse_quote_spanned!(span => builtin::spec_literal_int(#n));
+                                expr.replace_attrs(attrs);
+                            }
+                            InsideArith::Fixed => {
+                                // We generally won't want int/nat literals for bitwise ops,
+                                // so use Rust's native integer literals
+                                *expr = Expr::Lit(ExprLit { lit: Lit::Int(lit), attrs });
+                            }
+                        }
+                    } else if lit.suffix() == "int" {
+                        *expr = parse_quote_spanned!(span => builtin::spec_literal_int(#n));
+                        expr.replace_attrs(attrs);
+                    } else if lit.suffix() == "nat" {
+                        *expr = parse_quote_spanned!(span => builtin::spec_literal_nat(#n));
+                        expr.replace_attrs(attrs);
+                    } else {
+                        // Has a native Rust integer suffix, so leave it as a native Rust literal
+                        *expr = Expr::Lit(ExprLit { lit: Lit::Int(lit), attrs });
+                    }
+                }
+                Expr::Cast(cast) => {
+                    use syn_verus::spanned::Spanned;
+                    let span = cast.span();
+                    let src = cast.expr;
+                    let attrs = cast.attrs;
+                    let ty = cast.ty;
+                    *expr =
+                        parse_quote_spanned!(span => builtin::spec_cast_integer::<_, #ty>(#src));
+                    expr.replace_attrs(attrs);
+                }
                 Expr::Unary(unary) if quant => {
                     use syn_verus::spanned::Spanned;
                     let span = unary.span();
@@ -383,7 +529,7 @@ impl VisitMut for Visitor {
                                     Expr::Closure(closure) => {
                                         let body = take_expr(&mut closure.body);
                                         closure.body =
-                                            parse_quote_spanned!(span => #[auto_trigger] #body);
+                                            parse_quote_spanned!(span => #[auto_trigger] (#body));
                                     }
                                     _ => panic!("expected closure for quantifier"),
                                 }
@@ -443,6 +589,65 @@ impl VisitMut for Visitor {
                     }
                     expr.replace_attrs(attrs);
                 }
+                Expr::Unary(unary) if !quant => {
+                    use syn_verus::spanned::Spanned;
+                    let span = unary.span();
+                    let attrs = unary.attrs;
+                    match unary.op {
+                        UnOp::Neg(..) => {
+                            let arg = unary.expr;
+                            *expr = parse_quote_spanned!(span => (#arg).spec_neg());
+                        }
+                        _ => panic!("unary"),
+                    }
+                    expr.replace_attrs(attrs);
+                }
+                Expr::Binary(binary) => {
+                    use syn_verus::spanned::Spanned;
+                    let span = binary.span();
+                    let attrs = binary.attrs;
+                    let left = binary.left;
+                    let right = binary.right;
+                    match binary.op {
+                        BinOp::Eq(..) => {
+                            *expr = parse_quote_spanned!(span => spec_eq(#left, #right));
+                        }
+                        BinOp::Ne(..) => {
+                            *expr = parse_quote_spanned!(span => !spec_eq(#left, #right));
+                        }
+                        BinOp::Le(..) => {
+                            *expr = parse_quote_spanned!(span => (#left).spec_le(#right));
+                        }
+                        BinOp::Lt(..) => {
+                            *expr = parse_quote_spanned!(span => (#left).spec_lt(#right));
+                        }
+                        BinOp::Ge(..) => {
+                            *expr = parse_quote_spanned!(span => (#left).spec_ge(#right));
+                        }
+                        BinOp::Gt(..) => {
+                            *expr = parse_quote_spanned!(span => (#left).spec_gt(#right));
+                        }
+                        BinOp::Add(..) => {
+                            *expr = parse_quote_spanned!(span => (#left).spec_add(#right));
+                        }
+                        BinOp::Sub(..) => {
+                            *expr = parse_quote_spanned!(span => (#left).spec_sub(#right));
+                        }
+                        BinOp::Mul(..) => {
+                            *expr = parse_quote_spanned!(span => (#left).spec_mul(#right));
+                        }
+                        BinOp::Div(..) => {
+                            *expr =
+                                parse_quote_spanned!(span => (#left).spec_euclidean_div(#right));
+                        }
+                        BinOp::Rem(..) => {
+                            *expr =
+                                parse_quote_spanned!(span => (#left).spec_euclidean_mod(#right));
+                        }
+                        _ => panic!("binary"),
+                    }
+                    expr.replace_attrs(attrs);
+                }
                 Expr::Assume(assume) => {
                     let span = assume.assume_token.span;
                     let arg = assume.expr;
@@ -469,16 +674,16 @@ impl VisitMut for Visitor {
                                 parse_quote_spanned!(span => ::builtin::assert_bit_vector(#arg));
                         }
                         (Some(_), Some((_, id)), None) if id.to_string() == "nonlinear_arith" => {
-                            *expr = parse_quote_spanned!(span => ::builtin::assert_nonlinear_by({ensures(#arg);}));
+                            *expr = parse_quote_spanned!(span => ::builtin::assert_nonlinear_by({builtin::ensures(#arg);}));
                         }
                         (Some(_), Some((_, id)), Some(box (requires, mut block)))
                             if id.to_string() == "nonlinear_arith" =>
                         {
                             let mut stmts: Vec<Stmt> = Vec::new();
                             if let Some(Requires { token, exprs }) = requires {
-                                stmts.push(parse_quote_spanned!(token.span => requires([#exprs]);));
+                                stmts.push(parse_quote_spanned!(token.span => builtin::requires([#exprs]);));
                             }
-                            stmts.push(parse_quote_spanned!(span => ensures(#arg);));
+                            stmts.push(parse_quote_spanned!(span => builtin::ensures(#arg);));
                             block.stmts.splice(0..0, stmts);
                             *expr = parse_quote_spanned!(span => {::builtin::assert_nonlinear_by(#block);});
                         }
@@ -500,37 +705,36 @@ impl VisitMut for Visitor {
                     let mut block = assert.body;
                     let mut stmts: Vec<Stmt> = Vec::new();
                     if let Some((_, rhs)) = assert.implies {
-                        stmts.push(parse_quote_spanned!(span => requires(#arg);));
-                        stmts.push(parse_quote_spanned!(span => ensures(#rhs);));
+                        stmts.push(parse_quote_spanned!(span => builtin::requires(#arg);));
+                        stmts.push(parse_quote_spanned!(span => builtin::ensures(#rhs);));
                     } else {
-                        stmts.push(parse_quote_spanned!(span => ensures(#arg);));
+                        stmts.push(parse_quote_spanned!(span => builtin::ensures(#arg);));
                     }
                     block.stmts.splice(0..0, stmts);
                     *expr = parse_quote_spanned!(span => {::builtin::assert_forall_by(|#inputs| #block);});
                     expr.replace_attrs(attrs);
                 }
-                _ => panic!("expected assert/assume"),
+                _ => panic!("expected to replace expression"),
             }
         }
     }
 
     fn visit_expr_while_mut(&mut self, expr_while: &mut ExprWhile) {
-        visit_expr_while_mut(self, expr_while);
         let invariants = std::mem::take(&mut expr_while.invariant);
         let decreases = std::mem::take(&mut expr_while.decreases);
         let mut stmts: Vec<Stmt> = Vec::new();
         // TODO: wrap specs inside ghost blocks
         if let Some(Invariant { token, exprs }) = invariants {
-            stmts.push(parse_quote_spanned!(token.span => invariant([#exprs]);));
+            stmts.push(parse_quote_spanned!(token.span => builtin::invariant([#exprs]);));
         }
         if let Some(Decreases { token, exprs }) = decreases {
-            stmts.push(parse_quote_spanned!(token.span => decreases((#exprs));));
+            stmts.push(parse_quote_spanned!(token.span => builtin::decreases((#exprs));));
         }
         expr_while.body.stmts.splice(0..0, stmts);
+        visit_expr_while_mut(self, expr_while);
     }
 
     fn visit_expr_loop_mut(&mut self, expr_loop: &mut ExprLoop) {
-        visit_expr_loop_mut(self, expr_loop);
         let requires = std::mem::take(&mut expr_loop.requires);
         let invariants = std::mem::take(&mut expr_loop.invariant);
         let ensures = std::mem::take(&mut expr_loop.ensures);
@@ -538,18 +742,19 @@ impl VisitMut for Visitor {
         let mut stmts: Vec<Stmt> = Vec::new();
         // TODO: wrap specs inside ghost blocks
         if let Some(Requires { token, exprs }) = requires {
-            stmts.push(parse_quote_spanned!(token.span => requires([#exprs]);));
+            stmts.push(parse_quote_spanned!(token.span => builtin::requires([#exprs]);));
         }
         if let Some(Invariant { token, exprs }) = invariants {
-            stmts.push(parse_quote_spanned!(token.span => invariant([#exprs]);));
+            stmts.push(parse_quote_spanned!(token.span => builtin::invariant([#exprs]);));
         }
         if let Some(Ensures { token, exprs }) = ensures {
-            stmts.push(parse_quote_spanned!(token.span => ensures([#exprs]);));
+            stmts.push(parse_quote_spanned!(token.span => builtin::ensures([#exprs]);));
         }
         if let Some(Decreases { token, exprs }) = decreases {
-            stmts.push(parse_quote_spanned!(token.span => decreases((#exprs));));
+            stmts.push(parse_quote_spanned!(token.span => builtin::decreases((#exprs));));
         }
         expr_loop.body.stmts.splice(0..0, stmts);
+        visit_expr_loop_mut(self, expr_loop);
     }
 
     fn visit_local_mut(&mut self, local: &mut Local) {
@@ -744,11 +949,14 @@ impl quote::ToTokens for MacroInvoke {
     }
 }
 
-pub(crate) fn rewrite_items(stream: proc_macro::TokenStream) -> proc_macro::TokenStream {
+pub(crate) fn rewrite_items(
+    stream: proc_macro::TokenStream,
+    use_spec_traits: bool,
+) -> proc_macro::TokenStream {
     use quote::ToTokens;
     let items: Items = parse_macro_input!(stream as Items);
     let mut new_stream = TokenStream::new();
-    let mut visitor = Visitor { inside_ghost: 0 };
+    let mut visitor = Visitor { use_spec_traits, inside_ghost: 0, inside_arith: InsideArith::None };
     for mut item in items.items {
         visitor.visit_item_mut(&mut item);
         item.to_tokens(&mut new_stream);
@@ -763,7 +971,11 @@ pub(crate) fn rewrite_expr(
     use quote::ToTokens;
     let mut expr: Expr = parse_macro_input!(stream as Expr);
     let mut new_stream = TokenStream::new();
-    let mut visitor = Visitor { inside_ghost: if inside_ghost { 1 } else { 0 } };
+    let mut visitor = Visitor {
+        use_spec_traits: false,
+        inside_ghost: if inside_ghost { 1 } else { 0 },
+        inside_arith: InsideArith::None,
+    };
     visitor.visit_expr_mut(&mut expr);
     expr.to_tokens(&mut new_stream);
     proc_macro::TokenStream::from(new_stream)
@@ -833,7 +1045,11 @@ pub(crate) fn proof_macro_exprs(
     let stream = rejoin_tokens(stream);
     let mut invoke: MacroInvoke = parse_macro_input!(stream as MacroInvoke);
     let mut new_stream = TokenStream::new();
-    let mut visitor = Visitor { inside_ghost: if inside_ghost { 1 } else { 0 } };
+    let mut visitor = Visitor {
+        use_spec_traits: false,
+        inside_ghost: if inside_ghost { 1 } else { 0 },
+        inside_arith: InsideArith::None,
+    };
     for element in &mut invoke.elements.elements {
         match element {
             MacroElement::Expr(expr) => visitor.visit_expr_mut(expr),

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -456,7 +456,9 @@ impl VisitMut for Visitor {
                     | BinOp::Gt(..)
                     | BinOp::Add(..)
                     | BinOp::Sub(..)
-                    | BinOp::Mul(..),
+                    | BinOp::Mul(..)
+                    | BinOp::Div(..)
+                    | BinOp::Rem(..),
                 ..
             }) if use_spec_traits => (true, false),
             Expr::Assume(..) | Expr::Assert(..) | Expr::AssertForall(..) => (true, false),

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -977,7 +977,12 @@ pub(crate) fn rewrite_items(
     use quote::ToTokens;
     let items: Items = parse_macro_input!(stream as Items);
     let mut new_stream = TokenStream::new();
-    let mut visitor = Visitor { use_spec_traits, inside_ghost: 0, inside_arith: InsideArith::None, rustdoc: env_rustdoc() };
+    let mut visitor = Visitor {
+        use_spec_traits,
+        inside_ghost: 0,
+        inside_arith: InsideArith::None,
+        rustdoc: env_rustdoc(),
+    };
     for mut item in items.items {
         visitor.visit_item_mut(&mut item);
         item.to_tokens(&mut new_stream);

--- a/source/pervasive/atomic.rs
+++ b/source/pervasive/atomic.rs
@@ -254,7 +254,7 @@ macro_rules! atomic_integer_methods {
             ]);
             ensures(|ret: $value_ty| equal(old(perm).value, ret)
                 && perm.patomic == old(perm).patomic
-                && perm.value == $wrap_add(old(perm).value, n)
+                && perm.value as int == $wrap_add(old(perm).value as int, n as int)
             );
             opens_invariants_none();
 
@@ -270,7 +270,7 @@ macro_rules! atomic_integer_methods {
             ]);
             ensures(|ret: $value_ty| equal(old(perm).value, ret)
                 && perm.patomic == old(perm).patomic
-                && perm.value == $wrap_sub(old(perm).value, n)
+                && perm.value as int == $wrap_sub(old(perm).value as int, n as int)
             );
             opens_invariants_none();
 

--- a/source/pervasive/map.rs
+++ b/source/pervasive/map.rs
@@ -7,7 +7,7 @@ use crate::pervasive::*;
 #[allow(unused_imports)]
 use crate::pervasive::set::*;
 
-verus! {
+verus2! {
 
 /// `Map<K, V>` is an abstract map type for specifications.
 /// To use a "map" in compiled code, use an `exec` type like HashMap (TODO)

--- a/source/pervasive/modes.rs
+++ b/source/pervasive/modes.rs
@@ -82,7 +82,7 @@ impl<A> std::ops::Deref for Tracked<A> {
     }
 }
 
-verus! {
+verus2! {
 
 pub tracked struct TrackedAndGhost<T, G>(
     pub tracked T,

--- a/source/pervasive/seq.rs
+++ b/source/pervasive/seq.rs
@@ -5,7 +5,7 @@ use builtin_macros::*;
 #[allow(unused_imports)]
 use crate::pervasive::*;
 
-verus! {
+verus2! {
 
 /// `Seq<A>` is a sequence type for specifications.
 /// To use a "sequence" in compiled code, use an `exec` type like [`vec::Vec`]

--- a/source/pervasive/seq_lib.rs
+++ b/source/pervasive/seq_lib.rs
@@ -7,7 +7,7 @@ use crate::pervasive::*;
 #[allow(unused_imports)]
 use crate::pervasive::seq::*;
 
-verus! {
+verus2! {
 
 impl<A> Seq<A> {
     /// Applies the function `f` to each element of the sequence, and returns
@@ -20,7 +20,7 @@ impl<A> Seq<A> {
 
     // TODO is_sorted -- extract from summer_school e22
     pub open spec fn contains(self, needle: A) -> bool {
-        exists|i: nat| i < self.len() && self.index(i) === needle
+        exists|i: int| 0 <= i < self.len() && self.index(i) === needle
     }
 
     /// Drops the last element of a sequence and returns a sequence whose length is

--- a/source/pervasive/set.rs
+++ b/source/pervasive/set.rs
@@ -7,7 +7,7 @@ use crate::pervasive::*;
 #[allow(unused_imports)]
 use crate::pervasive::map::*;
 
-verus! {
+verus2! {
 
 /// `Set<A>` is a set type for specifications.
 ///

--- a/source/pervasive/set_lib.rs
+++ b/source/pervasive/set_lib.rs
@@ -7,7 +7,7 @@ use crate::pervasive::*;
 #[allow(unused_imports)]
 use crate::pervasive::set::*;
 
-verus! {
+verus2! {
 
 impl<A> Set<A> {
     pub open spec fn map<B, F: Fn(A) -> B>(self, f: F) -> Set<B> {

--- a/source/pervasive/state_machine_internal.rs
+++ b/source/pervasive/state_machine_internal.rs
@@ -117,7 +117,7 @@ pub fn assert_general_guard_map(b: bool) { requires(b); ensures(b); }
 impl<A> Seq<A> {
     #[spec] #[verifier(publish)]
     pub fn update_at_index(self, i: int, a: A) -> Self {
-        recommends(0 <= i && i < self.len());
+        recommends(0 <= i && i < self.len() as int);
 
         self.update(i, a)
     }

--- a/source/pervasive/vec.rs
+++ b/source/pervasive/vec.rs
@@ -7,7 +7,7 @@ use crate::pervasive::*;
 #[allow(unused_imports)]
 use crate::pervasive::seq::*;
 
-verus! {
+verus2! {
 
 #[verifier(external_body)]
 pub struct Vec<#[verifier(strictly_positive)] A> {
@@ -59,7 +59,7 @@ impl<A> Vec<A> {
         requires
             i < self.view().len(),
         ensures
-            *r === self.view().index(i),
+            *r === self.view().index(i as int),
     {
         &self.vec[i]
     }
@@ -69,7 +69,7 @@ impl<A> Vec<A> {
         requires
             i < old(self).view().len(),
         ensures
-            self.view() === old(self).view().update(i, a),
+            self.view() === old(self).view().update(i as int, a),
     {
         self.vec[i] = a;
     }

--- a/source/rust_verify/example/integers.rs
+++ b/source/rust_verify/example/integers.rs
@@ -12,12 +12,12 @@ spec fn add1_int(i: int) -> int {
 }
 
 spec fn add1_nat(i: nat) -> nat {
-    (i + 1) as nat
+    i + 1
 }
 
 #[verifier(opaque)]
 spec fn add1_nat_opaque(i: nat) -> nat {
-    (i + 1) as nat
+    i + 1
 }
 
 proof fn test0() -> (n:nat)

--- a/source/rust_verify/example/integers.rs
+++ b/source/rust_verify/example/integers.rs
@@ -3,7 +3,7 @@ use builtin::*;
 mod pervasive;
 use pervasive::*;
 
-verus! {
+verus2! {
 
 fn main() {}
 
@@ -12,12 +12,12 @@ spec fn add1_int(i: int) -> int {
 }
 
 spec fn add1_nat(i: nat) -> nat {
-    i + 1
+    (i + 1) as nat
 }
 
 #[verifier(opaque)]
 spec fn add1_nat_opaque(i: nat) -> nat {
-    i + 1
+    (i + 1) as nat
 }
 
 proof fn test0() -> (n:nat)
@@ -30,11 +30,11 @@ proof fn test1(i: int, n: nat, u: u8) {
     assert(n >= 0);
     assert(u >= 0);
     assert(n + n >= 0);
-    assert(((u + u) as int) < 256);
-    assert(u < 100 >>= ((u + u) as int) < 250);
-    assert(add1_int(u) == u as int + 1);
+    assert((add(u, u) as int) < 256);
+    assert(u < 100 >>= (add(u, u) as int) < 250);
+    assert(add1_int(u as int) == u as int + 1);
     // assert(add1_int(u) == (u + 1) as int); // FAILS
-    assert(add1_nat(u) == u as nat + 1);
+    assert(add1_nat(u as nat) == u as nat + 1);
     // assert((u as int) < 256 >>= u < 256); // FAILS, because 256 is a u8 in u < 256
     let n0 = test0();
     assert(n0 >= 0);

--- a/source/rust_verify/example/quantifiers.rs
+++ b/source/rust_verify/example/quantifiers.rs
@@ -5,7 +5,7 @@ mod pervasive;
 
 fn main() {}
 
-verus! {
+verus2! {
 
 spec fn f1(i: int, j: int) -> bool {
     i <= j
@@ -109,10 +109,10 @@ spec fn tr(i: int) -> bool {
 }
 
 fn test_nat() {
-    assert(forall|i: nat| i >= 0 && tr(i));
+    assert(forall|i: nat| i >= 0 && tr(i as int));
     assert(tr(300));
-    assert(exists|i: nat| i >= 0 && tr(i));
-    assert(exists|i: u16| i >= 300 && tr(i));
+    assert(exists|i: nat| i >= 0 && tr(i as int));
+    assert(exists|i: u16| i >= 300 && tr(i as int));
 }
 
 }

--- a/source/rust_verify/example/syntax.rs
+++ b/source/rust_verify/example/syntax.rs
@@ -168,13 +168,13 @@ proof fn test5_bound_checking(x: u32, y: u32, z: u32)
         y <= 0xffff,
         z <= 0xffff,
 {
-    assert((x as int) * (z as int) == ((x * z) as int)) by(nonlinear_arith)
+    assert(x * z == mul(x, z)) by(nonlinear_arith)
         requires
             x <= 0xffff,
             z <= 0xffff,
     {
-        assert(0 <= (x as int) * (z as int));
-        assert((x as int) * (z as int) <= 0xffff * 0xffff);
+        assert(0 <= x * z);
+        assert(x * z <= 0xffff * 0xffff);
     }
 }
 

--- a/source/rust_verify/example/test.rs
+++ b/source/rust_verify/example/test.rs
@@ -3,7 +3,7 @@ use builtin::*;
 mod pervasive;
 use pervasive::*;
 
-verus! {
+verus2! {
 
 pub fn foo(a: u64) -> u64
     requires a < 100

--- a/source/rust_verify/example/vectors.rs
+++ b/source/rust_verify/example/vectors.rs
@@ -6,7 +6,7 @@ mod pervasive;
 #[allow(unused_imports)]
 use crate::pervasive::{*, vec::*, seq::*, modes::*};
 
-verus! {
+verus2! {
 
 fn binary_search(v: &Vec<u64>, k: u64) -> (r: usize)
     requires
@@ -14,7 +14,7 @@ fn binary_search(v: &Vec<u64>, k: u64) -> (r: usize)
         exists|i:int| 0 <= i < v.len() && k == v.index(i),
     ensures
         r < v.len(),
-        k == v.index(r),
+        k == v.index(r as int),
 {
     let mut i1: usize = 0;
     let mut i2: usize = v.len() - 1;
@@ -24,7 +24,7 @@ fn binary_search(v: &Vec<u64>, k: u64) -> (r: usize)
             exists|i:int| i1 <= i <= i2 && k == v.index(i),
             forall|i:int, j:int| 0 <= i <= j < v.len() ==> v.index(i) <= v.index(j),
     {
-        let d: Ghost<usize> = ghost(i2 - i1);
+        let d: Ghost<int> = ghost(i2 - i1);
 
         let ix = i1 + (i2 - i1) / 2;
         if *v.index(ix) < k {

--- a/source/rust_verify/src/config.rs
+++ b/source/rust_verify/src/config.rs
@@ -35,6 +35,7 @@ pub struct Args {
     pub no_verify: bool,
     pub no_lifetime: bool,
     pub no_auto_recommends_check: bool,
+    pub no_enhanced_typecheck: bool,
     pub time: bool,
     pub rlimit: u32,
     pub smt_options: Vec<(String, String)>,
@@ -74,6 +75,7 @@ pub fn parse_args(program: &String, args: impl Iterator<Item = String>) -> (Args
     const OPT_NO_VERIFY: &str = "no-verify";
     const OPT_NO_LIFETIME: &str = "no-lifetime";
     const OPT_NO_AUTO_RECOMMENDS_CHECK: &str = "no-auto-recommends-check";
+    const OPT_NO_ENHANCED_TYPECHECK: &str = "no-enhanced-typecheck";
     const OPT_TIME: &str = "time";
     const OPT_RLIMIT: &str = "rlimit";
     const OPT_SMT_OPTION: &str = "smt-option";
@@ -122,6 +124,7 @@ pub fn parse_args(program: &String, args: impl Iterator<Item = String>) -> (Args
         OPT_NO_AUTO_RECOMMENDS_CHECK,
         "Do not automatically check recommends after verification failures",
     );
+    opts.optflag("", OPT_NO_ENHANCED_TYPECHECK, "Disable extensions to Rust type checker");
     opts.optflag("", OPT_TIME, "Measure and report time taken");
     opts.optopt(
         "",
@@ -199,6 +202,7 @@ pub fn parse_args(program: &String, args: impl Iterator<Item = String>) -> (Args
         no_verify: matches.opt_present(OPT_NO_VERIFY),
         no_lifetime: matches.opt_present(OPT_NO_LIFETIME),
         no_auto_recommends_check: matches.opt_present(OPT_NO_AUTO_RECOMMENDS_CHECK),
+        no_enhanced_typecheck: matches.opt_present(OPT_NO_ENHANCED_TYPECHECK),
         time: matches.opt_present(OPT_TIME),
         rlimit: matches
             .opt_get::<u32>(OPT_RLIMIT)

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -1038,7 +1038,11 @@ fn fn_call_to_vir<'tcx>(
             panic!("internal error")
         };
         let e = mk_expr(ExprX::Binary(vop, lhs, rhs));
-        if is_arith_binary { Ok(mk_ty_clip(&expr_typ(), &e)) } else { Ok(e) }
+        if is_arith_binary || is_spec_arith_binary {
+            Ok(mk_ty_clip(&expr_typ(), &e))
+        } else {
+            Ok(e)
+        }
     } else if is_chained_value {
         unsupported_err_unless!(len == 1, expr.span, "spec_chained_value", &args);
         unsupported_err_unless!(

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -440,9 +440,12 @@ fn fn_call_to_vir<'tcx>(
     let is_ge = f_name == "core::cmp::PartialOrd::ge";
     let is_lt = f_name == "core::cmp::PartialOrd::lt";
     let is_gt = f_name == "core::cmp::PartialOrd::gt";
-    let is_add = f_name == "std::ops::Add::add" || f_name == "builtin::add";
-    let is_sub = f_name == "std::ops::Sub::sub" || f_name == "builtin::sub";
-    let is_mul = f_name == "std::ops::Mul::mul" || f_name == "builtin::mul";
+    let is_builtin_add = f_name == "builtin::add";
+    let is_builtin_sub = f_name == "builtin::sub";
+    let is_builtin_mul = f_name == "builtin::mul";
+    let is_add = f_name == "std::ops::Add::add";
+    let is_sub = f_name == "std::ops::Sub::sub";
+    let is_mul = f_name == "std::ops::Mul::mul";
     let is_spec_eq = f_name == "builtin::spec_eq";
     let is_spec_le = f_name == "builtin::SpecOrd::spec_le";
     let is_spec_ge = f_name == "builtin::SpecOrd::spec_ge";
@@ -477,7 +480,8 @@ fn fn_call_to_vir<'tcx>(
     let is_quant = is_forall || is_exists || is_forall_arith;
     let is_directive = is_extra_dependency || is_hide || is_reveal || is_reveal_fuel;
     let is_cmp = is_equal || is_eq || is_ne || is_le || is_ge || is_lt || is_gt;
-    let is_arith_binary = is_add || is_sub || is_mul;
+    let is_arith_binary =
+        is_builtin_add || is_builtin_sub || is_builtin_mul || is_add || is_sub || is_mul;
     let is_spec_cmp = is_spec_eq || is_spec_le || is_spec_ge || is_spec_lt || is_spec_gt;
     let is_spec_arith_binary =
         is_spec_add || is_spec_sub || is_spec_mul || is_spec_euclidean_div || is_spec_euclidean_mod;
@@ -559,6 +563,9 @@ fn fn_call_to_vir<'tcx>(
         &name,
         is_spec
             || is_spec_op
+            || is_builtin_add
+            || is_builtin_sub
+            || is_builtin_mul
             || is_quant
             || is_directive
             || is_choose
@@ -1009,11 +1016,11 @@ fn fn_call_to_vir<'tcx>(
             BinaryOp::Inequality(InequalityOp::Lt)
         } else if is_gt || is_spec_gt {
             BinaryOp::Inequality(InequalityOp::Gt)
-        } else if is_add {
+        } else if is_add || is_builtin_add {
             BinaryOp::Arith(ArithOp::Add, Some(bctx.ctxt.infer_mode()))
-        } else if is_sub {
+        } else if is_sub || is_builtin_sub {
             BinaryOp::Arith(ArithOp::Sub, Some(bctx.ctxt.infer_mode()))
-        } else if is_mul {
+        } else if is_mul || is_builtin_mul {
             BinaryOp::Arith(ArithOp::Mul, Some(bctx.ctxt.infer_mode()))
         } else if is_spec_add {
             BinaryOp::Arith(ArithOp::Add, None)

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -17,7 +17,7 @@ use crate::util::{
 use crate::{unsupported, unsupported_err, unsupported_err_unless, unsupported_unless};
 use air::ast::{Binder, BinderX};
 use air::ast_util::str_ident;
-use rustc_ast::{Attribute, BorrowKind, Mutability};
+use rustc_ast::{Attribute, BorrowKind, LitKind, Mutability};
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::{
     BinOpKind, BindingAnnotation, Block, Destination, Expr, ExprKind, Guard, Local, LoopSource,
@@ -26,6 +26,7 @@ use rustc_hir::{
 use rustc_middle::ty::subst::GenericArgKind;
 use rustc_middle::ty::{PredicateKind, TyCtxt, TyKind};
 use rustc_span::def_id::DefId;
+use rustc_span::source_map::Spanned;
 use rustc_span::Span;
 use std::sync::Arc;
 use vir::ast::{
@@ -284,6 +285,24 @@ fn mk_ty_clip<'tcx>(typ: &Typ, expr: &vir::ast::Expr) -> vir::ast::Expr {
     mk_clip(&get_range(typ), expr)
 }
 
+fn check_lit_int(span: Span, in_negative_literal: bool, i: u128, typ: &Typ) -> Result<(), VirErr> {
+    let i_bump = if in_negative_literal { 1 } else { 0 };
+    if let TypX::Int(range) = **typ {
+        match range {
+            IntRange::Int | IntRange::Nat => Ok(()),
+            IntRange::U(n) if n == 128 || (n < 128 && i < (1u128 << n)) => Ok(()),
+            IntRange::I(n) if n - 1 < 128 && i < (1u128 << (n - 1)) + i_bump => Ok(()),
+            IntRange::USize if i < (1u128 << vir::def::ARCH_SIZE_MIN_BITS) => Ok(()),
+            IntRange::ISize if i < (1u128 << (vir::def::ARCH_SIZE_MIN_BITS - 1)) + i_bump => Ok(()),
+            _ => {
+                return err_span_str(span, "integer literal out of range");
+            }
+        }
+    } else {
+        return err_span_str(span, "expected integer type");
+    }
+}
+
 pub(crate) fn expr_to_vir<'tcx>(
     bctx: &BodyCtxt<'tcx>,
     expr: &Expr<'tcx>,
@@ -342,6 +361,7 @@ fn fn_call_to_vir<'tcx>(
     fn_span: Span,
     args_slice: &'tcx [Expr<'tcx>],
     autoview_typ: Option<&Typ>,
+    defined_locally: bool,
 ) -> Result<vir::ast::Expr, VirErr> {
     let mut args: Vec<&'tcx Expr<'tcx>> = args_slice.iter().collect();
 
@@ -398,12 +418,12 @@ fn fn_call_to_vir<'tcx>(
     let is_choose_tuple = f_name == "builtin::choose_tuple";
     let is_with_triggers = f_name == "builtin::with_triggers";
     let is_equal = f_name == "builtin::equal";
-    let is_chained_value = f_name == "builtin::chained_value";
-    let is_chained_le = f_name == "builtin::chained_le";
-    let is_chained_lt = f_name == "builtin::chained_lt";
-    let is_chained_ge = f_name == "builtin::chained_ge";
-    let is_chained_gt = f_name == "builtin::chained_gt";
-    let is_chained_cmp = f_name == "builtin::chained_cmp";
+    let is_chained_value = f_name == "builtin::spec_chained_value";
+    let is_chained_le = f_name == "builtin::spec_chained_le";
+    let is_chained_lt = f_name == "builtin::spec_chained_lt";
+    let is_chained_ge = f_name == "builtin::spec_chained_ge";
+    let is_chained_gt = f_name == "builtin::spec_chained_gt";
+    let is_chained_cmp = f_name == "builtin::spec_chained_cmp";
     let is_hide = f_name == "builtin::hide";
     let is_extra_dependency = f_name == "builtin::extra_dependency";
     let is_reveal = f_name == "builtin::reveal";
@@ -420,9 +440,24 @@ fn fn_call_to_vir<'tcx>(
     let is_ge = f_name == "core::cmp::PartialOrd::ge";
     let is_lt = f_name == "core::cmp::PartialOrd::lt";
     let is_gt = f_name == "core::cmp::PartialOrd::gt";
-    let is_add = f_name == "core::ops::arith::Add::add";
-    let is_sub = f_name == "core::ops::arith::Sub::sub";
-    let is_mul = f_name == "core::ops::arith::Mul::mul";
+    let is_add = f_name == "std::ops::Add::add" || f_name == "builtin::add";
+    let is_sub = f_name == "std::ops::Sub::sub" || f_name == "builtin::sub";
+    let is_mul = f_name == "std::ops::Mul::mul" || f_name == "builtin::mul";
+    let is_spec_eq = f_name == "builtin::spec_eq";
+    let is_spec_le = f_name == "builtin::SpecOrd::spec_le";
+    let is_spec_ge = f_name == "builtin::SpecOrd::spec_ge";
+    let is_spec_lt = f_name == "builtin::SpecOrd::spec_lt";
+    let is_spec_gt = f_name == "builtin::SpecOrd::spec_gt";
+    let is_spec_neg = f_name == "builtin::SpecNeg::spec_neg";
+    let is_spec_add = f_name == "builtin::SpecAdd::spec_add";
+    let is_spec_sub = f_name == "builtin::SpecSub::spec_sub";
+    let is_spec_mul = f_name == "builtin::SpecMul::spec_mul";
+    let is_spec_euclidean_div = f_name == "builtin::SpecEuclideanDiv::spec_euclidean_div";
+    let is_spec_euclidean_mod = f_name == "builtin::SpecEuclideanMod::spec_euclidean_mod";
+    let is_spec_literal_integer = f_name == "builtin::spec_literal_integer";
+    let is_spec_literal_int = f_name == "builtin::spec_literal_int";
+    let is_spec_literal_nat = f_name == "builtin::spec_literal_nat";
+    let is_spec_cast_integer = f_name == "builtin::spec_cast_integer";
     let is_panic = f_name == "core::panicking::panic";
     let is_alloc_ghost = f_name == "pervasive::modes::Ghost::<A>::exec";
     let is_alloc_tracked = f_name == "pervasive::modes::Tracked::<A>::exec";
@@ -443,7 +478,20 @@ fn fn_call_to_vir<'tcx>(
     let is_directive = is_extra_dependency || is_hide || is_reveal || is_reveal_fuel;
     let is_cmp = is_equal || is_eq || is_ne || is_le || is_ge || is_lt || is_gt;
     let is_arith_binary = is_add || is_sub || is_mul;
+    let is_spec_cmp = is_spec_eq || is_spec_le || is_spec_ge || is_spec_lt || is_spec_gt;
+    let is_spec_arith_binary =
+        is_spec_add || is_spec_sub || is_spec_mul || is_spec_euclidean_div || is_spec_euclidean_mod;
     let is_chained_ineq = is_chained_le || is_chained_lt || is_chained_ge || is_chained_gt;
+    let is_spec_literal = is_spec_literal_int || is_spec_literal_nat || is_spec_literal_integer;
+    let is_spec_op = is_spec_cast_integer
+        || is_spec_cmp
+        || is_spec_arith_binary
+        || is_spec_neg
+        || is_chained_ineq
+        || is_spec_literal
+        || is_chained_cmp
+        || is_chained_value
+        || is_chained_ineq;
 
     // These functions are all no-ops in the SMT encoding, so we don't emit any VIR
     let is_ignored_fn = f_name == "std::box::Box::<T>::new"
@@ -510,6 +558,7 @@ fn fn_call_to_vir<'tcx>(
         fn_span,
         &name,
         is_spec
+            || is_spec_op
             || is_quant
             || is_directive
             || is_choose
@@ -529,6 +578,36 @@ fn fn_call_to_vir<'tcx>(
     let mk_expr = |x: ExprX| spanned_typed_new(expr.span, &expr_typ(), x);
     let mk_expr_span = |span: Span, x: ExprX| spanned_typed_new(span, &expr_typ(), x);
 
+    if is_spec_literal_int || is_spec_literal_nat || is_spec_literal_integer {
+        unsupported_err_unless!(len == 1, expr.span, "expected spec_literal_*", &args);
+        let arg = &args[0];
+        let is_num = |s: &String| s.chars().count() > 0 && s.chars().all(|c| c.is_digit(10));
+        match &args[0] {
+            Expr { kind: ExprKind::Lit(Spanned { node: LitKind::Str(s, _), .. }), .. }
+                if is_num(&s.to_string()) =>
+            {
+                // TODO: negative literals for is_spec_literal_int and is_spec_literal_integer
+                if is_spec_literal_integer {
+                    // TODO: big integers for int, nat
+                    let i: u128 = match s.to_string().parse() {
+                        Ok(i) => i,
+                        Err(err) => {
+                            return err_span_string(
+                                arg.span,
+                                format!("integer out of range {}", err),
+                            );
+                        }
+                    };
+                    let in_negative_literal = false;
+                    check_lit_int(expr.span, in_negative_literal, i, &expr_typ())?
+                }
+                return Ok(mk_expr(ExprX::Const(vir::ast::Constant::Nat(Arc::new(s.to_string())))));
+            }
+            _ => {
+                return err_span_str(arg.span, "spec_literal_* requires a string literal");
+            }
+        }
+    }
     if is_no_method_body {
         return Ok(mk_expr(ExprX::Header(Arc::new(HeaderExprX::NoMethodBody))));
     }
@@ -767,6 +846,7 @@ fn fn_call_to_vir<'tcx>(
     } else {
         Box::new(std::iter::repeat(None))
     };
+
     let mut vir_args = args
         .iter()
         .zip(inputs)
@@ -849,11 +929,26 @@ fn fn_call_to_vir<'tcx>(
         None => {}
     }
 
+    let is_smt_unary = if is_spec_neg {
+        match *typ_of_node(bctx, &args[0].hir_id, false) {
+            TypX::Int(_) => true,
+            _ => false,
+        }
+    } else {
+        false
+    };
+
     let is_smt_binary = if is_equal {
         true
+    } else if is_spec_eq {
+        if is_smt_equality(bctx, expr.span, &args[0].hir_id, &args[1].hir_id) {
+            true
+        } else {
+            return err_span_str(expr.span, "types must be compatible to use == or !=");
+        }
     } else if is_eq || is_ne {
         is_smt_equality(bctx, expr.span, &args[0].hir_id, &args[1].hir_id)
-    } else if is_cmp || is_arith_binary || is_implies {
+    } else if is_cmp || is_arith_binary || is_implies || is_spec_cmp || is_spec_arith_binary {
         is_smt_arith(bctx, &args[0].hir_id, &args[1].hir_id)
     } else {
         false
@@ -872,30 +967,64 @@ fn fn_call_to_vir<'tcx>(
     } else if is_admit {
         unsupported_err_unless!(len == 0, expr.span, "expected admit", args);
         Ok(mk_expr(ExprX::Admit))
+    } else if is_spec_cast_integer {
+        unsupported_err_unless!(len == 1, expr.span, "spec_cast_integer", args);
+        let source_vir = vir_args[0].clone();
+        let source_ty = &source_vir.typ;
+        let to_ty = expr_typ();
+        match (&**source_ty, &*to_ty) {
+            (TypX::Int(_), TypX::Int(_)) => return Ok(mk_ty_clip(&to_ty, &source_vir)),
+            _ => {
+                return err_span_str(
+                    expr.span,
+                    "Verus currently only supports casts from integer types to integer types",
+                );
+            }
+        }
+    } else if is_smt_unary {
+        unsupported_err_unless!(len == 1, expr.span, "expected unary op", args);
+        let varg = vir_args[0].clone();
+        if is_spec_neg {
+            let zero_const = vir::ast::Constant::Nat(Arc::new("0".to_string()));
+            let zero = mk_expr(ExprX::Const(zero_const));
+            Ok(mk_expr(ExprX::Binary(BinaryOp::Arith(ArithOp::Sub, None), zero, varg)))
+        } else {
+            panic!("internal error")
+        }
     } else if is_smt_binary {
         unsupported_err_unless!(len == 2, expr.span, "expected binary op", args);
         let lhs = vir_args[0].clone();
         let rhs = vir_args[1].clone();
-        let vop = if is_equal {
+        let vop = if is_equal || is_spec_eq {
             BinaryOp::Eq(Mode::Spec)
         } else if is_eq {
             BinaryOp::Eq(Mode::Exec)
         } else if is_ne {
             BinaryOp::Ne
-        } else if is_le {
+        } else if is_le || is_spec_le {
             BinaryOp::Inequality(InequalityOp::Le)
-        } else if is_ge {
+        } else if is_ge || is_spec_ge {
             BinaryOp::Inequality(InequalityOp::Ge)
-        } else if is_lt {
+        } else if is_lt || is_spec_lt {
             BinaryOp::Inequality(InequalityOp::Lt)
-        } else if is_gt {
+        } else if is_gt || is_spec_gt {
             BinaryOp::Inequality(InequalityOp::Gt)
         } else if is_add {
-            BinaryOp::Arith(ArithOp::Add, bctx.ctxt.infer_mode())
+            BinaryOp::Arith(ArithOp::Add, Some(bctx.ctxt.infer_mode()))
         } else if is_sub {
-            BinaryOp::Arith(ArithOp::Sub, bctx.ctxt.infer_mode())
+            BinaryOp::Arith(ArithOp::Sub, Some(bctx.ctxt.infer_mode()))
         } else if is_mul {
-            BinaryOp::Arith(ArithOp::Mul, bctx.ctxt.infer_mode())
+            BinaryOp::Arith(ArithOp::Mul, Some(bctx.ctxt.infer_mode()))
+        } else if is_spec_add {
+            BinaryOp::Arith(ArithOp::Add, None)
+        } else if is_spec_sub {
+            BinaryOp::Arith(ArithOp::Sub, None)
+        } else if is_spec_mul {
+            BinaryOp::Arith(ArithOp::Mul, None)
+        } else if is_spec_euclidean_div {
+            BinaryOp::Arith(ArithOp::EuclideanDiv, None)
+        } else if is_spec_euclidean_mod {
+            BinaryOp::Arith(ArithOp::EuclideanMod, None)
         } else if is_implies {
             BinaryOp::Implies
         } else {
@@ -904,7 +1033,7 @@ fn fn_call_to_vir<'tcx>(
         let e = mk_expr(ExprX::Binary(vop, lhs, rhs));
         if is_arith_binary { Ok(mk_ty_clip(&expr_typ(), &e)) } else { Ok(e) }
     } else if is_chained_value {
-        unsupported_err_unless!(len == 1, expr.span, "chained_value", &args);
+        unsupported_err_unless!(len == 1, expr.span, "spec_chained_value", &args);
         unsupported_err_unless!(
             matches!(*vir_args[0].typ, TypX::Int(_)),
             expr.span,
@@ -950,9 +1079,17 @@ fn fn_call_to_vir<'tcx>(
             panic!("is_chained_ineq")
         }
     } else if is_chained_cmp {
-        unsupported_err_unless!(len == 1, expr.span, "chained_cmp", args);
+        unsupported_err_unless!(len == 1, expr.span, "spec_chained_cmp", args);
         Ok(vir_args[0].clone())
     } else {
+        if !defined_locally {
+            unsupported_err!(
+                expr.span,
+                format!("method call to method not defined in this crate"),
+                expr
+            );
+        }
+
         // filter out the Fn type parameters
         let mut fn_params: Vec<Ident> = Vec::new();
         for (x, _) in tcx.predicates_of(f).predicates {
@@ -1451,30 +1588,8 @@ pub(crate) fn expr_to_vir_inner<'tcx>(
     let modifier = ExprModifier { deref_mut: false, ..current_modifier };
 
     let mk_lit_int = |in_negative_literal: bool, i: u128, typ: Typ| {
-        let c = vir::ast::Constant::Nat(Arc::new(i.to_string()));
-        let i_bump = if in_negative_literal { 1 } else { 0 };
-        if let TypX::Int(range) = *typ {
-            match range {
-                IntRange::Int | IntRange::Nat => Ok(mk_expr(ExprX::Const(c))),
-                IntRange::U(n) if n == 128 || (n < 128 && i < (1u128 << n)) => {
-                    Ok(mk_expr(ExprX::Const(c)))
-                }
-                IntRange::I(n) if n - 1 < 128 && i < (1u128 << (n - 1)) + i_bump => {
-                    Ok(mk_expr(ExprX::Const(c)))
-                }
-                IntRange::USize if i < (1u128 << vir::def::ARCH_SIZE_MIN_BITS) => {
-                    Ok(mk_expr(ExprX::Const(c)))
-                }
-                IntRange::ISize if i < (1u128 << (vir::def::ARCH_SIZE_MIN_BITS - 1)) + i_bump => {
-                    Ok(mk_expr(ExprX::Const(c)))
-                }
-                _ => {
-                    return err_span_str(expr.span, "integer literal out of range");
-                }
-            }
-        } else {
-            panic!("unexpected constant: {:?} {:?}", i, typ)
-        }
+        check_lit_int(expr.span, in_negative_literal, i, &typ)?;
+        Ok(mk_expr(ExprX::Const(vir::ast::Constant::Nat(Arc::new(i.to_string())))))
     };
 
     match &expr.kind {
@@ -1526,6 +1641,7 @@ pub(crate) fn expr_to_vir_inner<'tcx>(
                             fun.span,
                             args_slice,
                             None,
+                            true,
                         )),
                         rustc_hir::def::Res::Local(_) => {
                             None // dynamically computed function, see below
@@ -1571,13 +1687,11 @@ pub(crate) fn expr_to_vir_inner<'tcx>(
             Ok(mk_expr(ExprX::Tuple(Arc::new(args?))))
         }
         ExprKind::Lit(lit) => match lit.node {
-            rustc_ast::LitKind::Bool(b) => {
+            LitKind::Bool(b) => {
                 let c = vir::ast::Constant::Bool(b);
                 Ok(mk_expr(ExprX::Const(c)))
             }
-            rustc_ast::LitKind::Int(i, _) => {
-                mk_lit_int(false, i, typ_of_node(bctx, &expr.hir_id, false))
-            }
+            LitKind::Int(i, _) => mk_lit_int(false, i, typ_of_node(bctx, &expr.hir_id, false)),
             _ => {
                 panic!("unexpected constant: {:?}", lit)
             }
@@ -1613,17 +1727,14 @@ pub(crate) fn expr_to_vir_inner<'tcx>(
             UnOp::Neg => {
                 let zero_const = vir::ast::Constant::Nat(Arc::new("0".to_string()));
                 let zero = mk_expr(ExprX::Const(zero_const));
-                let varg = if let ExprKind::Lit(rustc_span::source_map::Spanned {
-                    node: rustc_ast::LitKind::Int(i, _),
-                    ..
-                }) = &arg.kind
-                {
-                    mk_lit_int(true, *i, typ_of_node(bctx, &expr.hir_id, false))?
-                } else {
-                    expr_to_vir(bctx, arg, modifier)?
-                };
+                let varg =
+                    if let ExprKind::Lit(Spanned { node: LitKind::Int(i, _), .. }) = &arg.kind {
+                        mk_lit_int(true, *i, typ_of_node(bctx, &expr.hir_id, false))?
+                    } else {
+                        expr_to_vir(bctx, arg, modifier)?
+                    };
                 Ok(mk_expr(ExprX::Binary(
-                    BinaryOp::Arith(ArithOp::Sub, bctx.ctxt.infer_mode()),
+                    BinaryOp::Arith(ArithOp::Sub, Some(bctx.ctxt.infer_mode())),
                     zero,
                     varg,
                 )))
@@ -1682,11 +1793,15 @@ pub(crate) fn expr_to_vir_inner<'tcx>(
                 BinOpKind::Ge => BinaryOp::Inequality(InequalityOp::Ge),
                 BinOpKind::Lt => BinaryOp::Inequality(InequalityOp::Lt),
                 BinOpKind::Gt => BinaryOp::Inequality(InequalityOp::Gt),
-                BinOpKind::Add => BinaryOp::Arith(ArithOp::Add, bctx.ctxt.infer_mode()),
-                BinOpKind::Sub => BinaryOp::Arith(ArithOp::Sub, bctx.ctxt.infer_mode()),
-                BinOpKind::Mul => BinaryOp::Arith(ArithOp::Mul, bctx.ctxt.infer_mode()),
-                BinOpKind::Div => BinaryOp::Arith(ArithOp::EuclideanDiv, bctx.ctxt.infer_mode()),
-                BinOpKind::Rem => BinaryOp::Arith(ArithOp::EuclideanMod, bctx.ctxt.infer_mode()),
+                BinOpKind::Add => BinaryOp::Arith(ArithOp::Add, Some(bctx.ctxt.infer_mode())),
+                BinOpKind::Sub => BinaryOp::Arith(ArithOp::Sub, Some(bctx.ctxt.infer_mode())),
+                BinOpKind::Mul => BinaryOp::Arith(ArithOp::Mul, Some(bctx.ctxt.infer_mode())),
+                BinOpKind::Div => {
+                    BinaryOp::Arith(ArithOp::EuclideanDiv, Some(bctx.ctxt.infer_mode()))
+                }
+                BinOpKind::Rem => {
+                    BinaryOp::Arith(ArithOp::EuclideanMod, Some(bctx.ctxt.infer_mode()))
+                }
                 BinOpKind::BitXor => {
                     match ((tc.node_type(lhs.hir_id)).kind(), (tc.node_type(rhs.hir_id)).kind()) {
                         (TyKind::Bool, TyKind::Bool) => BinaryOp::Xor,
@@ -1740,11 +1855,7 @@ pub(crate) fn expr_to_vir_inner<'tcx>(
                 _ => Ok(e),
             }
         }
-        ExprKind::AssignOp(
-            rustc_span::source_map::Spanned { node: BinOpKind::Shr, .. },
-            lhs,
-            rhs,
-        ) => {
+        ExprKind::AssignOp(Spanned { node: BinOpKind::Shr, .. }, lhs, rhs) => {
             let vlhs = expr_to_vir(bctx, lhs, modifier)?;
             let vrhs = expr_to_vir(bctx, rhs, modifier)?;
             if matches!(*vlhs.typ, TypX::Bool) {
@@ -2054,15 +2165,15 @@ pub(crate) fn expr_to_vir_inner<'tcx>(
                 .type_dependent_def_id(expr.hir_id)
                 .expect("def id of the method definition");
 
-            match tcx.hir().get_if_local(fn_def_id) {
+            let defined_locally = match tcx.hir().get_if_local(fn_def_id) {
                 Some(rustc_hir::Node::ImplItem(rustc_hir::ImplItem {
                     kind: rustc_hir::ImplItemKind::Fn(..),
                     ..
-                })) => {}
+                })) => true,
                 Some(rustc_hir::Node::TraitItem(rustc_hir::TraitItem {
                     kind: rustc_hir::TraitItemKind::Fn(..),
                     ..
-                })) => {}
+                })) => true,
                 None => {
                     // Special case `clone` for standard Rc and Arc types
                     // (Could also handle it for other types where cloning is the identity
@@ -2081,15 +2192,10 @@ pub(crate) fn expr_to_vir_inner<'tcx>(
                             return Ok(arg);
                         }
                     }
-
-                    unsupported_err!(
-                        expr.span,
-                        format!("method call to method not defined in this crate"),
-                        expr
-                    );
+                    false
                 }
                 _ => panic!("unexpected hir for method impl item"),
-            }
+            };
             let autoview_typ = bctx.ctxt.autoviewed_call_typs.get(&expr.hir_id);
             fn_call_to_vir(
                 bctx,
@@ -2099,6 +2205,7 @@ pub(crate) fn expr_to_vir_inner<'tcx>(
                 *fn_span,
                 all_args,
                 autoview_typ,
+                defined_locally,
             )
         }
         ExprKind::Closure(_, _fn_decl, body_id, _, _) => {

--- a/source/rust_verify/src/typecheck.rs
+++ b/source/rust_verify/src/typecheck.rs
@@ -15,6 +15,7 @@ pub(crate) const BUILTIN_NAT: &str = "builtin::nat";
 pub(crate) struct Typecheck {
     pub int_ty_id: Option<DefId>,
     pub nat_ty_id: Option<DefId>,
+    pub enhanced_int: bool,
     pub exprs_in_spec: Arc<Mutex<HashSet<HirId>>>,
     pub autoviewed_calls: HashSet<HirId>,
     pub autoviewed_call_typs: Arc<Mutex<HashMap<HirId, Typ>>>,
@@ -107,6 +108,9 @@ impl FormalVerifierTyping for Typecheck {
         ty: Ty<'tcx>,
         expected_ty: &Option<Ty<'tcx>>,
     ) -> Ty<'tcx> {
+        if !self.enhanced_int {
+            return ty;
+        }
         // For convenience, allow implicit coercions from integral types to int in some situations.
         // This is strictly opportunistic; in many situations you still need "as int".
         match (ty.kind(), expected_ty, allow_widen(expr)) {
@@ -135,6 +139,10 @@ impl FormalVerifierTyping for Typecheck {
                 }
                 _ => return None,
             }
+        }
+
+        if !self.enhanced_int {
+            return None;
         }
 
         // For convenience, allow implicit coercions from integral types to int in some situations.

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1117,6 +1117,7 @@ impl Verifier {
         let _ = tcx.formal_verifier_callback.replace(Some(Box::new(crate::typecheck::Typecheck {
             int_ty_id: None,
             nat_ty_id: None,
+            enhanced_int: !self.args.no_enhanced_typecheck,
             exprs_in_spec: Arc::new(std::sync::Mutex::new(HashSet::new())),
             autoviewed_calls: HashSet::new(),
             autoviewed_call_typs: autoviewed_call_typs.clone(),

--- a/source/rust_verify/tests/assert_forall_by.rs
+++ b/source/rust_verify/tests/assert_forall_by.rs
@@ -225,7 +225,7 @@ test_verify_one_file! {
         }
 
         fn forallstmt_test() {
-            assert forall|x: nat| 1 <= f1(x) by {
+            assert forall|x: nat| 1 <= f1(x as int) by {
                 reveal(f1);
             }
             assert(f1(3) > 0);
@@ -241,7 +241,7 @@ test_verify_one_file! {
         }
 
         fn forallstmt_test() {
-            assert forall|x: nat| 1 <= f1(x) by {} // FAILS
+            assert forall|x: nat| 1 <= f1(x as int) by {} // FAILS
             assert(f1(3) > 0);
         }
     } => Err(err) => assert_one_fails(err)
@@ -263,18 +263,16 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_forallstmt_let code! {
-        #[spec]
+    #[test] test_forallstmt_let verus_code! {
         #[verifier(opaque)]
-        fn f1(i: int) -> int {
+        spec fn f1(i: int) -> int {
             i + 1
         }
 
         fn forallstmt_test() {
-            assert_forall_by(|x: nat| {
-                ensures({ #[spec] let a = 1; a <= #[trigger] f1(x) });
+            assert forall|x: nat| { let a: int = 1; a <= #[trigger] f1(x as int) } by {
                 reveal(f1);
-            });
+            }
             assert(f1(3) > 0);
         }
     } => Ok(())

--- a/source/rust_verify/tests/basic.rs
+++ b/source/rust_verify/tests/basic.rs
@@ -221,7 +221,7 @@ test_verify_one_file! {
         fn f3(a: bool, b: bool) {
             let mut x: Ghost<u64> = ghost(0);
             let y: Ghost<bool> = ghost(a ==> b);
-            let z: Ghost<bool> = ghost(a ==> { x = Ghost::new(*x + 1); b });
+            let z: Ghost<bool> = ghost(a ==> { x = Ghost::new((*x + 1) as u64); b });
             assert(*y == *z);
             assert((*x == 1) == a);
         }

--- a/source/rust_verify/tests/bitvector.rs
+++ b/source/rust_verify/tests/bitvector.rs
@@ -9,19 +9,19 @@ test_verify_one_file! {
             assert(b & 7 == b % 8) by(bit_vector);
             assert(b & 7 == b % 8);
 
-            assert(b ^ b == 0) by(bit_vector);
+            assert(b ^ b == 0u32) by(bit_vector);
             assert(b ^ b == 0);
 
             assert(b & b == b) by(bit_vector);
             assert(b & b == b);
 
-            assert(b + (!b) + 1 == 0) by(bit_vector);
-            assert(b + (!b) + 1 == 0);
+            assert(add(add(b, !b), 1) == 0u32) by(bit_vector);
+            assert(add(add(b, !b), 1) == 0);
 
             assert(b | b == b) by(bit_vector);
             assert(b | b == b);
 
-            assert(b & 0xff < 0x100) by(bit_vector);
+            assert(b & 0xff < 0x100u32) by(bit_vector);
             assert(b & 0xff < 0x100);
         }
     } => Ok(())
@@ -30,8 +30,8 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test2 verus_code! {
         proof fn test2(b: u32) {
-            assert(b << 2 == b * 4) by(bit_vector);
-            assert(b << 2 == b * 4);
+            assert(b << 2 == mul(b, 4)) by(bit_vector);
+            assert(b << 2 == mul(b, 4));
             assert(b < 256 ==> ((b << 2) as int) == (b as int) * 4);
 
             assert(b >> 1 == b / 2) by(bit_vector);
@@ -43,8 +43,8 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test3 verus_code! {
         proof fn test3(b: u32) {
-            assert(2 * b - b == b) by(bit_vector);
-            assert(2 * b - b == b);
+            assert(mul(2, b) - b == b) by(bit_vector);
+            assert(mul(2, b) - b == b);
 
             assert(b <= b) by(bit_vector);
             assert(b >= b) by(bit_vector);
@@ -58,9 +58,9 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test4 verus_code! {
         proof fn test4(u1: u32, u2:u32) {
-            assert( (u1 as u64) << (32 as u64) | (u2 as u64)  == (u1 as u64) * 0x100000000 + (u2 as u64))
+            assert( (u1 as u64) << 32u64 | (u2 as u64)  == add(mul(u1 as u64, 0x100000000), u2 as u64))
                 by(bit_vector);
-            assert( (u1 as u64) << (32 as u64) | (u2 as u64)  == (u1 as u64) * 0x100000000 + (u2 as u64));
+            assert( (u1 as u64) << (32 as u64) | (u2 as u64)  == add(mul(u1 as u64, 0x100000000), u2 as u64));
         }
     } => Ok(())
 }
@@ -68,7 +68,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test5 verus_code! {
         proof fn test5(u:u64) {
-            assert( (u >> (32 as u64)) as u32  ==  (u / (0x100000000 as u64)) as u32)
+            assert( (u >> 32u64) as u32  ==  (u / 0x100000000u64) as u32)
                 by(bit_vector);
             assert( (u >> (32 as u64)) as u32  ==  (u / (0x100000000 as u64)) as u32);
         }
@@ -88,7 +88,7 @@ test_verify_one_file! {
     #[test] test7 verus_code! {
         proof fn test7(b1:u64, b2:u64, b3:u64) {
             assert( !b1 != !b2 ==> !(b1 == b2)) by(bit_vector);
-            assert(((b1 == (1 as u64)) && (b2 == b3)) ==> (b1 + b2 == b3 + 1)) by(bit_vector);
+            assert(((b1 == 1u64) && (b2 == b3)) ==> (add(b1, b2) == add(b3, 1))) by(bit_vector);
             assert((b1 == b2) ==> (!b1 == !b2)) by(bit_vector);
             assert( b1 == (!(!b1))) by(bit_vector);
         }
@@ -99,7 +99,7 @@ test_verify_one_file! {
     #[test] test8 verus_code! {
         proof fn test8(b: u32) {
             assert_bit_vector(forall|a: u32, b: u32| #[trigger] (a & b) == b & a);
-            assert_bit_vector(b & 0xff < 0x100);
+            assert_bit_vector(b & 0xff < 0x100u32);
             assert(0xff & b < 0x100);
         }
     } => Ok(())
@@ -129,7 +129,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test2_fails verus_code! {
         proof fn test2(b: u32) {
-            assert(b + 1 == b) by(bit_vector); // FAILS
+            assert(add(b, 1) == b) by(bit_vector); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
 }
@@ -137,7 +137,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test3_fails verus_code! {
         proof fn test3(b: u32) {
-            assert(b & 0 > 0) by(bit_vector); // FAILS
+            assert(b & 0 > 0u32) by(bit_vector); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
 }
@@ -153,8 +153,8 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test5_fails verus_code! {
         proof fn test5(b: u32) {
-            assert((b << 1) == b * 2) by(bit_vector);
-            assert((b << 1) == b * 4); // FAILS
+            assert((b << 1) == mul(b, 2)) by(bit_vector);
+            assert((b << 1) == mul(b, 4)); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
 }
@@ -162,7 +162,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test6_fails verus_code! {
         proof fn test6(b: u32) {
-            assert(b << 2 == b * 4) by(bit_vector);
+            assert(b << 2 == mul(b, 4)) by(bit_vector);
             assert(((b << 2) as int) == (b as int) * 4);  // FAILS
         }
     } => Err(err) => assert_one_fails(err)

--- a/source/rust_verify/tests/bitvector.rs
+++ b/source/rust_verify/tests/bitvector.rs
@@ -9,19 +9,19 @@ test_verify_one_file! {
             assert(b & 7 == b % 8) by(bit_vector);
             assert(b & 7 == b % 8);
 
-            assert(b ^ b == 0u32) by(bit_vector);
+            assert(b ^ b == 0) by(bit_vector);
             assert(b ^ b == 0);
 
             assert(b & b == b) by(bit_vector);
             assert(b & b == b);
 
-            assert(add(add(b, !b), 1) == 0u32) by(bit_vector);
+            assert(add(add(b, !b), 1) == 0) by(bit_vector);
             assert(add(add(b, !b), 1) == 0);
 
             assert(b | b == b) by(bit_vector);
             assert(b | b == b);
 
-            assert(b & 0xff < 0x100u32) by(bit_vector);
+            assert(b & 0xff < 0x100) by(bit_vector);
             assert(b & 0xff < 0x100);
         }
     } => Ok(())
@@ -32,7 +32,7 @@ test_verify_one_file! {
         proof fn test2(b: u32) {
             assert(b << 2 == mul(b, 4)) by(bit_vector);
             assert(b << 2 == mul(b, 4));
-            assert(b < 256 ==> ((b << 2) as int) == (b as int) * 4);
+            assert(b < 256 ==> b << 2 == b * 4);
 
             assert(b >> 1 == b / 2) by(bit_vector);
             assert(b >> 1 == b / 2);
@@ -68,9 +68,9 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test5 verus_code! {
         proof fn test5(u:u64) {
-            assert( (u >> 32u64) as u32  ==  (u / 0x100000000u64) as u32)
+            assert( (u >> 32) as u32  ==  (u / 0x100000000) as u32)
                 by(bit_vector);
-            assert( (u >> (32 as u64)) as u32  ==  (u / (0x100000000 as u64)) as u32);
+            assert( (u >> 32) as u32  ==  (u / 0x100000000) as u32);
         }
     } => Ok(())
 }
@@ -99,7 +99,7 @@ test_verify_one_file! {
     #[test] test8 verus_code! {
         proof fn test8(b: u32) {
             assert_bit_vector(forall|a: u32, b: u32| #[trigger] (a & b) == b & a);
-            assert_bit_vector(b & 0xff < 0x100u32);
+            assert_bit_vector(b & 0xff < 0x100);
             assert(0xff & b < 0x100);
         }
     } => Ok(())
@@ -137,7 +137,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test3_fails verus_code! {
         proof fn test3(b: u32) {
-            assert(b & 0 > 0u32) by(bit_vector); // FAILS
+            assert(b & 0 > 0) by(bit_vector); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
 }
@@ -163,7 +163,7 @@ test_verify_one_file! {
     #[test] test6_fails verus_code! {
         proof fn test6(b: u32) {
             assert(b << 2 == mul(b, 4)) by(bit_vector);
-            assert(((b << 2) as int) == (b as int) * 4);  // FAILS
+            assert(b << 2 == b * 4);  // FAILS
         }
     } => Err(err) => assert_one_fails(err)
 }

--- a/source/rust_verify/tests/bitvector.rs
+++ b/source/rust_verify/tests/bitvector.rs
@@ -6,7 +6,7 @@ use common::*;
 test_verify_one_file! {
     #[test] test1 verus_code! {
         proof fn test1(b: u32) {
-            assert(b & 7 == b % 8u32) by(bit_vector);
+            assert(b & 7 == b % 8) by(bit_vector);
             assert(b & 7 == b % 8);
 
             assert(b ^ b == 0u32) by(bit_vector);
@@ -34,7 +34,7 @@ test_verify_one_file! {
             assert(b << 2 == mul(b, 4));
             assert(b < 256 ==> ((b << 2) as int) == (b as int) * 4);
 
-            assert(b >> 1 == b / 2u32) by(bit_vector);
+            assert(b >> 1 == b / 2) by(bit_vector);
             assert(b >> 1 == b / 2);
         }
     } => Ok(())

--- a/source/rust_verify/tests/bitvector.rs
+++ b/source/rust_verify/tests/bitvector.rs
@@ -6,7 +6,7 @@ use common::*;
 test_verify_one_file! {
     #[test] test1 verus_code! {
         proof fn test1(b: u32) {
-            assert(b & 7 == b % 8) by(bit_vector);
+            assert(b & 7 == b % 8u32) by(bit_vector);
             assert(b & 7 == b % 8);
 
             assert(b ^ b == 0u32) by(bit_vector);
@@ -34,7 +34,7 @@ test_verify_one_file! {
             assert(b << 2 == mul(b, 4));
             assert(b < 256 ==> ((b << 2) as int) == (b as int) * 4);
 
-            assert(b >> 1 == b / 2) by(bit_vector);
+            assert(b >> 1 == b / 2u32) by(bit_vector);
             assert(b >> 1 == b / 2);
         }
     } => Ok(())

--- a/source/rust_verify/tests/choose.rs
+++ b/source/rust_verify/tests/choose.rs
@@ -99,7 +99,7 @@ test_verify_one_file! {
         #[proof]
         fn cnat() {
             assert(choose(|n: nat| cnatf(n)) >= 0);
-            assert(choose(|n: nat| cintf(n) && n < 0) >= 0);
+            assert(choose(|n: nat| cintf(n as int) && n < 0) >= 0);
         }
     } => Ok(())
 }
@@ -114,7 +114,7 @@ test_verify_one_file! {
         #[proof]
         fn cnat() {
             assert(cintf(-10));
-            assert(choose(|n: nat| cintf(n) && n < 0) < 0); // FAILS
+            assert(choose(|n: nat| cintf(n as int) && n < 0) < 0); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
 }
@@ -239,7 +239,7 @@ test_verify_one_file! {
         #[proof]
         fn cnat() {
             assert(choose_tuple::<(nat, nat), _>(|m: nat, n: nat| cnatf(m, n)).0 >= 0);
-            assert(choose_tuple::<(nat, nat), _>(|m: nat, n: nat| cintf(m, n) && m < 0 && n < 0).0 >= 0);
+            assert(choose_tuple::<(nat, nat), _>(|m: nat, n: nat| cintf(m as int, n as int) && m < 0 && n < 0).0 >= 0);
         }
     } => Ok(())
 }
@@ -254,7 +254,7 @@ test_verify_one_file! {
         #[proof]
         fn cnat() {
             assert(cintf(-10, -10));
-            assert(choose_tuple::<(nat, nat), _>(|m: nat, n: nat| cintf(m, n) && m < 0 && n < 0).0 < 0); // FAILS
+            assert(choose_tuple::<(nat, nat), _>(|m: nat, n: nat| cintf(m as int, n as int) && m < 0 && n < 0).0 < 0); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
 }

--- a/source/rust_verify/tests/common/mod.rs
+++ b/source/rust_verify/tests/common/mod.rs
@@ -123,6 +123,7 @@ pub fn verify_files_and_pervasive(
         } else {
             Default::default()
         };
+        our_args.no_enhanced_typecheck = true;
         if let Ok(path) = std::env::var("VERIFY_LOG_IR_PATH") {
             our_args.log_dir = Some(path);
             our_args.log_all = true;

--- a/source/rust_verify/tests/integers.rs
+++ b/source/rust_verify/tests/integers.rs
@@ -10,12 +10,12 @@ test_verify_one_file! {
         }
 
         spec fn add1_nat(i: nat) -> nat {
-            (i + 1) as nat
+            i + 1
         }
 
         #[verifier(opaque)]
         spec fn add1_nat_opaque(i: nat) -> nat {
-            (i + 1) as nat
+            i + 1
         }
 
         proof fn test0() -> (n: nat)
@@ -95,7 +95,7 @@ test_verify_one_file! {
             let i5: int = n as int;
             let n3: nat = 10;
             let i6: int = -10;
-            let x = 2 + 2;
+            let x = 2int + 2;
             let b1: bool = u <= i; // implicit coercion ok
             let b2: bool = i <= u; // implicit coercion ok
             let b3: bool = u <= i + 1; // implicit coercion ok

--- a/source/rust_verify/tests/integers.rs
+++ b/source/rust_verify/tests/integers.rs
@@ -4,43 +4,38 @@ mod common;
 use common::*;
 
 test_verify_one_file! {
-    #[test] test1 code! {
-        #[spec]
-        fn add1_int(i: int) -> int {
+    #[test] test1 verus_code! {
+        spec fn add1_int(i: int) -> int {
             i + 1
         }
 
-        #[spec]
-        fn add1_nat(i: nat) -> nat {
-            i + 1
+        spec fn add1_nat(i: nat) -> nat {
+            (i + 1) as nat
         }
 
-        #[spec]
         #[verifier(opaque)]
-        fn add1_nat_opaque(i: nat) -> nat {
-            i + 1
+        spec fn add1_nat_opaque(i: nat) -> nat {
+            (i + 1) as nat
         }
 
-        #[proof]
-        fn test0() -> nat {
-            ensures(|n: nat| true);
+        proof fn test0() -> (n: nat)
+            ensures true
+        {
             100
         }
 
-        #[proof]
-        fn test0x() -> nat {
+        proof fn test0x() -> nat {
             100
         }
 
-        #[proof]
-        fn test1(i: int, n: nat, u: u8) {
+        proof fn test1(i: int, n: nat, u: u8) {
             assert(n >= 0);
             assert(u >= 0);
             assert(n + n >= 0);
-            assert(((u + u) as int) < 256);
-            assert(u < 100 >>= ((u + u) as int) < 250);
-            assert(add1_int(u) == u as int + 1);
-            assert(add1_nat(u) == u as nat + 1);
+            assert((add(u, u) as int) < 256);
+            assert(u < 100 >>= (add(u, u) as int) < 250);
+            assert(add1_int(u as int) == u as int + 1);
+            assert(add1_nat(u as nat) == u as nat + 1);
             let n0 = test0();
             assert(n0 >= 0);
             let n0x = test0x();
@@ -54,15 +49,13 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test1_fails code! {
-        #[spec]
-        fn add1_int(i: int) -> int {
+    #[test] test1_fails verus_code! {
+        spec fn add1_int(i: int) -> int {
             i + 1
         }
 
-        #[proof]
-        fn test1(i: int, n: nat, u: u8) {
-            assert(add1_int(u) == (u + 1) as int); // FAILS
+        proof fn test1(i: int, n: nat, u: u8) {
+            assert(add1_int(u as int) == add(u, 1) as int); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
 }
@@ -77,9 +70,8 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test3_fails code! {
-        #[proof]
-        fn test1(i: int, n: nat, u: u8) {
+    #[test] test3_fails verus_code! {
+        proof fn test1(i: int, n: nat, u: u8) {
             assert(i / 2 <= n); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
@@ -95,13 +87,12 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test4 code! {
-        #[proof]
-        fn typing(u: u64, i: int, n: nat) -> int {
+    #[test] test4 verus_code! {
+        proof fn typing(u: u64, i: int, n: nat) -> int {
             let u2 = i as u64;
             let i2 = u as int;
-            let i3: int = u; // implicit coercion ok
-            let i5: int = n; // implicit coercion ok
+            let i3: int = u as int;
+            let i5: int = n as int;
             let n3: nat = 10;
             let i6: int = -10;
             let x = 2 + 2;

--- a/source/rust_verify/tests/match.rs
+++ b/source/rust_verify/tests/match.rs
@@ -70,35 +70,36 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test2 code! {
+    #[test] test2 verus_code! {
         enum List<A> {
             Nil,
             Cons(A, Box<List<A>>),
         }
 
-        #[spec]
-        fn len<A>(list: &List<A>) -> nat {
-            decreases(list);
+        spec fn len<A>(list: &List<A>) -> nat
+            decreases list
+        {
             match list {
                 List::Nil => 0,
-                List::Cons(_, tl) => 1 + len(tl),
+                List::Cons(_, tl) => (1 + len(tl)) as nat,
             }
         }
 
-        fn get_len<A>(list: &List<A>) -> u64 {
-            requires(len(list) <= 0xffffffffffffffff);
-            ensures(|r: u64| r == len(list));
-
+        fn get_len<A>(list: &List<A>) -> (r: u64)
+            requires
+                len(list) <= 0xffffffffffffffff,
+            ensures
+                r == len(list),
+        {
             let mut n: u64 = 0;
             let mut done = false;
             let mut iter = list;
-            while !done {
-                invariant([
+            while !done
+                invariant
                     len(list) <= 0xffffffffffffffff,
                     n + len(iter) == len(list),
-                    done >>= len(iter) == 0,
-                ]);
-
+                    done ==> len(iter) == 0,
+            {
                 match iter {
                     List::Nil => {
                         done = true;
@@ -116,35 +117,36 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test2_struct code! {
+    #[test] test2_struct verus_code! {
         enum List<A> {
             Nil,
             Cons { hd: A, tl: Box<List<A>> },
         }
 
-        #[spec]
-        fn len<A>(list: &List<A>) -> nat {
-            decreases(list);
+        spec fn len<A>(list: &List<A>) -> nat
+            decreases list
+        {
             match list {
                 List::Nil => 0,
-                List::Cons { hd: _, tl } => 1 + len(tl),
+                List::Cons { hd: _, tl } => (1 + len(tl)) as nat,
             }
         }
 
-        fn get_len<A>(list: &List<A>) -> u64 {
-            requires(len(list) <= 0xffffffffffffffff);
-            ensures(|r: u64| r == len(list));
-
+        fn get_len<A>(list: &List<A>) -> (r: u64)
+            requires
+                len(list) <= 0xffffffffffffffff,
+            ensures
+                r == len(list),
+        {
             let mut n: u64 = 0;
             let mut done = false;
             let mut iter = list;
-            while !done {
-                invariant([
+            while !done
+                invariant
                     len(list) <= 0xffffffffffffffff,
                     n + len(iter) == len(list),
-                    done >>= len(iter) == 0,
-                ]);
-
+                    done ==> len(iter) == 0,
+            {
                 match iter {
                     List::Nil => {
                         done = true;
@@ -162,34 +164,35 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test2_fails code! {
+    #[test] test2_fails verus_code! {
         enum List<A> {
             Nil,
             Cons(A, Box<List<A>>),
         }
 
-        #[spec]
-        fn len<A>(list: &List<A>) -> nat {
-            decreases(list);
+        spec fn len<A>(list: &List<A>) -> nat
+            decreases list
+        {
             match list {
                 List::Nil => 0,
-                List::Cons(_, tl) => 1 + len(tl),
+                List::Cons(_, tl) => (1 + len(tl)) as nat,
             }
         }
 
-        fn get_len<A>(list: &List<A>) -> u64 {
-            requires(len(list) <= 0xffffffffffffffff);
-            ensures(|r: u64| r == len(list));
-
+        fn get_len<A>(list: &List<A>) -> (r: u64)
+            requires
+                len(list) <= 0xffffffffffffffff,
+            ensures
+                r == len(list),
+        {
             let mut n: u64 = 0;
             let mut done = false;
             let mut iter = list;
-            while !done {
-                invariant([
+            while !done
+                invariant
                     n + len(iter) == len(list),
-                    done >>= len(iter) == 0,
-                ]);
-
+                    done ==> len(iter) == 0,
+            {
                 match iter {
                     List::Nil => {
                         done = true;

--- a/source/rust_verify/tests/match.rs
+++ b/source/rust_verify/tests/match.rs
@@ -81,7 +81,7 @@ test_verify_one_file! {
         {
             match list {
                 List::Nil => 0,
-                List::Cons(_, tl) => (1 + len(tl)) as nat,
+                List::Cons(_, tl) => 1 + len(tl),
             }
         }
 
@@ -128,7 +128,7 @@ test_verify_one_file! {
         {
             match list {
                 List::Nil => 0,
-                List::Cons { hd: _, tl } => (1 + len(tl)) as nat,
+                List::Cons { hd: _, tl } => 1 + len(tl),
             }
         }
 
@@ -175,7 +175,7 @@ test_verify_one_file! {
         {
             match list {
                 List::Nil => 0,
-                List::Cons(_, tl) => (1 + len(tl)) as nat,
+                List::Cons(_, tl) => 1 + len(tl),
             }
         }
 

--- a/source/rust_verify/tests/nonlinear.rs
+++ b/source/rust_verify/tests/nonlinear.rs
@@ -103,25 +103,25 @@ test_verify_one_file! {
                 y <= 0xffff,
                 z <= 0xffff,
         {
-            assert((x as int) * (z as int) == ((x * z) as int)) by(nonlinear_arith)
+            assert(x * z == mul(x, z)) by(nonlinear_arith)
                 requires
                     x <= 0xffff,
                     z <= 0xffff,
             {
-                assert(0 <= (x as int) * (z as int));
-                assert((x as int) * (z as int) <= 0xffff * 0xffff);
+                assert(0 <= x * z);
+                assert(x * z <= 0xffff * 0xffff);
             }
-            assert((x as int) * (z as int) == ((x * z) as int));
+            assert(x * z == mul(x, z));
 
-            assert((y as int) * (z as int) == ((y * z) as int)) by(nonlinear_arith)
+            assert(y * z == mul(y, z)) by(nonlinear_arith)
                 requires
                     y <= 0xffff,
                     z <= 0xffff,
             {
-                assert(0 <= (y as int) * (z as int));
-                assert((y as int) * (z as int) <= 0xffff * 0xffff);
+                assert(0 <= y * z);
+                assert(y * z <= 0xffff * 0xffff);
             }
-            assert((y as int) * (z as int) == ((y * z) as int));
+            assert(y * z == mul(y, z));
         }
     } => Ok(())
 }
@@ -131,14 +131,14 @@ test_verify_one_file! {
         proof fn test6(x: u32, y: u32, z: u32)
             requires x < 0xfff
         {
-            assert(x * x + x == x * (x + 1)) by(nonlinear_arith)
+            assert(add(mul(x, x), x) == mul(x, add(x, 1))) by(nonlinear_arith)
                 requires x < 0xfff
             {
             }
-            assert(x * x + x == x * (x + 1));
+            assert(add(mul(x, x), x) == mul(x, add(x, 1)));
 
-            assert(x * y == y * x) by(nonlinear_arith);
-            assert(x * y == y * x);
+            assert(mul(x, y) == mul(y, x)) by(nonlinear_arith);
+            assert(mul(x, y) == mul(y, x));
         }
     } => Ok(())
 }
@@ -178,7 +178,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test4_fails verus_code! {
         proof fn test4_fails(x: u32, y: u32, z: u32) {
-            assert((x as int) * (z as int) == (mul(x, z) as int)) by(nonlinear_arith); // FAILS
+            assert(x * z == (mul(x, z) as int)) by(nonlinear_arith); // FAILS
         }
     } => Err(e) => assert_one_fails(e)
 }

--- a/source/rust_verify/tests/nonlinear.rs
+++ b/source/rust_verify/tests/nonlinear.rs
@@ -178,7 +178,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test4_fails verus_code! {
         proof fn test4_fails(x: u32, y: u32, z: u32) {
-            assert((x as int) * (z as int) == ((x * z) as int)) by(nonlinear_arith); // FAILS
+            assert((x as int) * (z as int) == (mul(x, z) as int)) by(nonlinear_arith); // FAILS
         }
     } => Err(e) => assert_one_fails(e)
 }
@@ -244,10 +244,10 @@ test_verify_one_file! {
         proof fn test6(x: int)
             requires x == 5
         {
-            assert({let z = 2; x * z == 10}) by(nonlinear_arith)
-                requires ({let z = 5; x == z})
+            assert({let z: int = 2; x * z == 10}) by(nonlinear_arith)
+                requires ({let z: int = 5; x == z})
             {
-                let y: nat = x as nat * 2;
+                let y: nat = mul(x as nat, 2);
                 assert(y == 10);
             }
             assert(x * 2 == 10);

--- a/source/rust_verify/tests/overflow.rs
+++ b/source/rust_verify/tests/overflow.rs
@@ -24,17 +24,17 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_overflow_spec_fails_1 code! {
-        fn test(a: u64) {
-            #[spec] let mut j = a;
-            j = j + 2;
+    #[test] test_overflow_spec_fails_1 verus_code! {
+        proof fn test(a: u64) {
+            let mut j = a;
+            j = add(j, 2);
             assert(j == a as nat + 2); // FAILS
         }
     } => Err(e) => assert_one_fails(e)
 }
 
 test_verify_one_file! {
-    #[test] test_overflow_fails_1 code! {
+    #[test] test_overflow_fails_1 verus_code! {
         fn test(a: u64) {
             let mut j = a;
             j = j + 2; // FAILS

--- a/source/rust_verify/tests/quantifiers.rs
+++ b/source/rust_verify/tests/quantifiers.rs
@@ -16,7 +16,7 @@ test_verify_one_file! {
 
         proof fn test1_inference() {
             assert(tr(300));
-            assert(exists|i| i >= 0 && tr(i));
+            assert(exists|i| 0 <= i && tr(i));
         }
     } => Ok(())
 }

--- a/source/rust_verify/tests/quantifiers.rs
+++ b/source/rust_verify/tests/quantifiers.rs
@@ -11,7 +11,7 @@ test_verify_one_file! {
 
         proof fn test1() {
             assert(tr(300));
-            assert(exists|i: nat| i >= 0 && tr(i));
+            assert(exists|i: nat| i >= 0 && tr(i as int));
         }
 
         proof fn test1_inference() {
@@ -28,7 +28,7 @@ test_verify_one_file! {
         }
 
         proof fn test1() {
-            assert(exists|i: nat| i >= 0 && tr(i)); // FAILS
+            assert(exists|i: nat| i >= 0 && tr(i as int)); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
 }
@@ -45,7 +45,7 @@ test_verify_one_file! {
 
         proof fn test1() {
             assert(tr1(300));
-            assert(exists|i: nat| i >= 0 && tr1(i) && tr2(i));
+            assert(exists|i: nat| i >= 0 && tr1(i as int) && tr2(i as int));
         }
     } => Ok(())
 }
@@ -62,7 +62,7 @@ test_verify_one_file! {
 
         proof fn test1() {
             assert(tr2(300));
-            assert(exists|i: nat| i >= 0 && tr1(i) && tr2(i));
+            assert(exists|i: nat| i >= 0 && tr1(i as int) && tr2(i as int));
         }
     } => Ok(())
 }
@@ -142,7 +142,7 @@ test_verify_one_file! {
 
         proof fn test1() {
             assert(tr2(300));
-            assert(exists|i: nat| i >= 0 && tr1(i) && #[trigger] tr2(i));
+            assert(exists|i: nat| i >= 0 && tr1(i as int) && #[trigger] tr2(i as int));
         }
     } => Ok(())
 }
@@ -159,7 +159,7 @@ test_verify_one_file! {
 
         proof fn test1() {
             assert(tr1(300));
-            assert(exists|i: nat| i >= 0 && tr1(i) && #[trigger] tr2(i)); // FAILS
+            assert(exists|i: nat| i >= 0 && tr1(i as int) && #[trigger] tr2(i as int)); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
 }

--- a/source/rust_verify/tests/refs.rs
+++ b/source/rust_verify/tests/refs.rs
@@ -282,15 +282,19 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
-    #[test] test_mut_ref_old_trigger code! {
+    #[test] test_mut_ref_old_trigger verus_code! {
         use crate::pervasive::vec::*;
 
-        fn add1(v: &mut Vec<u64>) {
-            requires(forall(|i: nat| i < old(v).len() >>= old(v).index(i) < 10));
+        fn add1(v: &mut Vec<u64>)
+            requires
+                forall|i: int| 0 <= i < old(v).len() ==> old(v).index(i) < 10,
+        {
         }
 
-        fn test(v: Vec<u64>) {
-            requires(forall(|i: nat| i < v.len() >>= v.index(i) < 5));
+        fn test(v: Vec<u64>)
+            requires
+                forall|i: int| 0 <= i < v.len() ==> v.index(i) < 5,
+        {
             let mut v1 = v;
             add1(&mut v1);
         }

--- a/source/rust_verify/tests/regression.rs
+++ b/source/rust_verify/tests/regression.rs
@@ -27,7 +27,7 @@ test_verify_one_file! {
             let s1: Set<i32> = Set::empty().insert(1);
 
             assert (exists|s3: Set<i32>| different_set(s3) !== s1) by {
-                assert(!different_set(Set::empty()).contains(1));
+                assert(!different_set(Set::empty()).contains(1i32));
             }
         }
     } => Ok(())

--- a/source/rust_verify/tests/summer_school.rs
+++ b/source/rust_verify/tests/summer_school.rs
@@ -858,7 +858,7 @@ test_verify_one_file! {
         {
             if val == 0 { 0 }
             else if val == 1 { 1 }
-            else { (fibo((val - 2) as nat) + fibo((val - 1) as nat)) as nat }
+            else { fibo((val - 2) as nat) + fibo((val - 1) as nat) }
         }
 
         spec fn max_u64_fibo_arg() -> nat {

--- a/source/rust_verify/tests/triggers.rs
+++ b/source/rust_verify/tests/triggers.rs
@@ -15,9 +15,9 @@ test_verify_one_file! {
 
         impl Node {
             #[spec] fn inv(&self) -> bool {
-                forall(|i: nat, j: nat| (i < self.nodes.len() && j < self.nodes.index(i).values.len()) >>= {
-                    let values = #[trigger] self.nodes.index(i).values;
-                    self.base_v <= #[trigger] values.index(j)
+                forall(|i: nat, j: nat| (i < self.nodes.len() && j < self.nodes.index(i as int).values.len()) >>= {
+                    let values = #[trigger] self.nodes.index(i as int).values;
+                    self.base_v <= #[trigger] values.index(j as int)
                 })
             }
         }
@@ -37,10 +37,10 @@ test_verify_one_file! {
 
         impl Node {
             #[spec] fn inv(&self) -> bool {
-                forall(|i: nat, j: nat| with_triggers!([self.nodes.index(i).values.index(j)] =>
-                                                       (i < self.nodes.len() && j < self.nodes.index(i).values.len()) >>= {
-                    let values = self.nodes.index(i).values;
-                    self.base_v <= values.index(j)
+                forall(|i: nat, j: nat| with_triggers!([self.nodes.index(i as int).values.index(j as int)] =>
+                                                       (i < self.nodes.len() && j < self.nodes.index(i as int).values.len()) >>= {
+                    let values = self.nodes.index(i as int).values;
+                    self.base_v <= values.index(j as int)
                 }))
             }
         }

--- a/source/rust_verify_test_macros/src/lib.rs
+++ b/source/rust_verify_test_macros/src/lib.rs
@@ -13,7 +13,7 @@ pub fn code(input: TokenStream) -> TokenStream {
 
 #[proc_macro]
 pub fn verus_code(input: TokenStream) -> TokenStream {
-    let src = "verus!{\n".to_string() + &rust_code::rust_code_core(input) + "}\n";
+    let src = "verus2!{\n".to_string() + &rust_code::rust_code_core(input) + "}\n";
     quote!(#src.to_string()).into()
 }
 
@@ -25,6 +25,6 @@ pub fn code_str(input: TokenStream) -> TokenStream {
 
 #[proc_macro]
 pub fn verus_code_str(input: TokenStream) -> TokenStream {
-    let src = "verus!{\n".to_string() + &rust_code::rust_code_core(input) + "}\n";
+    let src = "verus2!{\n".to_string() + &rust_code::rust_code_core(input) + "}\n";
     quote!(#src).into()
 }

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -207,8 +207,9 @@ pub enum BinaryOp {
     Ne,
     ///
     Inequality(InequalityOp),
-    /// IntRange operations that may require overflow or divide-by zero checks
-    Arith(ArithOp, InferMode),
+    /// IntRange operations that may require overflow or divide-by-zero checks
+    /// (None for InferMode means always mode Spec)
+    Arith(ArithOp, Option<InferMode>),
     /// Bit Vector Operators
     Bitwise(BitwiseOp),
 }

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -884,10 +884,15 @@ fn expr_to_stm_opt(
                     let bin = mk_exp(ExpX::Binary(*op, e1, e2.clone()));
 
                     if let BinaryOp::Arith(arith, inferred_mode) = op {
+                        let arith_mode = if let Some(inferred_mode) = inferred_mode {
+                            ctx.global.inferred_modes[inferred_mode]
+                        } else {
+                            Mode::Spec
+                        };
                         // Insert bounds check
                         match (
                             state.view_as_spec,
-                            ctx.global.inferred_modes[inferred_mode],
+                            arith_mode,
                             &*expr.typ,
                             state.checking_recommends(ctx),
                         ) {

--- a/source/vir/src/ast_util.rs
+++ b/source/vir/src/ast_util.rs
@@ -85,6 +85,21 @@ pub fn bitwidth_from_type(et: &Typ) -> Option<u32> {
     }
 }
 
+pub(crate) fn fixed_integer_const(n: &String, typ: &Typ) -> bool {
+    if let TypX::Int(IntRange::U(bits)) = &**typ {
+        if let Ok(u) = n.parse::<u128>() {
+            return *bits == 128 || u < 2u128 << bits;
+        }
+    }
+    if let TypX::Int(IntRange::I(bits)) = &**typ {
+        if let Ok(i) = n.parse::<i128>() {
+            return *bits == 128
+                || -((2u128 << (bits - 1)) as i128) <= i && i < (2u128 << (bits - 1)) as i128;
+        }
+    }
+    false
+}
+
 impl TypX {
     pub fn is_ghost_typ(&self) -> bool {
         match self {

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -129,7 +129,7 @@ fn func_body_to_air(
     let mut decrease_by_stms: Vec<Stm> = Vec::new();
     let decrease_by_reqs = if let Some(req) = &function.x.decrease_when {
         let exp = crate::ast_to_sst::expr_to_exp(ctx, &pars, req)?;
-        let expr = exp_to_expr(ctx, &exp, ExprCtxt { mode: ExprMode::Spec, is_bit_vector: false });
+        let expr = exp_to_expr(ctx, &exp, &ExprCtxt::new_mode(ExprMode::Spec));
         decrease_by_stms.push(Spanned::new(req.span.clone(), StmX::Assume(exp)));
         vec![expr]
     } else {
@@ -190,8 +190,7 @@ fn func_body_to_air(
     //   (axiom (forall (... fuel) (= (rec%f ... fuel) (rec%f ... zero) )))
     //   (axiom (forall (... fuel) (= (rec%f ... (succ fuel)) body[rec%f ... fuel] )))
     //   (axiom (=> (fuel_bool fuel%f) (forall (...) (= (f ...) (rec%f ... (succ fuel_nat%f))))))
-    let body_expr =
-        exp_to_expr(&ctx, &body_exp, ExprCtxt { mode: ExprMode::Body, is_bit_vector: false });
+    let body_expr = exp_to_expr(&ctx, &body_exp, &ExprCtxt::new());
     let def_body = if !is_recursive {
         body_expr
     } else {
@@ -269,8 +268,7 @@ pub fn req_ens_to_air(
         }
         for e in specs.iter() {
             let exp = crate::ast_to_sst::expr_to_exp(ctx, params, e)?;
-            let expr =
-                exp_to_expr(ctx, &exp, ExprCtxt { mode: ExprMode::Spec, is_bit_vector: false });
+            let expr = exp_to_expr(ctx, &exp, &ExprCtxt::new_mode(ExprMode::Spec));
             let loc_expr = match msg {
                 None => expr,
                 Some(msg) => {
@@ -553,11 +551,7 @@ pub fn func_axioms_to_air(
                 let bndx = BndX::Quant(QUANT_FORALL, Arc::new(binders), triggers);
                 let forallx = ExpX::Bind(Spanned::new(span.clone(), bndx), exp);
                 let forall = SpannedTyped::new(&span, &Arc::new(TypX::Bool), forallx);
-                let expr = exp_to_expr(
-                    ctx,
-                    &forall,
-                    ExprCtxt { mode: ExprMode::Spec, is_bit_vector: false },
-                );
+                let expr = exp_to_expr(ctx, &forall, &ExprCtxt::new_mode(ExprMode::Spec));
                 let axiom = Arc::new(DeclX::Axiom(expr));
                 decl_commands.push(Arc::new(CommandX::Global(axiom)));
             }

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -490,7 +490,7 @@ fn check_expr(
                 _ => Mode::Exec,
             };
             match op {
-                BinaryOp::Arith(_, id) => {
+                BinaryOp::Arith(_, Some(id)) => {
                     assert!(!typing.inferred_modes.contains_key(id));
                     typing.inferred_modes.insert(*id, erasure_mode.clone());
                 }


### PR DESCRIPTION
Our current fork of rustc contains special type checking for `int` and `nat` types, but our new plan is to move Verus to a more standard version of rustc without special type checking for `int` and `nat`.  This pull request attempts to implement this move.  First, it introduces a new command-line option `--no-enhanced-typecheck` that disables the special type checking in our fork of rustc.  Second, it introduces new traits for arithmetic like `SpecAdd` and `SpecOrd` that try to soften the blow from `--no-enhanced-typecheck`, handling some of the integer coercions that were previously handled by the special type checking in our rustc fork.

As an example, for a function `spec fn f(i: int) -> int` and a variable `x: u32`, you now have to write `f(x as int)` rather than just `f(x)`.  However, most arithmetic operations in ghost code will not require an explicit `as int` coercion.  For example, you can write `f(3) + x` or `f(3) < x` with no `as int` coercion.  In these cases, the `u32` is automatically widened (in ghost code) to type `int`.

In fact, in ghost code, `+`, `-`, and `*` will always widen integer operands to `int` to avoid overflow.  So `x + x` would widen both `x` operands to `int` before performing the addition, producing a result of type `int` (not `u32`) that is potentially larger than a 32-bit number.  If you don't want this widening behavior (e.g. in bit vector arithmetic), you can use the `builtin` `add`, `sub`, and `mul` functions (e.g. `add(x, x)`).  But it seems that in most specification code, people actually want widening more often than not.

This pull request enables `--no-enhanced-typecheck` for all of our tests, and the tests have been updated to handle this.  Otherwise, `--no-enhanced-typecheck` is currently false by default to give people a chance to port their code to `--no-enhanced-typecheck` without breaking it immediately.  Also, the original `verus!` macro has been left unchanged, with a new `verus2!` macro implementing the new integer arithmetic.  This is also to give people a chance to port their code without breaking it.  Once people have ported their code, we can make `verus!` point to `verus2!` and turn on `--no-enhanced-typecheck` by default.

There are some improvements that can still be implemented, but which I'm delaying until future commits:
- assert-by-bit_vector currently requires more annotations on integer literals than it should, but I'd rather fix this later to avoid conflicts with ongoing development on bit vectors in the main branch.
- spec_eq is currently just a function, not a trait, because I think we should discuss plans for `==` separately.
- SpecIndex is declared but not yet hooked up to anything.  This can wait for a later commit in `main`.
