### PR TITLE
Error localization via expression splitting

### DIFF
--- a/source/rust_verify/example/debug_expand.rs
+++ b/source/rust_verify/example/debug_expand.rs
@@ -356,5 +356,20 @@ proof fn test_binder_inlining(b: bool)
 }
 
 
+// example15: recursive function
+spec fn is_even(p:nat) -> bool
+//   ------------------------- Note: this function is recursive with fuel 10
+{
+   decreases(p);
+   if p == 0 { true }
+   else {!is_even(p-1)}
+}
+
+proof fn test_rec() {
+  reveal_with_fuel(is_even, 10);
+  assert(is_even(1));
+//^^^^^^ ^^^^^^^^^^
+}
+
 
 }

--- a/source/rust_verify/example/debug_expand.rs
+++ b/source/rust_verify/example/debug_expand.rs
@@ -1,0 +1,310 @@
+// rust_verify/tests/example.rs expect-failures
+
+#[allow(unused_imports)]
+use builtin_macros::*;
+#[allow(unused_imports)]
+use builtin::*;
+#[allow(unused_imports)]
+use pervasive::option::*;
+mod pervasive;
+#[allow(unused_imports)]
+use crate::pervasive::modes::*;
+#[allow(unused_imports)]
+use crate::pervasive::{*, seq::*, vec::*};
+
+#[verifier(external)]
+fn main() {
+}
+
+verus!{
+
+// exmaple 0: conjunt
+proof fn test_expansion_very_easy() 
+{
+  let x = 5;
+  assert((x >= 0) && (x != 5));
+  //                  ^^^^^^^
+}
+
+
+// example1: simple function inline
+// 
+// TODO: check the span of `&&&`
+// spec fn is_good_integer(z: int) -> bool 
+// {
+//   &&& z >= 0
+//   &&& z != 5
+// }
+spec fn is_good_integer(z: int) -> bool 
+{
+  z >= 0 && z != 5
+//          ^^^^^^
+}
+
+proof fn test_expansion_easy() 
+{
+  let x = 5;
+  assert(is_good_integer(x));
+}
+
+
+
+// example2: simple `match` inline
+spec fn is_good_opt(opt: Option<int>) -> bool
+{
+  match opt {
+    Option::Some(k) => k > 10,
+    Option::None => true,
+  }
+}
+
+proof fn test_expansion_match() {
+  let x = Option::Some(5);
+  let y = Option::Some(4);
+  assert(is_good_opt(x));
+}
+
+
+// example3: 2-level failure
+spec fn is_good_integer_2(z: int) -> bool 
+{
+  z >= 0 && z != 5
+//          ^^^^^^
+}
+spec fn is_good_option(opt: Option<int>) -> bool
+{
+  match opt {
+    Option::Some(x) => is_good_integer_2(x),
+//                     ^^^^^^^^^^^^^^^^^^^^
+    Option::None => true,
+  }
+}
+
+proof fn test_expansion() {
+  let x = Option::Some(5);
+  let y = Option::Some(4);
+  assert(is_good_option(x));
+//^^^^^^ ^^^^^^^^^^^^^^^^^
+}
+
+
+// example4: 3-level failure
+#[derive(PartialEq, Eq)] 
+pub enum Message {
+    Quit(bool),
+    Move { x: i32, y: i32 },
+    Write(bool),
+}
+
+spec fn is_good_integer_3(x: int) -> bool 
+{
+    x >= 0 && x != 5
+//  ^^^^^^^
+}
+
+spec fn is_good_message(msg:Message) -> bool {
+    match msg {
+        Message::Quit(b) => b,
+        Message::Move{x, y} => is_good_integer_3( (x as int)  - (y as int)),
+//                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        Message::Write(b) => b,
+    }
+}
+
+spec fn is_good(msg: Message) -> bool {
+  is_good_message(msg)
+//^^^^^^^^^^^^^^^^^^^^
+}
+
+proof fn test_expansion_multiple_call() {
+  let x = Message::Move{x: 5, y:6};
+  assert(is_good(x));
+//^^^^^^ ^^^^^^^^^^
+}
+
+
+// example5: negation
+spec fn is_good_integer_5(x: int) -> bool 
+{
+    !(x < 0 || !(x != 5))
+//  |          | ^^^^^^
+//  |          This leftmost boolean-not negated the highlighted expression
+//  This leftmost boolean-not negated the highlighted expression
+}
+
+proof fn test_expansion_negate() 
+{
+  let x = 5;
+  assert(is_good_integer_5(x));
+//^^^^^^ ^^^^^^^^^^^^^^^^^^
+}
+
+
+// example6: forall
+spec fn seq_bounded_by_length(s1: Seq<int>) -> bool {
+  (forall|i:int| (0 <= i && i < s1.len())  ==> (0 <= s1.index(i) && s1.index(i) < s1.len()))
+//                                                                  ^^^^^^^^^^^^^^^^^^^^^^
+}
+
+proof fn test_expansion_forall() 
+{
+  let mut ss = Seq::empty();
+  ss = ss.push(0);
+  ss = ss.push(10);
+  assert(seq_bounded_by_length(ss));
+//^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^
+}
+
+
+
+
+// example7: requires
+spec fn is_good_integer_7(x: int) -> bool 
+{
+    x >= 0 && x != 5
+//  ^^^^^^  
+}
+
+spec fn is_good_message_7(msg:Message) -> bool {
+  match msg {
+      Message::Quit(b) => b,
+      Message::Move{x, y} => is_good_integer_7( (x as int)  - (y as int)),
+//                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      Message::Write(b) => b,
+  }
+}
+
+proof fn test_require_failure(m:Message, b: bool) -> (good_int: int)
+  requires 
+    b,
+    is_good_message_7(m),
+//  ^^^^^^^^^^^^^^^^^^^^
+  ensures
+    is_good_integer_7(good_int),
+{
+  return 0;
+}
+
+proof fn test_7(x:int) {
+  let x = Message::Move{x: 0, y: 5};
+  test_require_failure(x, true);
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  assert(false);
+}
+
+
+
+// example8: ensures
+spec fn is_good_integer_8(x: int) -> bool 
+{
+    x >= 0 && x != 5
+//            ^^^^^^  
+}
+
+spec fn is_good_message_8(msg:Message) -> bool {
+  match msg {
+      Message::Quit(b) => b,
+      Message::Move{x, y} => is_good_integer_8( (x as int)  - (y as int)),
+//                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      Message::Write(b) => b,
+  }
+}
+
+
+proof fn test_ensures_failure(b: bool) -> (good_msg: Message)
+  ensures
+  is_good_message_8(good_msg),
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^
+{
+  let mut ret =  Message::Write(true);
+  if !b {ret = Message::Move{x: 10, y: 5};}
+  ret
+}
+
+
+// example9: opaque/reveal
+#[verifier(opaque)]
+spec fn is_good_integer_9(x: int) -> bool 
+//   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Note: this function is opaque
+{
+  x >= 0 && x != 5
+}
+
+#[verifier(opaque)]
+spec fn is_good_message_9(msg:Message) -> bool {
+  match msg {
+      Message::Quit(b) => b,
+      Message::Move{x, y} => is_good_integer_9( (x as int)  - (y as int)),
+//                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      Message::Write(b) => b,
+  }
+}
+
+
+proof fn test_opaque(b: bool) {
+    let good_msg = Message::Move{x: 0, y: 0};
+    reveal(is_good_message_9);
+    assert(is_good_message_9(good_msg));
+//  ^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+}
+
+
+// example10: `reveal` does not flow
+#[verifier(opaque)]
+spec fn is_good_message_10(msg:Message) -> bool {
+//   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Note: this function is opaque
+  match msg {
+      Message::Quit(b) => b,
+      Message::Move{x, y} => is_good_integer_9( (x as int)  - (y as int)),
+      Message::Write(b) => b,
+  }
+}
+
+proof fn test_reveal(b: bool) {
+    let good_msg = Message::Move{x: 0, y: 0};
+    if b {
+      reveal(is_good_message_10);        
+    } else {
+      assert_by(true, {reveal(is_good_message_10);});
+      assert(is_good_message_10(good_msg));
+//    ^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^  
+    }
+}
+
+// example11: `hide`
+spec fn is_good_integer_11(x: int) -> bool 
+//   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Note: this function is opaque
+{
+  x >= 0 && x != 5
+}
+
+proof fn test_hide(b: bool) 
+{
+   hide(is_good_integer_11);
+   let i = 0;
+   assert(is_good_integer_11(i));
+// ^^^^^^ ^^^^^^^^^^^^^^^^^^
+}
+
+
+// example12: publish
+mod M3 {
+  pub closed spec fn is_good_integer(x: builtin::int) -> bool 
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Note: this function is closed at the module boundary
+  {
+    x >= 0 && x != 5
+  }
+}
+
+mod M4 {
+  #[allow(unused_imports)]
+  use crate::M3;
+  proof fn test_publish(b: bool) 
+  {
+    let i = 0;
+    assert(M3::is_good_integer(i));
+  //^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^
+  }
+}
+
+}

--- a/source/rust_verify/example/debug_expand.rs
+++ b/source/rust_verify/example/debug_expand.rs
@@ -307,4 +307,34 @@ mod M4 {
   }
 }
 
