### PR TITLE
fix bug with deref in Tracked/Ghost

### DIFF
--- a/source/rust_verify/tests/modes.rs
+++ b/source/rust_verify/tests/modes.rs
@@ -418,3 +418,17 @@ test_verify_one_file! {
         }
     } => Err(e) => assert_vir_error(e)
 }
+
+test_verify_one_file! {
+    #[test] tracked_double_deref code! {
+        use pervasive::modes::*;
+
+        fn foo<V>(x: Tracked<V>) {
+            let y = &x;
+
+            assert(equal((**y), (*x)));
+            assert(equal((**y), x.value()));
+            assert(equal((*y).value(), x.value()));
+        }
+    } => Ok(())
+}


### PR DESCRIPTION
Fix a bug in the Rust -> VIR conversion where dereferencing something of type `&Tracked<V>` erroneously created an extra `.value()`. See explanation in the code.