### PR TITLE
support type aliases

### DIFF
--- a/source/rust_verify/src/erase.rs
+++ b/source/rust_verify/src/erase.rs
@@ -1279,6 +1279,7 @@ fn erase_item(ctxt: &Ctxt, mctxt: &mut MCtxt, item: &Item) -> Vec<P<Item>> {
             }
         }
         ItemKind::MacroDef(..) => item.kind.clone(),
+        ItemKind::TyAlias(..) => item.kind.clone(),
         ItemKind::Trait(tr) => ItemKind::Trait(erase_trait(ctxt, mctxt, tr)),
         _ => {
             unsupported!("unsupported item", item)

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -421,6 +421,10 @@ fn check_item<'tcx>(
             };
             vir.traits.push(spanned_new(item.span, traitx));
         }
+        ItemKind::TyAlias(_ty, _generics) => {
+            // type alias (like lines of the form `type X = ...;`
+            // Nothing to do here - we can rely on Rust's type resolution to handle these
+        }
         _ => {
             unsupported_err!(item.span, "unsupported item", item);
         }

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -143,6 +143,7 @@ pub(crate) fn check_item_fn<'tcx>(
     let mut vir_params: Vec<vir::ast::Param> = Vec::new();
     for (param, input) in params.iter().zip(sig.decl.inputs.iter()) {
         let Param { hir_id, pat, ty_span: _, span } = param;
+
         let name = Arc::new(pat_to_var(pat));
         let param_mode = get_var_mode(mode, ctxt.tcx.hir().attrs(*hir_id));
         let is_mut = is_mut_ty(&input);

--- a/source/rust_verify/tests/adts.rs
+++ b/source/rust_verify/tests/adts.rs
@@ -747,3 +747,59 @@ test_verify_one_file! {
         }
     } => Ok(())
 }
+
+test_verify_one_file! {
+    #[test] type_alias_basic code!{
+        struct Foo {
+            u: u64,
+        }
+
+        type X = Foo;
+
+        fn test1(x: X) {
+            requires(x.u == 5);
+
+            let u = x.u;
+            assert(u == 5);
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] #[ignore] type_alias_with_params code!{
+        struct Bar<T> {
+            u: T,
+        }
+
+        type Y<T> = Bar<T>;
+
+        fn test2<T>(x: Y<T>, t: T) {
+            requires(equal(x.u, t));
+
+            let u = x.u;
+            assert(equal(u, t));
+        }
+
+        fn test3<S>(x: Y<S>, t: S) {
+            requires(equal(x.u, t));
+
+            let u = x.u;
+            assert(equal(u, t));
+        }
+
+
+        fn test4<T>(x: Y<u64>) {
+            requires(x.u == 5);
+
+            let u = x.u;
+            assert(u == 5);
+        }
+
+        fn test5(x: Y<Bar<u64>>, b: Bar<u64>) {
+            requires(equal(x.u, b));
+
+            let u = x.u;
+            assert(equal(u, b));
+        }
+    } => Ok(())
+}


### PR DESCRIPTION
Basic support for type aliases.

The difficult part of supporting this is `ty_to_vir`. I couldn't find an easy function to do all the work for me from rustc_hir - the best I found the `type_of` function from rustc that returns the type synonym as a mid_ty, but it doesn't do type param substitution.

This PR provides full support for type aliases that don't take any type parameters.

For those that do, I think it's probably easy enough to just manually perform the type substitution, if you all don't see any better ideas.