### PR TITLE
Add ARM support, along with minimum build requirements

### DIFF
--- a/source/tools/docs.sh
+++ b/source/tools/docs.sh
@@ -19,7 +19,7 @@ cp -r pervasive $TEMPD
 echo "#[allow(rustdoc::invalid_rust_codeblocks)] pub mod pervasive;" >> $TEMPD/lib.rs
 
 echo "Running rustdoc..."
-VERUSDOC=1 VERUS_Z3_PATH=/Users/thance/verus/source/z3 DYLD_LIBRARY_PATH=../rust/install/lib/rustlib/${ARCH}-apple-darwin/lib LD_LIBRARY_PATH=../rust/install/lib/rustlib/${ARCH}-unknown-linux-gnu/lib ../rust/install/bin/rustdoc --extern builtin=../rust/install/bin/libbuiltin.rlib --extern builtin_macros=../rust/install/bin/libbuiltin_macros.dylib --extern state_machines_macros=../rust/install/bin/libstate_machines_macros.dylib --edition=2018 -Zenable_feature=stmt_expr_attributes -Zenable_feature=box_syntax -Zenable_feature=box_patterns -Zenable_feature=negative_impls -Zproc-macro-backtrace $TEMPD/lib.rs
+VERUSDOC=1 VERUS_Z3_PATH="$(pwd)/z3" DYLD_LIBRARY_PATH=../rust/install/lib/rustlib/${ARCH}-apple-darwin/lib LD_LIBRARY_PATH=../rust/install/lib/rustlib/${ARCH}-unknown-linux-gnu/lib ../rust/install/bin/rustdoc --extern builtin=../rust/install/bin/libbuiltin.rlib --extern builtin_macros=../rust/install/bin/libbuiltin_macros.dylib --extern state_machines_macros=../rust/install/bin/libstate_machines_macros.dylib --edition=2018 -Zenable_feature=stmt_expr_attributes -Zenable_feature=box_syntax -Zenable_feature=box_patterns -Zenable_feature=negative_impls -Zproc-macro-backtrace $TEMPD/lib.rs
 
 rm -rf $TEMPD
 

--- a/source/tools/docs.sh
+++ b/source/tools/docs.sh
@@ -1,12 +1,25 @@
 #! /bin/bash
 
+case $(uname -m) in
+  x86_64)
+    ARCH=x86_64
+    ;;
+  arm64)
+    ARCH=aarch64
+    ;;
+  *)
+    echo "Unknown architecture $(uname -m)" 1>&2
+    exit 1
+    ;;
+esac
+
 TEMPD=$(mktemp -d)
 
 cp -r pervasive $TEMPD
 echo "#[allow(rustdoc::invalid_rust_codeblocks)] pub mod pervasive;" >> $TEMPD/lib.rs
 
 echo "Running rustdoc..."
-VERUSDOC=1 VERUS_Z3_PATH=/Users/thance/verus/source/z3 DYLD_LIBRARY_PATH=../rust/install/lib/rustlib/x86_64-apple-darwin/lib LD_LIBRARY_PATH=../rust/install/lib/rustlib/x86_64-unknown-linux-gnu/lib ../rust/install/bin/rustdoc --extern builtin=../rust/install/bin/libbuiltin.rlib --extern builtin_macros=../rust/install/bin/libbuiltin_macros.dylib --extern state_machines_macros=../rust/install/bin/libstate_machines_macros.dylib --edition=2018 -Zenable_feature=stmt_expr_attributes -Zenable_feature=box_syntax -Zenable_feature=box_patterns -Zenable_feature=negative_impls $TEMPD/lib.rs
+VERUSDOC=1 VERUS_Z3_PATH=/Users/thance/verus/source/z3 DYLD_LIBRARY_PATH=../rust/install/lib/rustlib/${ARCH}-apple-darwin/lib LD_LIBRARY_PATH=../rust/install/lib/rustlib/${ARCH}-unknown-linux-gnu/lib ../rust/install/bin/rustdoc --extern builtin=../rust/install/bin/libbuiltin.rlib --extern builtin_macros=../rust/install/bin/libbuiltin_macros.dylib --extern state_machines_macros=../rust/install/bin/libstate_machines_macros.dylib --edition=2018 -Zenable_feature=stmt_expr_attributes -Zenable_feature=box_syntax -Zenable_feature=box_patterns -Zenable_feature=negative_impls $TEMPD/lib.rs
 
 rm -rf $TEMPD
 