+
+// example13: reveal at ensures
+#[verifier(opaque)]
+spec fn is_good_integer_13(x: int) -> bool 
+//   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Note: this function is opaque
+{
+  x >= 0 && x != 5
+}
+
+#[verifier(opaque)]
+spec fn is_good_message_13(msg:Message) -> bool {
+  match msg {
+      Message::Quit(b) => b,
+      Message::Move{x, y} => is_good_integer_13( (x as int)  - (y as int)),
+//                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      Message::Write(b) => b,
+  }
+}
+
+proof fn test_reveal_at_ensures(b: bool) -> (good_msg: Message)
+  ensures
+    is_good_message_13(good_msg), 
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+{
+    let good_msg = Message::Move{x: 0, y: 0};
+    reveal(is_good_message_13);
+    good_msg
+}
+
+
 }

--- a/source/rust_verify/example/debug_expand.rs
+++ b/source/rust_verify/example/debug_expand.rs
@@ -337,4 +337,24 @@ proof fn test_reveal_at_ensures(b: bool) -> (good_msg: Message)
 }
 
 
+// example14: respect binder when function inlining
+spec fn positive(yy: int) -> bool {
+  0 < yy
+//^^^^^^
+}
+
+spec fn is_good_integer_14(yy: int) -> bool 
+{
+  forall |yy:int| positive(yy)      // shouldn't replace `yy` with `1` 
+//                ^^^^^^^^^^^^  
+}
+
+proof fn test_binder_inlining(b: bool) 
+{
+  assert(is_good_integer_14(1));
+//^^^^^^ ^^^^^^^^^^^^^^^^^^^^^
+}
+
+
+
 }

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -54,7 +54,7 @@ pub struct Verifier {
     air_no_span: Option<air::ast::Span>,
     inferred_modes: Option<HashMap<InferMode, Mode>>,
 
-    // debugging aid purposes
+    // proof debugging purposes
     expand_flag: bool,
     pub expand_targets: Vec<air::errors::Error>,
     pub expanded_errors: Vec<Vec<ErrorSpan>>,
@@ -969,11 +969,10 @@ impl Verifier {
 
         // In the presence of error, re-verify this module with "splitted expressions" of failing assertions/requires/ensures
         // to get more precise error message.
-        // TODO: might separate into `self.debug_module(..)`
         if !self.encountered_vir_error && before_err_count < self.count_errors {
             // TODO: log in a different file?
             ctx.debug_expand_targets = self.expand_targets.to_vec(); // TODO: avoid copying
-            ctx.debug = true;
+            ctx.expand_flag = true;
             self.expand_flag = true;
             self.verify_module(compiler, &poly_krate, module, &mut ctx)?; // maybe report error it is new?(not reporting if it had no impact)
         }

--- a/source/rust_verify/tests/common/mod.rs
+++ b/source/rust_verify/tests/common/mod.rs
@@ -214,7 +214,7 @@ fn relevant_error_span(err: &Vec<ErrorSpan>) -> &ErrorSpan {
     if let Some(e) = err.iter().find(|e| e.description == Some("at this exit".to_string())) {
         return e;
     } else if let Some(e) = err.iter().find(|e| {
-        e.description == Some("failed this postcondition".to_string())
+        e.description == Some(vir::def::THIS_POST_FAILED.to_string())
             && !e.test_span_line.contains("TRAIT")
     }) {
         return e;

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -608,9 +608,7 @@ fn stm_call(
                 &crate::split_expression::TracedExpX::new(args[0].0.clone(), error.clone()),
                 false,
             );
-            if exprs.is_err() {
-                (); // TODO: instead of silent continue, report user that this is not inlined
-            } else {
+            if exprs.is_ok() {
                 let exprs = exprs.unwrap();
                 stms.extend(
                     crate::split_expression::register_splitted_assertions(exprs).into_iter(),
@@ -627,7 +625,7 @@ fn stm_call(
                 let exp_subsituted =
                     crate::split_expression::tr_inline_expression(&exp, params, &arg_exps);
                 if exp_subsituted.is_err() {
-                    continue; // TODO: instead of silent continue, report user that this is not inlined
+                    continue;
                 }
                 let exp_subsituted = exp_subsituted.unwrap();
                 let error = air::errors::error("splitted requires failure", span);
@@ -637,13 +635,12 @@ fn stm_call(
                     &crate::split_expression::TracedExpX::new(exp_subsituted, error.clone()),
                     false,
                 );
-                if exprs.is_err() {
-                    continue; // TODO: instead of silent continue, report user that this is not inlined
+                if exprs.is_ok() {
+                    let exprs = exprs.unwrap();
+                    stms.extend(
+                        crate::split_expression::register_splitted_assertions(exprs).into_iter(),
+                    );
                 }
-                let exprs = exprs.unwrap();
-                stms.extend(
-                    crate::split_expression::register_splitted_assertions(exprs).into_iter(),
-                );
             }
         }
     }

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -42,6 +42,10 @@ pub(crate) struct State {
     pub(crate) ret_post: Option<(Option<UniqueIdent>, Vec<Stm>, Exps)>,
     // If > 0, disable checking recommends (used to make sure pure expressions stay pure)
     disable_recommends: u64,
+    // For debug purpose, track the status of fuel for each function. Since `reveal` statement can change the fuel locally.
+    reveal_map: Vec<HashMap<Fun, u32>>, //  HashMap<Fun, fuel>
+    // For debug purporse, track the function that is being translated
+    pub(crate) fun: Option<Fun>,
 }
 
 #[derive(Clone)]
@@ -91,6 +95,8 @@ impl State {
     pub fn new() -> Self {
         let mut rename_map = ScopeMap::new();
         rename_map.push_scope(true);
+        let mut reveal_map = Vec::new();
+        reveal_map.push(HashMap::new());
         State {
             view_as_spec: false,
             next_var: 0,
@@ -100,6 +106,8 @@ impl State {
             dont_rename: HashSet::new(),
             ret_post: None,
             disable_recommends: 0,
+            reveal_map,
+            fun: None,
         }
     }
 
@@ -203,6 +211,29 @@ impl State {
     fn checking_recommends(&self, ctx: &Ctx) -> bool {
         ctx.checking_recommends() && self.disable_recommends == 0
     }
+
+    // debug purposes
+    fn record_fuel(&mut self, x: &Fun, fuel: u32) {
+        let mut last = self.reveal_map.pop().unwrap();
+        last.insert(x.clone(), fuel);
+        self.reveal_map.push(last);
+    }
+    pub(crate) fn find_fuel(&self, x: &Fun) -> Option<u32> {
+        for rmap in &self.reveal_map {
+            if let Some(local_fuel) = rmap.get(x) {
+                return Some(*local_fuel);
+            }
+        }
+        None
+    }
+
+    // debug purposes. if some expr can contain `proof` block, push and pop around that proof block's translation
+    pub(crate) fn push_fuel_scope(&mut self) {
+        self.reveal_map.push(HashMap::new());
+    }
+    pub(crate) fn pop_fuel_scope(&mut self) {
+        self.reveal_map.pop();
+    }
 }
 
 pub(crate) fn var_loc_exp(span: &Span, typ: &Typ, lhs: UniqueIdent) -> Exp {
@@ -219,7 +250,7 @@ fn init_var(span: &Span, x: &UniqueIdent, exp: &Exp) -> Stm {
     )
 }
 
-fn get_function(ctx: &Ctx, span: &Span, name: &Fun) -> Result<Function, VirErr> {
+pub(crate) fn get_function(ctx: &Ctx, span: &Span, name: &Fun) -> Result<Function, VirErr> {
     match ctx.func_map.get(name) {
         None => err_string(span, format!("could not find function {:?}", &name)),
         Some(func) => Ok(func.clone()),
@@ -563,8 +594,47 @@ fn stm_call(
     dest: Option<Dest>,
 ) -> Result<Stm, VirErr> {
     let fun = get_function(ctx, span, &name)?;
-    let mut small_args: Vec<Exp> = Vec::new();
     let mut stms: Vec<Stm> = Vec::new();
+    if ctx.debug && crate::split_expression::need_split_expression(ctx, span) {
+        if name.path.segments[0].to_string() == "pervasive".to_string()
+            && name.path.segments[1].to_string() == "assert".to_string()
+        {
+            // take the boolean argument, and split this expressino into pieces.
+            // then push all these as extra assertions
+            let error = air::errors::error("splitted assertion failure", span);
+            let exprs = crate::split_expression::split_expr(
+                ctx,
+                state,
+                &crate::split_expression::TracedExpX::new(args[0].0.clone(), error.clone()),
+                false,
+            );
+            stms = crate::split_expression::register_splitted_assertions(exprs);
+        } else {
+            // we are spliting the `requires` expression on the call site.
+            // If we split the `requires` expression on the function itself,
+            // this splitted encoding will take effect on every call site, which is not desirable.
+            let params = &fun.x.params;
+            for e in &**fun.x.require {
+                let exp = crate::split_expression::pure_ast_expression_to_sst(ctx, e, params);
+                let arg_exps = Arc::new(vec_map(&args, |x| x.0.clone()));
+                let exp_subsituted =
+                    match crate::split_expression::tr_inline_expression(&exp, params, &arg_exps) {
+                        Ok(e) => e,
+                        Err(..) => panic!("remove this panic: failed requires substitution"),
+                    };
+                let error = air::errors::error("splitted requires failure", span);
+                let exprs = crate::split_expression::split_expr(
+                    ctx,
+                    state,
+                    &crate::split_expression::TracedExpX::new(exp_subsituted, error.clone()),
+                    false,
+                );
+                stms = crate::split_expression::register_splitted_assertions(exprs);
+            }
+        }
+    }
+
+    let mut small_args: Vec<Exp> = Vec::new();
     for arg in args.iter() {
         if is_small_exp_or_loc(&arg.0) {
             small_args.push(arg.0.clone());
@@ -1027,6 +1097,7 @@ fn expr_to_stm_opt(
         }
         ExprX::Fuel(x, fuel) => {
             let stm = Spanned::new(expr.span.clone(), StmX::Fuel(x.clone(), *fuel));
+            state.record_fuel(x, *fuel);
             Ok((vec![stm], ReturnValue::ImplicitUnit(expr.span.clone())))
         }
         ExprX::Header(_) => {
@@ -1052,7 +1123,9 @@ fn expr_to_stm_opt(
                 let x = state.declare_new_var(&var.name, &var.a, false, true);
                 body.push(assume_has_typ(&x, &var.a, &require.span));
             }
+            state.push_fuel_scope();
             let (mut proof_stms, e) = expr_to_stm_opt(ctx, state, proof)?;
+            state.pop_fuel_scope();
             if let ReturnValue::Some(_) = e {
                 return err_str(&expr.span, "forall/assert-by cannot end with an expression");
             }
@@ -1098,7 +1171,9 @@ fn expr_to_stm_opt(
                 inner_body.push(assume);
             }
 
+            state.push_fuel_scope();
             let (proof_stms, e) = expr_to_stm_opt(ctx, state, proof)?;
+            state.pop_fuel_scope();
             if let ReturnValue::Some(_) = e {
                 return err_str(&expr.span, "forall/assert-by cannot end with an expression");
             }
@@ -1169,15 +1244,21 @@ fn expr_to_stm_opt(
         }
         ExprX::If(expr0, expr1, None) => {
             let (stms0, e0) = expr_to_stm_opt(ctx, state, expr0)?;
+            state.push_fuel_scope();
             let (stms1, e1) = expr_to_stm_opt(ctx, state, expr1)?;
+            state.pop_fuel_scope();
             let stms2 = vec![];
             let e2 = ReturnValue::ImplicitUnit(expr.span.clone());
             Ok(if_to_stm(state, expr, stms0, &e0, stms1, &e1, stms2, &e2))
         }
         ExprX::If(expr0, expr1, Some(expr2)) => {
             let (stms0, e0) = expr_to_stm_opt(ctx, state, expr0)?;
+            state.push_fuel_scope();
             let (stms1, e1) = expr_to_stm_opt(ctx, state, expr1)?;
+            state.pop_fuel_scope();
+            state.push_fuel_scope();
             let (stms2, e2) = expr_to_stm_opt(ctx, state, expr2)?;
+            state.pop_fuel_scope();
             Ok(if_to_stm(state, expr, stms0, &e0, stms1, &e1, stms2, &e2))
         }
         ExprX::Match(..) => {
@@ -1196,8 +1277,9 @@ fn expr_to_stm_opt(
                     return Ok((stms0, ReturnValue::Never));
                 }
             };
-
+            state.push_fuel_scope();
             let (mut stms1, e1) = expr_to_stm_opt(ctx, state, body)?;
+            state.pop_fuel_scope();
             check_unit_or_never(&e1)?;
             let (check_recommends, invs): (Vec<Vec<Stm>>, Vec<Exp>) =
                 vec_map_result(invs, |e| expr_to_pure_exp_check(ctx, state, e))?

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -595,7 +595,7 @@ fn stm_call(
 ) -> Result<Stm, VirErr> {
     let fun = get_function(ctx, span, &name)?;
     let mut stms: Vec<Stm> = Vec::new();
-    if ctx.debug && crate::split_expression::need_split_expression(ctx, span) {
+    if ctx.expand_flag && crate::split_expression::need_split_expression(ctx, span) {
         if name.path.segments[0].to_string() == "pervasive".to_string()
             && name.path.segments[1].to_string() == "assert".to_string()
         {
@@ -1382,11 +1382,11 @@ fn expr_to_stm_opt(
                 }
                 for ens in enss.iter() {
                     let error = error_with_label(
-                        "postcondition not satisfied".to_string(),
+                        crate::def::POSTCONDITION_FAILURE.to_string(),
                         &expr.span,
                         "at this exit".to_string(),
                     )
-                    .secondary_label(&ens.span, "failed this postcondition".to_string());
+                    .secondary_label(&ens.span, crate::def::THIS_POST_FAILED.to_string());
                     stms.push(Spanned::new(
                         expr.span.clone(),
                         StmX::Assert(Some(error), ens.clone()),

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -42,9 +42,9 @@ pub(crate) struct State {
     pub(crate) ret_post: Option<(Option<UniqueIdent>, Vec<Stm>, Exps)>,
     // If > 0, disable checking recommends (used to make sure pure expressions stay pure)
     disable_recommends: u64,
-    // For debug purpose, track the status of fuel for each function. Since `reveal` statement can change the fuel locally.
+    // For proof debug purpose, track the status of fuel for each function. Since `reveal`, `reveal_with_fuel` can change the fuel locally.
     reveal_map: Vec<HashMap<Fun, u32>>, //  HashMap<Fun, fuel>
-    // For debug purporse, track the function that is being translated
+    // For proof debug purporse, track the function that is being translated
     pub(crate) fun: Option<Fun>,
 }
 

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -601,7 +601,8 @@ fn stm_call(
         {
             // take the boolean argument, and split this expressino into pieces.
             // then push all these as extra assertions
-            let error = air::errors::error("splitted assertion failure", span);
+            // original span needed for later use -- to check if this additional assertion produces additional info
+            let error = air::errors::error(crate::def::SPLIT_ASSERT_FAILURE, span);
             let exprs = crate::split_expression::split_expr(
                 ctx,
                 state,
@@ -628,7 +629,7 @@ fn stm_call(
                     continue;
                 }
                 let exp_subsituted = exp_subsituted.unwrap();
-                let error = air::errors::error("splitted requires failure", span);
+                let error = air::errors::error(crate::def::SPLIT_PRE_FAILURE.to_string(), span);
                 let exprs = crate::split_expression::split_expr(
                     ctx,
                     state,

--- a/source/vir/src/context.rs
+++ b/source/vir/src/context.rs
@@ -65,10 +65,12 @@ pub struct Ctx {
     pub(crate) funcs_with_ensure_predicate: HashSet<Fun>,
     pub(crate) datatype_map: HashMap<Path, Datatype>,
     pub(crate) trait_map: HashMap<Path, Trait>,
-    pub debug: bool,
-    pub debug_expand_targets: Vec<air::errors::Error>,
-    pub fun: Option<FunctionCtx>,
     pub global: GlobalCtx,
+    pub fun: Option<FunctionCtx>,
+    // proof debug purposes
+    pub debug: bool,
+    pub expand_flag: bool,
+    pub debug_expand_targets: Vec<air::errors::Error>,
 }
 
 impl Ctx {
@@ -259,10 +261,11 @@ impl Ctx {
             funcs_with_ensure_predicate,
             datatype_map,
             trait_map,
-            debug,
-            debug_expand_targets: vec![],
             fun: None,
             global,
+            debug,
+            expand_flag: false,
+            debug_expand_targets: vec![],
         })
     }
 

--- a/source/vir/src/context.rs
+++ b/source/vir/src/context.rs
@@ -65,7 +65,8 @@ pub struct Ctx {
     pub(crate) funcs_with_ensure_predicate: HashSet<Fun>,
     pub(crate) datatype_map: HashMap<Path, Datatype>,
     pub(crate) trait_map: HashMap<Path, Trait>,
-    pub(crate) debug: bool,
+    pub debug: bool,
+    pub debug_expand_targets: Vec<air::errors::Error>,
     pub fun: Option<FunctionCtx>,
     pub global: GlobalCtx,
 }
@@ -259,6 +260,7 @@ impl Ctx {
             datatype_map,
             trait_map,
             debug,
+            debug_expand_targets: vec![],
             fun: None,
             global,
         })

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -132,6 +132,10 @@ pub const QID_ACCESSOR: &str = "accessor";
 pub const QID_INVARIANT: &str = "invariant";
 pub const QID_HAS_TYPE_ALWAYS: &str = "has_type_always";
 
+// List of pre-defined error messages
+pub const POSTCONDITION_FAILURE: &str = "postcondition not satisfied";
+pub const THIS_POST_FAILED: &str = "failed this postcondition";
+
 // We assume that usize is at least ARCH_SIZE_MIN_BITS wide
 pub const ARCH_SIZE_MIN_BITS: u32 = 32;
 

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -133,8 +133,13 @@ pub const QID_INVARIANT: &str = "invariant";
 pub const QID_HAS_TYPE_ALWAYS: &str = "has_type_always";
 
 // List of pre-defined error messages
+pub const ASSERTION_FAILURE: &str = "assertion failure";
+pub const PRECONDITION_FAILURE: &str = "precondition not satisfied";
 pub const POSTCONDITION_FAILURE: &str = "postcondition not satisfied";
 pub const THIS_POST_FAILED: &str = "failed this postcondition";
+pub const SPLIT_ASSERT_FAILURE: &str = "splitted assertion failure";
+pub const SPLIT_PRE_FAILURE: &str = "splitted precondition failure";
+pub const SPLIT_POST_FAILURE: &str = "splitted postcondition failure";
 
 // We assume that usize is at least ARCH_SIZE_MIN_BITS wide
 pub const ARCH_SIZE_MIN_BITS: u32 = 32;

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -654,7 +654,9 @@ pub fn func_def_to_air(
                     ens_stmts.extend(crate::ast_to_sst::check_pure_expr(ctx, &mut state, e)?);
                 } else {
                     // split failing ensures expressions into additional assertions
-                    if ctx.debug && crate::split_expression::need_split_expression(ctx, &e.span) {
+                    if ctx.expand_flag
+                        && crate::split_expression::need_split_expression(ctx, &e.span)
+                    {
                         let ens_exp = crate::ast_to_sst::expr_to_exp(ctx, &ens_pars, e)?;
                         let error = air::errors::error("splitted ensures failure", &ens_exp.span);
                         let splitted_exprs = crate::split_expression::split_expr(
@@ -705,7 +707,7 @@ pub fn func_def_to_air(
                 stm = crate::ast_to_sst::stms_to_one_stm(&body.span, req_stms);
             }
             // add splitted ensures expressions for error localization
-            let stm = if ctx.debug {
+            let stm = if ctx.expand_flag {
                 let mut my_stms = vec![stm.clone()];
                 my_stms.extend(small_ens_assertions);
                 crate::ast_to_sst::stms_to_one_stm(&stm.span, my_stms)

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -666,9 +666,16 @@ pub fn func_def_to_air(
                             ),
                             false,
                         );
-                        small_ens_assertions.extend(
-                            crate::split_expression::register_splitted_assertions(splitted_exprs),
-                        );
+                        if splitted_exprs.is_err() {
+                            ()
+                        } else {
+                            let splitted_exprs = splitted_exprs.unwrap();
+                            small_ens_assertions.extend(
+                                crate::split_expression::register_splitted_assertions(
+                                    splitted_exprs,
+                                ),
+                            );
+                        }
                         enss.push(ens_exp);
                     } else {
                         enss.push(crate::ast_to_sst::expr_to_exp(ctx, &ens_pars, e)?);

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -648,40 +648,11 @@ pub fn func_def_to_air(
             }
             let mut ens_stmts: Vec<Stm> = Vec::new();
             let mut enss: Vec<Exp> = Vec::new();
-            let mut small_ens_assertions = vec![];
             for e in req_ens_function.x.ensure.iter() {
                 if ctx.checking_recommends() {
                     ens_stmts.extend(crate::ast_to_sst::check_pure_expr(ctx, &mut state, e)?);
                 } else {
-                    // split failing ensures expressions into additional assertions
-                    if ctx.expand_flag
-                        && crate::split_expression::need_split_expression(ctx, &e.span)
-                    {
-                        let ens_exp = crate::ast_to_sst::expr_to_exp(ctx, &ens_pars, e)?;
-                        let error = air::errors::error("splitted ensures failure", &ens_exp.span);
-                        let splitted_exprs = crate::split_expression::split_expr(
-                            ctx,
-                            &mut crate::ast_to_sst::State::new(), // TODO: get the final state from this body's translation
-                            &crate::split_expression::TracedExpX::new(
-                                ens_exp.clone(),
-                                error.clone(),
-                            ),
-                            false,
-                        );
-                        if splitted_exprs.is_err() {
-                            ()
-                        } else {
-                            let splitted_exprs = splitted_exprs.unwrap();
-                            small_ens_assertions.extend(
-                                crate::split_expression::register_splitted_assertions(
-                                    splitted_exprs,
-                                ),
-                            );
-                        }
-                        enss.push(ens_exp);
-                    } else {
-                        enss.push(crate::ast_to_sst::expr_to_exp(ctx, &ens_pars, e)?);
-                    }
+                    enss.push(crate::ast_to_sst::expr_to_exp(ctx, &ens_pars, e)?);
                 }
             }
             let enss = Arc::new(enss);
@@ -706,8 +677,35 @@ pub fn func_def_to_air(
                 }
                 stm = crate::ast_to_sst::stms_to_one_stm(&body.span, req_stms);
             }
-            // add splitted ensures expressions for error localization
-            let stm = if ctx.expand_flag {
+
+            let stm = if !ctx.checking_recommends() && ctx.expand_flag {
+                // split ensures expressions for error localization
+                let mut small_ens_assertions = vec![];
+                for e in req_ens_function.x.ensure.iter() {
+                    if crate::split_expression::need_split_expression(ctx, &e.span) {
+                        let ens_exp = crate::ast_to_sst::expr_to_exp(ctx, &ens_pars, e)?;
+                        let error = air::errors::error("splitted ensures failure", &ens_exp.span);
+                        let splitted_exprs = crate::split_expression::split_expr(
+                            ctx,
+                            &state,
+                            &crate::split_expression::TracedExpX::new(
+                                ens_exp.clone(),
+                                error.clone(),
+                            ),
+                            false,
+                        );
+                        if splitted_exprs.is_err() {
+                            ()
+                        } else {
+                            let splitted_exprs = splitted_exprs.unwrap();
+                            small_ens_assertions.extend(
+                                crate::split_expression::register_splitted_assertions(
+                                    splitted_exprs,
+                                ),
+                            );
+                        }
+                    }
+                }
                 let mut my_stms = vec![stm.clone()];
                 my_stms.extend(small_ens_assertions);
                 crate::ast_to_sst::stms_to_one_stm(&stm.span, my_stms)

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -684,7 +684,7 @@ pub fn func_def_to_air(
                 for e in req_ens_function.x.ensure.iter() {
                     if crate::split_expression::need_split_expression(ctx, &e.span) {
                         let ens_exp = crate::ast_to_sst::expr_to_exp(ctx, &ens_pars, e)?;
-                        let error = air::errors::error("splitted ensures failure", &ens_exp.span);
+                        let error = air::errors::error(crate::def::SPLIT_POST_FAILURE, &e.span);
                         let splitted_exprs = crate::split_expression::split_expr(
                             ctx,
                             &state, // use the state after `body` translation to get the fuel info

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -687,16 +687,14 @@ pub fn func_def_to_air(
                         let error = air::errors::error("splitted ensures failure", &ens_exp.span);
                         let splitted_exprs = crate::split_expression::split_expr(
                             ctx,
-                            &state,
+                            &state, // use the state after `body` translation to get the fuel info
                             &crate::split_expression::TracedExpX::new(
                                 ens_exp.clone(),
                                 error.clone(),
                             ),
                             false,
                         );
-                        if splitted_exprs.is_err() {
-                            ()
-                        } else {
+                        if splitted_exprs.is_ok() {
                             let splitted_exprs = splitted_exprs.unwrap();
                             small_ens_assertions.extend(
                                 crate::split_expression::register_splitted_assertions(

--- a/source/vir/src/lib.rs
+++ b/source/vir/src/lib.rs
@@ -50,6 +50,7 @@ pub mod prune;
 pub mod recursion;
 pub mod recursive_types;
 mod scc;
+pub mod split_expression;
 pub mod sst;
 mod sst_to_air;
 mod sst_util;

--- a/source/vir/src/split_expression.rs
+++ b/source/vir/src/split_expression.rs
@@ -1,0 +1,470 @@
+use crate::ast::{BinaryOp, Expr, Function, Params, Quant, SpannedTyped, Typ, TypX, UnaryOp};
+use crate::ast_to_sst::{get_function, State};
+use crate::context::Ctx;
+use crate::def::Spanned;
+use crate::sst::{Bnd, BndX, Exp, ExpX, Exps, Stm, StmX};
+use air::ast::{Binder, BinderX, Span};
+use core::panic;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+fn subsitute_argument(
+    exp: &Exp,
+    arg_map: &HashMap<Arc<String>, Exp>,
+) -> Result<Exp, (Span, String)> {
+    let result = match &exp.x {
+        ExpX::Var((id, _num)) => {
+            // println!("id: {:?}", id);
+            match arg_map.get(id) {
+                Some(e) => e.clone(),
+                None => exp.clone(),
+            }
+        }
+        ExpX::Call(x, typs, es) => {
+            let mut es_replaced = vec![];
+            for e in es.iter() {
+                let e_replaced = subsitute_argument(e, arg_map)?;
+                es_replaced.push(e_replaced);
+            }
+            let new_exp = ExpX::Call(x.clone(), typs.clone(), Arc::new(es_replaced));
+            SpannedTyped::new(&exp.span, &exp.typ, new_exp)
+        }
+        ExpX::Unary(op, e1) => {
+            let e1_replaced = subsitute_argument(e1, arg_map)?;
+            let new_exp = ExpX::Unary(*op, e1_replaced);
+            SpannedTyped::new(&exp.span, &exp.typ, new_exp)
+        }
+        ExpX::UnaryOpr(uop, e1) => {
+            let e1_replaced = subsitute_argument(e1, arg_map)?;
+            let new_exp = ExpX::UnaryOpr(uop.clone(), e1_replaced);
+            SpannedTyped::new(&exp.span, &exp.typ, new_exp)
+        }
+        ExpX::Binary(bop, e1, e2) => {
+            let e1_replaced = subsitute_argument(e1, arg_map)?;
+            let e2_replaced = subsitute_argument(e2, arg_map)?;
+            let new_exp = ExpX::Binary(*bop, e1_replaced, e2_replaced);
+            SpannedTyped::new(&exp.span, &exp.typ, new_exp)
+        }
+        ExpX::If(e1, e2, e3) => {
+            let e1_replaced = subsitute_argument(e1, arg_map)?;
+            let e2_replaced = subsitute_argument(e2, arg_map)?;
+            let e3_replaced = subsitute_argument(e3, arg_map)?;
+            let new_exp = ExpX::If(e1_replaced, e2_replaced, e3_replaced);
+            SpannedTyped::new(&exp.span, &exp.typ, new_exp)
+        }
+        ExpX::Bind(bnd, e1) => {
+            // TODO: check if binded name and  `var to replace` is same
+            let e1_replaced = subsitute_argument(e1, arg_map)?;
+            let bnd_replaced: Bnd = match &bnd.x {
+                BndX::Let(binders) => {
+                    let mut new_binders: Vec<Binder<Exp>> = vec![];
+                    for old_b in &**binders {
+                        let new_b = BinderX {
+                            name: old_b.name.clone(),
+                            a: subsitute_argument(&old_b.a, arg_map)?,
+                        };
+                        new_binders.push(Arc::new(new_b));
+                    }
+                    Spanned::new(bnd.span.clone(), BndX::Let(Arc::new(new_binders)))
+                }
+                BndX::Quant(quant, bndrs, trigs) => {
+                    // replace vars in trigger
+                    let mut replaced_trigs: Vec<crate::sst::Trig> = vec![];
+                    for ts in &***trigs {
+                        let mut replaced_ts: Vec<Exp> = vec![];
+                        for t in &**ts {
+                            replaced_ts.push(subsitute_argument(t, arg_map)?);
+                        }
+                        replaced_trigs.push(Arc::new(replaced_ts));
+                    }
+                    Spanned::new(
+                        bnd.span.clone(),
+                        BndX::Quant(quant.clone(), bndrs.clone(), Arc::new(replaced_trigs)),
+                    )
+                }
+                _ => return Err((exp.span.clone(), format!("TODO: binders, subsitute_argument"))),
+            };
+            let new_exp = ExpX::Bind(bnd_replaced, e1_replaced);
+            SpannedTyped::new(&exp.span, &exp.typ, new_exp)
+        }
+        ExpX::Const(_) => exp.clone(),
+        _ => {
+            // | ExpX::WithTriggers(_, _) => exp.clone()
+            // VarLoc(UniqueIdent),
+            // VarAt(UniqueIdent, VarAt),
+            // Loc(Exp),
+            // Old(Ident, UniqueIdent),
+            // CallLambda(Typ, Exp, Exps),
+            // Ctor(Path, Ident, Binders<Exp>),
+            // WithTriggers(Trigs, Exp),
+            return Err((exp.span.clone(), format!("TODO: unsubsituted exp, subsitute_argument ")));
+        }
+    };
+    Ok(result)
+}
+
+// e1: param, e2: exp_to_replace
+fn assert_same_type(param_typ: &Typ, e2: &Exp) -> Result<(), (Span, String)> {
+    match (&**param_typ, &*e2.typ) {
+        (TypX::Bool, TypX::Bool) |
+        (TypX::Int(_),TypX::Int(_)) |
+        (TypX::Tuple(_), TypX::Tuple(_)) |
+        (TypX::Lambda(_, _), TypX::Lambda(_,_)) |
+        (TypX::Datatype(_, _), TypX::Datatype(_,_)) |
+        // TODO: recursive check instead
+        (TypX::Boxed(_), TypX::Boxed(_)) |
+        (TypX::TypParam(_), TypX::TypParam(_)) |
+        (TypX::TypeId, TypX::TypeId) |
+        (TypX::Air(_), TypX::Air(_)) => Ok(()),
+        _ => return Err((e2.span.clone(), "TODO or interal error: arg type mismatch during function inlining".to_string())),
+    }
+}
+pub(crate) fn tr_inline_expression(
+    body_exp: &Exp,
+    params: &Params,
+    exps: &Exps,
+) -> Result<Exp, (Span, String)> {
+    let mut arg_map: HashMap<Arc<String>, Exp> = HashMap::new();
+    let mut count = 0;
+    for param in &**params {
+        let exp_to_insert = &exps[count];
+        assert_same_type(&param.x.typ, exp_to_insert)?;
+        arg_map.insert(param.x.name.clone(), exp_to_insert.clone());
+        count = count + 1;
+    }
+    return subsitute_argument(body_exp, &arg_map);
+}
+
+// TODO: see if I can use `expr_to_exp_as_spec` instead of below one
+pub(crate) fn pure_ast_expression_to_sst(ctx: &Ctx, body: &Expr, params: &Params) -> Exp {
+    // let pars = crate::func_to_air::params_to_pars(params, false);
+    // let mut state = crate::ast_to_sst::State::new();
+    // state.declare_params(&pars);
+    // state.view_as_spec = true;
+    // let body_exp = expr_to_pure_exp(&ctx, &mut state, &body).expect("pure_ast_expression_to_sst");
+    // state.finalize_exp(&body_exp)
+    crate::ast_to_sst::expr_to_exp_as_spec(
+        &ctx,
+        &crate::func_to_air::params_to_pars(params, false),
+        &body,
+    )
+    .expect("pure_ast_expression_to_sst")
+}
+
+fn tr_inline_function(
+    ctx: &Ctx,
+    state: &State,
+    fun_to_inline: Function,
+    exps: &Exps,
+    span: &Span,
+) -> Result<Exp, (Span, String)> {
+    // TODO: recursive function inline. don't inline
+    let opaque_err = Err((fun_to_inline.span.clone(), "Note: this function is opaque".to_string()));
+    let closed_err = Err((
+        fun_to_inline.span.clone(),
+        "Note: this function is closed at the module boundary".to_string(),
+    ));
+    let foriegn_module_err = Err((
+        fun_to_inline.span.clone(),
+        "Note: this function is inside a foriegn module".to_string(),
+    ));
+    let mut found_local_fuel = false;
+    let fuel = match state.find_fuel(&fun_to_inline.x.name) {
+        Some(local_fuel) => {
+            found_local_fuel = true;
+            local_fuel
+        } // prefer local_fuel on fun.x.fuel. local_fuel tracks `reveal` statements
+        None => fun_to_inline.x.fuel,
+    };
+
+    let mut hidden = false; // track `hide` statement
+    match &state.fun {
+        Some(f) => {
+            let fun_owner = get_function(ctx, span, f).unwrap();
+            let fs_to_hide = &fun_owner.x.attrs.hidden;
+            for f_to_hide in &**fs_to_hide {
+                if **f_to_hide == *fun_to_inline.x.name {
+                    hidden = true;
+                };
+            }
+        }
+        None => (), // should I panic instead?
+    };
+
+    if fuel == 0 || (!found_local_fuel && hidden) {
+        return opaque_err;
+    } else {
+        if fun_to_inline.x.visibility.owning_module.is_none() {
+            return foriegn_module_err;
+        } else {
+            if *ctx.module != **fun_to_inline.x.visibility.owning_module.as_ref().unwrap() {
+                // if the target inline function is outside this module, track `open` `closed` at module boundaries
+                match fun_to_inline.x.publish {
+                    Some(b) => {
+                        if !b {
+                            return opaque_err;
+                        }
+                    }
+                    None => {
+                        return closed_err;
+                    }
+                };
+            }
+        }
+
+        let body = match fun_to_inline.x.body.as_ref() {
+            Some(body) => body,
+            None => {
+                return closed_err;
+            }
+        };
+        let params = &fun_to_inline.x.params;
+        let body_exp = pure_ast_expression_to_sst(ctx, body, params);
+        return tr_inline_expression(&body_exp, params, exps);
+    }
+}
+
+// trace
+// 1) when inlining function, log call stack into `trace`
+// 2) boolean negation
+pub type TracedExp = Arc<TracedExpX>;
+pub type TracedExps = Arc<Vec<TracedExp>>;
+pub struct TracedExpX {
+    pub e: Exp,
+    pub trace: air::errors::Error,
+}
+impl TracedExpX {
+    pub fn new(e: Exp, trace: air::errors::Error) -> TracedExp {
+        Arc::new(TracedExpX { e, trace })
+    }
+}
+
+fn negate_atom(exp: TracedExp) -> TracedExp {
+    let negated_expx = ExpX::Unary(UnaryOp::Not, exp.e.clone());
+    let negated_exp = SpannedTyped::new(&exp.e.span, &exp.e.typ, negated_expx);
+    TracedExpX::new(negated_exp, exp.trace.clone())
+}
+
+macro_rules! return_atom {
+    ($e:expr, $negated:expr) => {
+        if $negated {
+            return Arc::new(vec![negate_atom($e)]);
+        } else {
+            return Arc::new(vec![$e]);
+        }
+    };
+}
+
+fn merge_two_es(es1: TracedExps, es2: TracedExps) -> TracedExps {
+    let mut merged_vec = vec![];
+    for e in &*es1 {
+        merged_vec.push(e.clone());
+    }
+    for e in &*es2 {
+        merged_vec.push(e.clone());
+    }
+    return Arc::new(merged_vec);
+}
+
+// Note: this splitting referenced Dafny
+// https://github.com/dafny-lang/dafny/blob/cf285b9282499c46eb24f05c7ecc7c72423cd878/Source/Dafny/Verifier/Translator.cs#L11100
+pub(crate) fn split_expr(ctx: &Ctx, state: &State, exp: &TracedExp, negated: bool) -> TracedExps {
+    match *exp.e.typ {
+        TypX::Bool => (),
+        _ => panic!("cannot split non boolean expression"),
+    }
+    match &exp.e.x {
+        ExpX::Unary(UnaryOp::Not, e1) => {
+            let tr_exp = TracedExpX::new(
+                e1.clone(),
+                exp.trace.secondary_label(
+                    &exp.e.span,
+                    "This leftmost boolean-not negated the highlighted expression",
+                ),
+            );
+            return split_expr(ctx, state, &tr_exp, !negated);
+        }
+        ExpX::Binary(bop, e1, e2) => {
+            match bop {
+                BinaryOp::And if !negated => {
+                    let es1 = split_expr(
+                        ctx,
+                        state,
+                        &TracedExpX::new(e1.clone(), exp.trace.clone()),
+                        false,
+                    );
+                    let es2 = split_expr(
+                        ctx,
+                        state,
+                        &TracedExpX::new(e2.clone(), exp.trace.clone()),
+                        false,
+                    );
+                    return merge_two_es(es1, es2);
+                }
+                // apply DeMorgan's Law
+                BinaryOp::Or if negated => {
+                    let es1 = split_expr(
+                        ctx,
+                        state,
+                        &TracedExpX::new(e1.clone(), exp.trace.clone()),
+                        true,
+                    );
+                    let es2 = split_expr(
+                        ctx,
+                        state,
+                        &TracedExpX::new(e2.clone(), exp.trace.clone()),
+                        true,
+                    );
+                    return merge_two_es(es1, es2);
+                }
+                // in case of implies, split rhs. (e.g.  A => (B && C)  to  [ (A => B) , (A => C) ] )
+                BinaryOp::Implies if !negated => {
+                    let es2 = split_expr(
+                        ctx,
+                        state,
+                        &TracedExpX::new(e2.clone(), exp.trace.clone()),
+                        negated,
+                    );
+                    let mut splitted: Vec<TracedExp> = vec![];
+                    for e in &*es2 {
+                        let new_e = ExpX::Binary(BinaryOp::Implies, e1.clone(), e.e.clone());
+                        let new_exp = SpannedTyped::new(&e.e.span, &exp.e.typ, new_e);
+                        let new_tr_exp = TracedExpX::new(new_exp, e.trace.clone());
+                        splitted.push(new_tr_exp);
+                    }
+                    return Arc::new(splitted);
+                }
+                // TODO
+                // BinaryOp::Implies if negated
+                _ => return_atom!(exp.clone(), negated),
+            }
+        }
+        ExpX::Call(fun_name, _typs, exps) => {
+            let fun = get_function(ctx, &exp.e.span, fun_name).unwrap();
+            // println!("{:?}", &fun.span.as_string);
+            // println!("{:?}", exps[0].span.as_string);
+            let res_inlined_exp = tr_inline_function(ctx, state, fun, exps, &exp.e.span);
+            match res_inlined_exp {
+                Ok(inlined_exp) => {
+                    // println!("inlined exp: {:?}", inlined_exp);
+                    let inlined_tr_exp = TracedExpX::new(
+                        inlined_exp,
+                        exp.trace.secondary_label(&exp.e.span, "inlining this function call"), // TODO: pretty print inlined expr
+                    );
+                    return split_expr(ctx, state, &inlined_tr_exp, negated);
+                }
+                Err((sp, msg)) => {
+                    println!("inline failed for {:?}", fun_name);
+                    let not_inlined_exp =
+                        TracedExpX::new(exp.e.clone(), exp.trace.secondary_label(&sp, msg));
+                    // stop inlining. treat as atom
+                    return_atom!(not_inlined_exp, negated);
+                }
+            }
+        }
+        ExpX::If(e1, e2, e3) if !negated => {
+            let then_e = ExpX::Binary(BinaryOp::Implies, e1.clone(), e2.clone());
+            let then_exp = SpannedTyped::new(&e2.span, &exp.e.typ, then_e);
+
+            let not_e1 =
+                SpannedTyped::new(&e1.span, &exp.e.typ, ExpX::Unary(UnaryOp::Not, e1.clone()));
+            let else_e = ExpX::Binary(BinaryOp::Implies, not_e1, e3.clone());
+            let else_exp = SpannedTyped::new(&e3.span, &exp.e.typ, else_e);
+
+            let es1 = split_expr(
+                ctx,
+                state,
+                &TracedExpX::new(then_exp.clone(), exp.trace.clone()),
+                negated,
+            );
+            let es2 = split_expr(
+                ctx,
+                state,
+                &TracedExpX::new(else_exp.clone(), exp.trace.clone()),
+                negated,
+            );
+            return merge_two_es(es1, es2);
+        }
+        ExpX::UnaryOpr(uop, e1) => {
+            let es1 =
+                split_expr(ctx, state, &TracedExpX::new(e1.clone(), exp.trace.clone()), negated);
+            let mut splitted: Vec<TracedExp> = vec![];
+            for e in &*es1 {
+                let new_e = ExpX::UnaryOpr(uop.clone(), e.e.clone());
+                let new_exp = SpannedTyped::new(&e.e.span, &exp.e.typ, new_e);
+                let new_tr_exp = TracedExpX::new(new_exp, e.trace.clone());
+                splitted.push(new_tr_exp);
+            }
+            return Arc::new(splitted);
+        }
+        ExpX::Bind(bnd, e1) => {
+            // TODO: split on `exists` when negated
+            // TODO: Lambda, Choose
+            // split on `forall` when !neagted,
+            match bnd.x {
+                BndX::Quant(Quant { quant: air::ast::Quant::Forall, boxed_params: _ }, _, _)
+                    if !negated =>
+                {
+                    ()
+                }
+                BndX::Let(..) => (),
+                _ => return_atom!(exp.clone(), negated),
+            };
+            let es1 =
+                split_expr(ctx, state, &TracedExpX::new(e1.clone(), exp.trace.clone()), negated);
+            let mut splitted: Vec<TracedExp> = vec![];
+            for e in &*es1 {
+                // REVIEW: should I split expression in `let sth = exp`?
+                let new_expx = ExpX::Bind(bnd.clone(), e.e.clone());
+                let new_exp = SpannedTyped::new(&e.e.span, &exp.e.typ, new_expx);
+                let new_tr_exp = TracedExpX::new(new_exp, e.trace.clone());
+                splitted.push(new_tr_exp);
+            }
+            return Arc::new(splitted);
+        }
+
+        // TODO: more cases
+
+        // cases that cannot be splitted. "atom" boolean expressions
+        _ => return_atom!(exp.clone(), negated),
+    }
+}
+
+pub(crate) fn register_splitted_assertions(traced_exprs: TracedExps) -> Vec<Stm> {
+    // maybe check some condition here before registering every small exps
+    let mut stms: Vec<Stm> = Vec::new();
+    for small_exp in &*traced_exprs {
+        let new_error = small_exp.trace.primary_span(&small_exp.e.span);
+        let additional_assert = StmX::Assert(Some(new_error), small_exp.e.clone());
+        stms.push(Spanned::new(small_exp.e.span.clone(), additional_assert));
+    }
+    stms
+}
+
+pub(crate) fn need_split_expression(ctx: &Ctx, span: &Span) -> bool {
+    for err in &*ctx.debug_expand_targets {
+        // println!("target error msg: {:?}", err.msg);
+        // TODO: make this message in a def.rs somewhere
+        if err.msg == "postcondition not satisfied".to_string() {
+            for label in &err.labels {
+                // println!("label msg {:?}", label.msg);
+                // println!("label span {:?}", label.span);
+                if label.msg == "failed this postcondition".to_string() {
+                    if label.span.as_string == span.as_string {
+                        return true;
+                    }
+                }
+            }
+        } else {
+            for sp in &err.spans {
+                // println!("error span: {:?}", sp);
+                // TODO: is this string matching desirable??
+                if sp.as_string == span.as_string {
+                    return true;
+                }
+            }
+        }
+    }
+    // println!("chose not to split. query span: {:?}", span);
+    false
+}

--- a/source/vir/src/split_expression.rs
+++ b/source/vir/src/split_expression.rs
@@ -207,7 +207,12 @@ fn tr_inline_function(
                 };
             }
         }
-        None => (), // should I panic instead?
+        None => {
+            return Err((
+                span.clone(),
+                "Internal error: cannot find the owning function of this function call".to_string(),
+            ));
+        }
     };
 
     if fuel == 0 || (!found_local_fuel && hidden) {
@@ -294,10 +299,10 @@ pub(crate) fn split_expr(
     state: &State,
     exp: &TracedExp,
     negated: bool,
-) -> Result<TracedExps, String> {
+) -> Result<TracedExps, (Span, String)> {
     match *exp.e.typ {
         TypX::Bool => (),
-        _ => return Err("cannot split non boolean expression".to_string()),
+        _ => return Err((exp.e.span.clone(), "cannot split non boolean expression".to_string())),
     }
     match &exp.e.x {
         ExpX::Unary(UnaryOp::Not, e1) => {
@@ -443,7 +448,7 @@ pub(crate) fn split_expr(
                 {
                     bnd.clone()
                 }
-                // TODO: check if I can find an example that uses this path
+                // REVIEW: is this actually useful?
                 BndX::Quant(
                     Quant { quant: air::ast::Quant::Exists, boxed_params },
                     bndrs,
@@ -499,7 +504,7 @@ pub(crate) fn need_split_expression(ctx: &Ctx, span: &Span) -> bool {
             }
         } else {
             for sp in &err.spans {
-                // TODO: is this string matching desirable??
+                // REVIEW: is this string matching desirable?
                 if sp.as_string == span.as_string {
                     return true;
                 }

--- a/source/vir/src/split_expression.rs
+++ b/source/vir/src/split_expression.rs
@@ -444,7 +444,6 @@ pub(crate) fn split_expr(
 }
 
 pub(crate) fn register_splitted_assertions(traced_exprs: TracedExps) -> Vec<Stm> {
-    // maybe check some condition here before registering every small exps
     let mut stms: Vec<Stm> = Vec::new();
     for small_exp in &*traced_exprs {
         let new_error = small_exp.trace.primary_span(&small_exp.e.span);
@@ -456,13 +455,10 @@ pub(crate) fn register_splitted_assertions(traced_exprs: TracedExps) -> Vec<Stm>
 
 pub(crate) fn need_split_expression(ctx: &Ctx, span: &Span) -> bool {
     for err in &*ctx.debug_expand_targets {
-        // println!("target error msg: {:?}", err.msg);
         // TODO: make this message in a def.rs somewhere
-        if err.msg == "postcondition not satisfied".to_string() {
+        if err.msg == crate::def::POSTCONDITION_FAILURE.to_string() {
             for label in &err.labels {
-                // println!("label msg {:?}", label.msg);
-                // println!("label span {:?}", label.span);
-                if label.msg == "failed this postcondition".to_string() {
+                if label.msg == crate::def::THIS_POST_FAILED.to_string() {
                     if label.span.as_string == span.as_string {
                         return true;
                     }
@@ -470,7 +466,6 @@ pub(crate) fn need_split_expression(ctx: &Ctx, span: &Span) -> bool {
             }
         } else {
             for sp in &err.spans {
-                // println!("error span: {:?}", sp);
                 // TODO: is this string matching desirable??
                 if sp.as_string == span.as_string {
                     return true;
@@ -478,6 +473,5 @@ pub(crate) fn need_split_expression(ctx: &Ctx, span: &Span) -> bool {
             }
         }
     }
-    // println!("chose not to split. query span: {:?}", span);
     false
 }

--- a/source/vir/src/split_expression.rs
+++ b/source/vir/src/split_expression.rs
@@ -104,14 +104,6 @@ fn subsitute_argument(
         }
         ExpX::Const(_) => exp.clone(),
         _ => {
-            // | ExpX::WithTriggers(_, _) => exp.clone()
-            // VarLoc(UniqueIdent),
-            // VarAt(UniqueIdent, VarAt),
-            // Loc(Exp),
-            // Old(Ident, UniqueIdent),
-            // CallLambda(Typ, Exp, Exps),
-            // Ctor(Path, Ident, Binders<Exp>),
-            // WithTriggers(Trigs, Exp),
             return Err((exp.span.clone(), format!("Unsupported expression during subsitution")));
         }
     };
@@ -394,7 +386,7 @@ pub(crate) fn split_expr(
                 Ok(inlined_exp) => {
                     let inlined_tr_exp = TracedExpX::new(
                         inlined_exp,
-                        exp.trace.secondary_label(&exp.e.span, "inlining this function call"), // TODO: pretty print inlined expr
+                        exp.trace.secondary_label(&exp.e.span, "inlining this function call"), // TODO(channy1413): pretty print inlined expr
                     );
                     return split_expr(ctx, state, &inlined_tr_exp, negated);
                 }
@@ -462,7 +454,7 @@ pub(crate) fn split_expr(
                     );
                     Spanned::new(bnd.span.clone(), new_bndx)
                 }
-                // TODO: consider splittig further: Lambda, Choose
+                // TODO(channy1413): consider splittig further: Lambda, Choose
                 _ => return Ok(mk_atom(exp.clone(), negated)),
             };
             let es1 =
@@ -476,8 +468,8 @@ pub(crate) fn split_expr(
             }
             return Ok(Arc::new(splitted));
         }
+        // TODO(channy1413): consider splitting further cases
 
-        // TODO: consider splitting further cases
         // cases that cannot be splitted. "atom" boolean expressions
         _ => return Ok(mk_atom(exp.clone(), negated)),
     }
@@ -521,7 +513,6 @@ pub(crate) fn need_split_expression(ctx: &Ctx, span: &Span) -> bool {
     false
 }
 
-//  find the corresponding old error and check if the new error contains new information on proof failure
 pub fn is_split_error(error: &Error) -> bool {
     if error.msg == crate::def::SPLIT_ASSERT_FAILURE {
         true

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1623,11 +1623,11 @@ pub fn body_stm_to_air(
 
         for ens in enss {
             let error = error_with_label(
-                "postcondition not satisfied".to_string(),
+                crate::def::POSTCONDITION_FAILURE.to_string(),
                 &stm.span,
                 "at the end of the function body".to_string(),
             )
-            .secondary_label(&ens.span, "failed this postcondition".to_string());
+            .secondary_label(&ens.span, crate::def::THIS_POST_FAILED.to_string());
 
             let expr_ctxt = ExprCtxt { mode: ExprMode::Body, is_bit_vector: is_bit_vector_mode };
             let e = mk_let(&trait_typ_bind, &exp_to_expr(ctx, ens, expr_ctxt));

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1005,7 +1005,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
                 let e_req = Arc::new(ExprX::Apply(f_req, Arc::new(req_args)));
                 let description = match (ctx.checking_recommends(), &func.x.attrs.custom_req_err) {
                     (true, None) => "recommendation not met".to_string(),
-                    (_, None) => "precondition not satisfied".to_string(),
+                    (_, None) => crate::def::PRECONDITION_FAILURE.to_string(),
                     (_, Some(s)) => s.clone(),
                 };
                 let error = error(description, &stm.span);


### PR DESCRIPTION
This pull request implements expression splitting to get better error messages for proof failures. 

When proof fails, it saves error spans and reruns `verify_module`. During VIR -> SST translation, it splits previously failed assertions. It runs this splitting by default on proof failure. It does not emit an additional error message if this additional run does not produce new information.



Not included in this pull request (TODO) :
- setting up testing for this feature
- splitting `&&&` and `|||`
- supporting some variety of `assert_by_*`. Now it only splits on `assert`, `requires`, and `ensures`. 
 