--- a/source/tools/rust-verify.sh
+++ b/source/tools/rust-verify.sh
@@ -6,4 +6,17 @@ elif [ `uname` == "Linux" ]; then
     DYN_LIB_EXT=so
 fi
 
-VERUS_Z3_PATH="$(pwd)/z3" DYLD_LIBRARY_PATH=../rust/install/lib/rustlib/x86_64-apple-darwin/lib LD_LIBRARY_PATH=../rust/install/lib/rustlib/x86_64-unknown-linux-gnu/lib ../rust/install/bin/rust_verify --pervasive-path pervasive --extern builtin=../rust/install/bin/libbuiltin.rlib --extern builtin_macros=../rust/install/bin/libbuiltin_macros.$DYN_LIB_EXT --extern state_machines_macros=../rust/install/bin/libstate_machines_macros.$DYN_LIB_EXT --edition=2018 $@
+case $(uname -m) in
+  x86_64)
+    ARCH=x86_64
+    ;;
+  arm64)
+    ARCH=aarch64
+    ;;
+  *)
+    echo "Unknown architecture $(uname -m)" 1>&2
+    exit 1
+    ;;
+esac
+
+VERUS_Z3_PATH="$(pwd)/z3" DYLD_LIBRARY_PATH=../rust/install/lib/rustlib/${ARCH}-apple-darwin/lib LD_LIBRARY_PATH=../rust/install/lib/rustlib/${ARCH}-unknown-linux-gnu/lib ../rust/install/bin/rust_verify --pervasive-path pervasive --extern builtin=../rust/install/bin/libbuiltin.rlib --extern builtin_macros=../rust/install/bin/libbuiltin_macros.$DYN_LIB_EXT --extern state_machines_macros=../rust/install/bin/libstate_machines_macros.$DYN_LIB_EXT --edition=2018 $@

--- a/tools/shell.nix
+++ b/tools/shell.nix
@@ -1,0 +1,21 @@
+# Minimal set of build requirements for Verus
+#
+# Open a shell which has access to nothing but these requirements using
+#    nix-shell --pure tools/shell.nix
+# from the root of the repository.
+
+{ pkgs ? import <nixpkgs> {} }:
+  pkgs.mkShell {
+    nativeBuildInputs = with pkgs; [
+      git
+      python3
+      openssh
+      cmake
+      ninja
+      pkg-config
+      openssl
+      libiconv
+      curl
+      libgit2_1_3_0 # Interestingly, libgit2 at the moment (at version 1.4.3.x) ends up in a segfault, but 1.3.0 works fine.
+    ];
+}


### PR DESCRIPTION
This PR updates the scripts to be able to run Verus on an Arm64 machine (tested on an M1 mac). 

Additionally, it introduces a `shell.nix` that keeps track of the minimum build requirements to be able to build and run Verus. If you are a [Nix](https://nixos.org/) package manager user, `nix-shell --pure tools/shell.nix` will ensure an environment that doesn't have anything accessible except the build requirements in `shell.nix`.

Interestingly, in the process of producing this minimal set, I discovered that the latest version of `libgit2` (technically the latest as of a few hours ago, since I haven't tested on the version that released 7 hours ago) leads to a segfault _very_ early on, while still trying to build the verifier. Thus, I've marked (temporarily) as requiring a slightly older `libgit2`. I suspect that this segfault is specific to ARM and that specific version, but I have not spent time debugging this.