### PR TITLE
update pervasive::cell to use the new syntax

### DIFF
--- a/source/pervasive/modes.rs
+++ b/source/pervasive/modes.rs
@@ -35,7 +35,16 @@ impl<A> Tracked<A> {
     #[verifier(external_body)]
     pub fn exec(#[proof] a: A) -> Tracked<A> {
         ensures(|s: Tracked<A>| equal(a, s.value()));
+        opens_invariants_none();
         Tracked { phantom: PhantomData }
+    }
+
+    #[verifier(external_body)]
+    pub fn exec_borrow<'a>(#[proof] a: &'a A) -> &'a Tracked<A> {
+        ensures(|s: Tracked<A>| equal(*a, s.value()));
+        opens_invariants_none();
+
+        unimplemented!(); // REVIEW: is this okay?
     }
 
     #[proof]
@@ -44,6 +53,12 @@ impl<A> Tracked<A> {
     pub fn get(#[proof] self) -> A {
         ensures(|a: A| equal(a, self.value()));
         unimplemented!()
+    }
+
+    #[doc(hidden)]
+    #[verifier(external)]
+    pub fn for_external_body() -> Self {
+        Tracked { phantom: PhantomData }
     }
 }
 

--- a/source/pervasive/ptr.rs
+++ b/source/pervasive/ptr.rs
@@ -7,6 +7,8 @@ use std::alloc::{dealloc};
 #[allow(unused_imports)] use crate::pervasive::*;
 #[allow(unused_imports)] use crate::pervasive::modes::*;
 
+verus!{
+
 /// `PPtr<V>` (which stands for "permissioned pointer")
 /// is a wrapper around a raw pointer to `V` on the heap.
 ///
@@ -76,18 +78,17 @@ unsafe impl<T> Send for PPtr<T> {}
 ///
 /// See the [`PPtr`] documentation for more details.
 
-#[proof]
 #[verifier(unforgeable)]
-pub struct Permission<V> {
+pub tracked struct Permission<V> {
     /// Indicates that this token is for a pointer `ptr: PPtr<V>`
     /// such that [`ptr.id()`](PPtr::id) equal to this value.
 
-    #[spec] pub pptr: int,
+    pub ghost pptr: int,
 
     /// Indicates that this token gives the ability to read a value `V` from memory.
     /// When `None`, it indicates that the memory is uninitialized.
 
-    #[spec] pub value: option::Option<V>,
+    pub ghost value: option::Option<V>,
 }
 
 impl<V> Permission<V> {
@@ -96,16 +97,14 @@ impl<V> Permission<V> {
     /// however, it is not possible to obtain a `Permission` token for
     /// any such a pointer.)
 
-    #[proof]
     #[verifier(external_body)]
-    pub fn is_nonnull(#[proof] &self) {
+    pub proof fn is_nonnull(tracked &self) {
         ensures(self.pptr != 0);
         unimplemented!();
     }
 
-    #[proof]
     #[verifier(external_body)]
-    pub fn leak_contents(#[proof] &mut self) {
+    pub proof fn leak_contents(tracked &mut self) {
         ensures(self.pptr == old(self).pptr && self.value.is_None());
         unimplemented!();
     }
@@ -116,11 +115,14 @@ impl<V> PPtr<V> {
 
     #[inline(always)]
     #[verifier(external_body)]
-    #[exec]
     pub fn to_usize(&self) -> usize {
         ensures(|u: usize| u as int == self.id());
         self.uptr as usize
     }
+
+    /// integer address of the pointer
+
+    pub spec fn id(&self) -> int;
 
     /// Cast an integer to a pointer.
     /// 
@@ -136,9 +138,9 @@ impl<V> PPtr<V> {
 
     #[inline(always)]
     #[verifier(external_body)]
-    #[exec]
-    pub fn from_usize(u: usize) -> Self {
-        ensures(|p: Self| p.id() == u as int);
+    pub fn from_usize(u: usize) -> (p: Self)
+        ensures p.id() == u as int,
+    {
         let uptr = u as *mut MaybeUninit<V>;
         PPtr { uptr }
     }
@@ -147,29 +149,25 @@ impl<V> PPtr<V> {
 
     #[inline(always)]
     #[verifier(external_body)]
-    pub fn empty() -> (PPtr<V>, Proof<Permission<V>>) {
-        ensures(|pt : (PPtr<V>, Proof<Permission<V>>)|
-            equal(pt.1, Proof(Permission{ pptr: pt.0.id(), value: option::Option::None }))
-        );
+    pub fn empty() -> (pt: (PPtr<V>, Tracked<Permission<V>>))
+        ensures (*pt.1 === Permission{ pptr: pt.0.id(), value: option::Option::None }),
+    {
         opens_invariants_none();
 
         let p = PPtr {
             uptr: Box::leak(box MaybeUninit::uninit()).as_mut_ptr(),
         };
-        let Proof(t) = exec_proof_from_false();
-        (p, Proof(t))
+        (p, Tracked::for_external_body())
     }
-
-    // integer address of the pointer
-    fndecl!(pub fn id(&self) -> int);
 
     /// Clones the pointer.
     /// TODO implement the `Clone` and `Copy` traits
 
     #[inline(always)]
     #[verifier(external_body)]
-    pub fn clone(&self) -> PPtr<V> {
-        ensures(|pt: PPtr<V>| equal(pt.id(), self.id()));
+    pub fn clone(&self) -> (pt: PPtr<V>)
+        ensures pt.id() === self.id(),
+    {
         opens_invariants_none();
 
         PPtr { uptr: self.uptr }
@@ -183,15 +181,14 @@ impl<V> PPtr<V> {
 
     #[inline(always)]
     #[verifier(external_body)]
-    pub fn put(&self, #[proof] perm: &mut Permission<V>, v: V) {
-        requires([
-            equal(self.id(), old(perm).pptr),
-            equal(old(perm).value, option::Option::None),
-        ]);
-        ensures([
-            equal(perm.pptr, old(perm).pptr),
-            equal(perm.value, option::Option::Some(v)),
-        ]);
+    pub fn put(&self, perm: &mut Tracked<Permission<V>>, v: V)
+        requires
+            self.id() === (**old(perm)).pptr,
+            (**old(perm)).value === option::Option::None,
+        ensures
+            (**perm).pptr === (**old(perm)).pptr,
+            (**perm).value === option::Option::Some(v),
+    {
         opens_invariants_none();
 
         unsafe {
@@ -209,16 +206,15 @@ impl<V> PPtr<V> {
 
     #[inline(always)]
     #[verifier(external_body)]
-    pub fn take(&self, #[proof] perm: &mut Permission<V>) -> V {
-        requires([
-            equal(self.id(), old(perm).pptr),
-            old(perm).value.is_Some(),
-        ]);
-        ensures(|v: V| [
-            equal(perm.pptr, old(perm).pptr),
-            equal(perm.value, option::Option::None),
-            equal(v, old(perm).value.get_Some_0()),
-        ]);
+    pub fn take(&self, perm: &mut Tracked<Permission<V>>) -> (v: V)
+        requires
+            self.id() === (**old(perm)).pptr,
+            (**old(perm)).value.is_Some(),
+        ensures
+            (**perm).pptr === (**old(perm)).pptr,
+            (**perm).value === option::Option::None,
+            v === (**old(perm)).value.get_Some_0(),
+    {
         opens_invariants_none();
 
         unsafe {
@@ -233,16 +229,15 @@ impl<V> PPtr<V> {
 
     #[inline(always)]
     #[verifier(external_body)]
-    pub fn replace(&self, #[proof] perm: &mut Permission<V>, in_v: V) -> V {
-        requires([
-            equal(self.id(), old(perm).pptr),
-            old(perm).value.is_Some(),
-        ]);
-        ensures(|out_v: V| [
-            equal(perm.pptr, old(perm).pptr),
-            equal(perm.value, option::Option::Some(in_v)),
-            equal(out_v, old(perm).value.get_Some_0()),
-        ]);
+    pub fn replace(&self, perm: &mut Tracked<Permission<V>>, in_v: V) -> (out_v: V)
+        requires
+            self.id() === (**old(perm)).pptr,
+            (**old(perm)).value.is_Some(),
+        ensures
+            (**perm).pptr === (**old(perm)).pptr,
+            (**perm).value === option::Option::Some(in_v),
+            out_v === (**old(perm)).value.get_Some_0(),
+    {
         opens_invariants_none();
 
         unsafe {
@@ -259,14 +254,12 @@ impl<V> PPtr<V> {
 
     #[inline(always)]
     #[verifier(external_body)]
-    pub fn borrow<'a>(&self, #[proof] perm: &'a Permission<V>) -> &'a V {
-        requires([
-            equal(self.id(), perm.pptr),
-            perm.value.is_Some(),
-        ]);
-        ensures(|v: V|
-            equal(v, perm.value.get_Some_0())
-        );
+    pub fn borrow<'a>(&self, perm: &'a Tracked<Permission<V>>) -> (v: &'a V)
+        requires
+            self.id() === (**perm).pptr,
+            (**perm).value.is_Some(),
+        ensures *v === (**perm).value.get_Some_0(),
+    {
         opens_invariants_none();
         
         unsafe {
@@ -282,11 +275,11 @@ impl<V> PPtr<V> {
 
     #[inline(always)]
     #[verifier(external_body)]
-    pub fn dispose(&self, #[proof] perm: Permission<V>) {
-        requires([
-            equal(self.id(), perm.pptr),
-            equal(perm.value, option::Option::None),
-        ]);
+    pub fn dispose(&self, perm: Tracked<Permission<V>>)
+        requires
+            self.id() === (*perm).pptr,
+            (*perm).value === option::Option::None,
+    {
         opens_invariants_none();
 
         unsafe {
@@ -304,17 +297,16 @@ impl<V> PPtr<V> {
     /// access to the memory by freeing it.
 
     #[inline(always)]
-    pub fn into_inner(self, #[proof] perm: Permission<V>) -> V {
-        requires([
-            equal(self.id(), perm.pptr),
-            perm.value.is_Some(),
-        ]);
-        ensures(|v|
-            equal(v, perm.value.get_Some_0())
-        );
+    pub fn into_inner(self, perm: Tracked<Permission<V>>) -> (v: V)
+        requires
+            self.id() === (*perm).pptr,
+            (*perm).value.is_Some(),
+        ensures
+            v === (*perm).value.get_Some_0(),
+    {
         opens_invariants_none();
 
-        #[proof] let mut perm = perm;
+        let mut perm = perm;
         let v = self.take(&mut perm);
         self.dispose(perm);
         v
@@ -324,13 +316,14 @@ impl<V> PPtr<V> {
     /// with the given value `v`.
 
     #[inline(always)]
-    pub fn new(v: V) -> (PPtr<V>, Proof<Permission<V>>) {
-        ensures(|pt : (PPtr<V>, Proof<Permission<V>>)|
-            equal(pt.1, Proof(Permission{ pptr: pt.0.id(), value: option::Option::Some(v) }))
-        );
-
-        let (p, Proof(mut t)) = Self::empty();
+    pub fn new(v: V) -> (pt: (PPtr<V>, Tracked<Permission<V>>))
+        ensures
+            (*pt.1 === Permission{ pptr: pt.0.id(), value: option::Option::Some(v) }),
+    {
+        let (p, mut t) = Self::empty();
         p.put(&mut t, v);
-        (p, Proof(t))
+        (p, t)
     }
+}
+
 }

--- a/source/rust_verify/example/cells.rs
+++ b/source/rust_verify/example/cells.rs
@@ -14,9 +14,9 @@ struct X {
 fn main() {
     let x = X { i: 5 };
 
-    let (pcell, Proof(mut token)) = PCell::empty();
+    let (pcell, mut token) = PCell::empty();
 
     pcell.put(&mut token, x);
 
-    assert(equal(token.value, option::Option::Some(X { i : 5 })));
+    assert(equal((*token).value, option::Option::Some(X { i : 5 })));
 }

--- a/source/rust_verify/example/state_machines/rc.rs
+++ b/source/rust_verify/example/state_machines/rc.rs
@@ -271,15 +271,17 @@ impl<S> MyRc<S> {
             equal(rc.view(), s),
         ]);
 
-        let (rc_cell, Proof(rc_perm)) = PCell::new(1);
+        let (rc_cell, rc_perm) = PCell::new(1);
         let inner_rc = InnerRc::<S> { rc_cell, s };
 
-        let (ptr, Proof(ptr_perm)) = PPtr::new(inner_rc);
+        let (ptr, ptr_perm) = PPtr::new(inner_rc);
 
         #[proof] let (inst, mut rc_token, _) = RefCounter::Instance::initialize_empty(Option::None);
+        
+        #[proof] let ptr_perm = ptr_perm.get();
         #[proof] let reader = inst.do_deposit(ptr_perm, &mut rc_token, ptr_perm);
 
-        #[proof] let g = GhostStuff::<S> { rc_perm, rc_token };
+        #[proof] let g = GhostStuff::<S> { rc_perm: rc_perm.get(), rc_token };
 
         #[proof] let inv = LocalInvariant::new(g,
             |g: GhostStuff<S>|
@@ -297,7 +299,7 @@ impl<S> MyRc<S> {
         #[proof] let perm = self.inst.reader_guard(
             self.reader.value,
             &self.reader);
-        &self.ptr.borrow(perm).s
+        &self.ptr.borrow(Tracked::exec_borrow(perm)).s
     }
 
     fn clone(&self) -> Self {
@@ -307,11 +309,12 @@ impl<S> MyRc<S> {
         #[proof] let perm = self.inst.reader_guard(
             self.reader.value,
             &self.reader);
-        let inner_rc_ref = &self.ptr.borrow(perm);
+        let inner_rc_ref = &self.ptr.borrow(Tracked::exec_borrow(perm));
 
         #[proof] let new_reader;
         open_local_invariant!(self.inv.borrow() => g => {
-            #[proof] let GhostStuff { rc_perm: mut rc_perm, rc_token: mut rc_token } = g;
+            #[proof] let GhostStuff { rc_perm: rc_perm, rc_token: mut rc_token } = g;
+            let mut rc_perm = Tracked::exec(rc_perm);
 
             let count = inner_rc_ref.rc_cell.take(&mut rc_perm);
 
@@ -325,7 +328,7 @@ impl<S> MyRc<S> {
                 &mut rc_token,
                 &self.reader);
                 
-            g = GhostStuff { rc_perm, rc_token };
+            g = GhostStuff { rc_perm: rc_perm.get(), rc_token };
         });
 
         MyRc {
@@ -344,10 +347,11 @@ impl<S> MyRc<S> {
         #[proof] let perm = inst.reader_guard(
             reader.value,
             &reader);
-        let inner_rc_ref = &ptr.borrow(perm);
+        let inner_rc_ref = &ptr.borrow(Tracked::exec_borrow(perm));
 
         open_local_invariant!(inv.borrow() => g => {
-            #[proof] let GhostStuff { rc_perm: mut rc_perm, rc_token: mut rc_token } = g;
+            #[proof] let GhostStuff { rc_perm: rc_perm, rc_token: mut rc_token } = g;
+            let mut rc_perm = Tracked::exec(rc_perm);
 
             let count = inner_rc_ref.rc_cell.take(&mut rc_perm);
             if count >= 2 {
@@ -359,10 +363,11 @@ impl<S> MyRc<S> {
                     &mut rc_token,
                     reader);
             } else {
-                #[proof] let mut inner_rc_perm = inst.dec_to_zero(
+                #[proof] let inner_rc_perm = inst.dec_to_zero(
                     reader.value,
                     &mut rc_token,
                     reader);
+                let mut inner_rc_perm = Tracked::exec(inner_rc_perm);
 
                 let inner_rc = ptr.take(&mut inner_rc_perm);
 
@@ -375,7 +380,7 @@ impl<S> MyRc<S> {
                 ptr.dispose(inner_rc_perm);
             }
 
-            g = GhostStuff { rc_perm, rc_token };
+            g = GhostStuff { rc_perm: rc_perm.get(), rc_token };
         });
     }
 }

--- a/source/rust_verify/example/state_machines/tutorial/fifo.rs
+++ b/source/rust_verify/example/state_machines/tutorial/fifo.rs
@@ -573,10 +573,10 @@ pub fn new_queue<T>(len: usize) -> (Producer<T>, Consumer<T>) {
 
         #[spec] let i = backing_cells_vec.len();
         
-        let (cell, Proof(cell_perm)) = PCell::empty();
+        let (cell, cell_perm) = PCell::empty();
         backing_cells_vec.push(cell);
 
-        perms.tracked_insert(i, cell_perm);
+        perms.tracked_insert(i, cell_perm.get());
     }
 
     // Vector for ids
@@ -663,14 +663,16 @@ impl<T> Producer<T> {
             // Here's where we "actually" do the `head != next_tail` check:
             if head != next_tail as u64 {
                 // Unwrap the cell_perm from the option.
-                #[proof] let mut cell_perm = match cell_perm {
+                #[proof] let cell_perm = match cell_perm {
                     Option::Some(cp) => cp,
                     Option::None => { assert(false); proof_from_false() }
                 };
 
                 // Write the element t into the buffer, updating the cell
                 // from uninitialized to initialized (to the value t).
+                let mut cell_perm = Tracked::exec(cell_perm);
                 queue.buffer.index(self.tail).put(&mut cell_perm, t);
+                #[proof] let cell_perm = cell_perm.get();
 
                 // Store the updated tail to the shared `tail` atomic,
                 // while performing the `produce_end` transition.
@@ -718,11 +720,13 @@ impl<T> Consumer<T> {
             );
 
             if self.head as u64 != tail {
-                #[proof] let mut cell_perm = match cell_perm {
+                #[proof] let cell_perm = match cell_perm {
                     Option::Some(cp) => cp,
                     Option::None => { assert(false); proof_from_false() }
                 };
+                let mut cell_perm = Tracked::exec(cell_perm);
                 let t = queue.buffer.index(self.head).take(&mut cell_perm);
+                #[proof] let cell_perm = cell_perm.get();
 
                 atomic_with_ghost!(&queue.head => store(next_head as u64); ghost head_token => {
                     queue.instance.consume_end(cell_perm,

--- a/source/rust_verify/example/state_machines/tutorial/pcell_example.rs
+++ b/source/rust_verify/example/state_machines/tutorial/pcell_example.rs
@@ -9,11 +9,11 @@ use crate::pervasive::option::*;
 // ANCHOR: example
 fn main() {
     // Construct a new pcell and obtain the permission for it.
-    let (pcell, Proof(mut perm)) = PCell::<u64>::empty();
+    let (pcell, mut perm) = PCell::<u64>::empty();
 
     // Initially, cell is unitialized, and the `perm` token
     // represents that as the value `None`.
-    assert(equal(perm.value, Option::None));
+    assert(equal((*perm).value, Option::None));
 
     // We can write a value to the pcell (thus initializing it).
     // This only requires an `&` reference to the PCell, but it does
@@ -21,14 +21,14 @@ fn main() {
     pcell.put(&mut perm, 5); 
 
     // Having written the value, this is reflected in the token:
-    assert(equal(perm.value, Option::Some(5)));
+    assert(equal((*perm).value, Option::Some(5)));
 
     // We can take the value back out:
     let x = pcell.take(&mut perm); 
 
     // Which leaves it uninitialized again:
     assert(x == 5);
-    assert(equal(perm.value, Option::None));
+    assert(equal((*perm).value, Option::None));
 }
 // ANCHOR_END: example
 

--- a/source/rust_verify/tests/cell_lib.rs
+++ b/source/rust_verify/tests/cell_lib.rs
@@ -4,11 +4,11 @@ mod common;
 use common::*;
 
 const IMPORTS: &str = code_str! {
-    use crate::pervasive::{cell::*};
-    use crate::pervasive::{ptr::*};
-    use crate::pervasive::{modes::*};
-    use crate::pervasive::{option::*};
-    use crate::pervasive::result::*;
+    #[allow(unused_imports)] use crate::pervasive::{cell::*};
+    #[allow(unused_imports)] use crate::pervasive::{ptr::*};
+    #[allow(unused_imports)] use crate::pervasive::{modes::*};
+    #[allow(unused_imports)] use crate::pervasive::{option::*};
+    #[allow(unused_imports)] use crate::pervasive::result::*;
 };
 
 /// With contradiction_smoke_test, add a final `assert(false)` that is expected to fail at the end
@@ -22,25 +22,25 @@ fn test_body(tests: &str, contradiction_smoke_test: bool) -> String {
 }
 
 const CELL_TEST: &str = code_str! {
-    let (cell, Proof(mut token)) = PCell::<u32>::empty();
-    assert(equal(token.pcell, cell.id()));
-    assert(equal(token.value, option::Option::None));
+    let (cell, mut token) = PCell::<u32>::empty();
+    assert(equal((*token).pcell, cell.id()));
+    assert(equal((*token).value, option::Option::None));
 
     cell.put(&mut token, 5);
-    assert(equal(token.pcell, cell.id()));
-    assert(equal(token.value, option::Option::Some(5)));
+    assert(equal((*token).pcell, cell.id()));
+    assert(equal((*token).value, option::Option::Some(5)));
 
     let x = cell.replace(&mut token, 7);
-    assert(equal(token.pcell, cell.id()));
-    assert(equal(token.value, option::Option::Some(7)));
+    assert(equal((*token).pcell, cell.id()));
+    assert(equal((*token).value, option::Option::Some(7)));
     assert(equal(x, 5));
 
     let t = cell.borrow(&token);
     assert(equal(*t, 7));
 
     let x = cell.take(&mut token);
-    assert(equal(token.pcell, cell.id()));
-    assert(equal(token.value, option::Option::None));
+    assert(equal((*token).pcell, cell.id()));
+    assert(equal((*token).value, option::Option::None));
     assert(equal(x, 7));
 };
 
@@ -53,25 +53,25 @@ test_verify_one_file! {
 }
 
 const PTR_TEST: &str = code_str! {
-    let (ptr, Proof(mut token)) = PPtr::<u32>::empty();
-    assert(equal(token.pptr, ptr.id()));
-    assert(equal(token.value, option::Option::None));
+    let (ptr, mut token) = PPtr::<u32>::empty();
+    assert(equal((*token).pptr, ptr.id()));
+    assert(equal((*token).value, option::Option::None));
 
     ptr.put(&mut token, 5);
-    assert(equal(token.pptr, ptr.id()));
-    assert(equal(token.value, option::Option::Some(5)));
+    assert(equal((*token).pptr, ptr.id()));
+    assert(equal((*token).value, option::Option::Some(5)));
 
     let x = ptr.replace(&mut token, 7);
-    assert(equal(token.pptr, ptr.id()));
-    assert(equal(token.value, option::Option::Some(7)));
+    assert(equal((*token).pptr, ptr.id()));
+    assert(equal((*token).value, option::Option::Some(7)));
     assert(equal(x, 5));
 
     let t = ptr.borrow(&token);
     assert(equal(*t, 7));
 
     let x = ptr.take(&mut token);
-    assert(equal(token.pptr, ptr.id()));
-    assert(equal(token.value, option::Option::None));
+    assert(equal((*token).pptr, ptr.id()));
+    assert(equal((*token).value, option::Option::None));
     assert(equal(x, 7));
 
     ptr.dispose(token);
@@ -88,8 +88,8 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] cell_mismatch_put IMPORTS.to_string() + code_str! {
         pub fn f() {
-            let (cell1, Proof(mut token1)) = PCell::<u32>::empty();
-            let (cell2, Proof(mut token2)) = PCell::<u32>::empty();
+            let (cell1, mut token1) = PCell::<u32>::empty();
+            let (cell2, mut token2) = PCell::<u32>::empty();
             cell1.put(&mut token2, 5); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
@@ -98,8 +98,8 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] cell_mismatch_take IMPORTS.to_string() + code_str! {
         pub fn f() {
-            let (cell1, Proof(mut token1)) = PCell::<u32>::empty();
-            let (cell2, Proof(mut token2)) = PCell::<u32>::empty();
+            let (cell1, mut token1) = PCell::<u32>::empty();
+            let (cell2, mut token2) = PCell::<u32>::empty();
             cell1.put(&mut token1, 5);
             cell2.put(&mut token2, 5);
             let x = cell1.take(&mut token2); // FAILS
@@ -110,8 +110,8 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] cell_mismatch_replace IMPORTS.to_string() + code_str! {
         pub fn f() {
-            let (cell1, Proof(mut token1)) = PCell::<u32>::empty();
-            let (cell2, Proof(mut token2)) = PCell::<u32>::empty();
+            let (cell1, mut token1) = PCell::<u32>::empty();
+            let (cell2, mut token2) = PCell::<u32>::empty();
             cell1.put(&mut token1, 5);
             cell2.put(&mut token2, 5);
             let x = cell1.replace(&mut token2, 7); // FAILS
@@ -122,8 +122,8 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] cell_mismatch_borrow IMPORTS.to_string() + code_str! {
         pub fn f() {
-            let (cell1, Proof(mut token1)) = PCell::<u32>::empty();
-            let (cell2, Proof(mut token2)) = PCell::<u32>::empty();
+            let (cell1, mut token1) = PCell::<u32>::empty();
+            let (cell2, mut token2) = PCell::<u32>::empty();
             cell1.put(&mut token1, 5);
             cell2.put(&mut token2, 5);
             let x = cell1.borrow(&token2); // FAILS
@@ -134,7 +134,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] cell_some_put IMPORTS.to_string() + code_str! {
         pub fn f() {
-            let (cell1, Proof(mut token1)) = PCell::<u32>::empty();
+            let (cell1, mut token1) = PCell::<u32>::empty();
             cell1.put(&mut token1, 7);
             cell1.put(&mut token1, 5); // FAILS
         }
@@ -144,7 +144,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] cell_none_take IMPORTS.to_string() + code_str! {
         pub fn f() {
-            let (cell1, Proof(mut token1)) = PCell::<u32>::empty();
+            let (cell1, mut token1) = PCell::<u32>::empty();
             let x = cell1.take(&mut token1); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
@@ -153,7 +153,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] cell_none_replace IMPORTS.to_string() + code_str! {
         pub fn f() {
-            let (cell1, Proof(mut token1)) = PCell::<u32>::empty();
+            let (cell1, mut token1) = PCell::<u32>::empty();
             let x = cell1.replace(&mut token1, 7); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
@@ -162,7 +162,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] cell_none_borrow IMPORTS.to_string() + code_str! {
         pub fn f() {
-            let (cell1, Proof(mut token1)) = PCell::<u32>::empty();
+            let (cell1, mut token1) = PCell::<u32>::empty();
             let x = cell1.borrow(&token1); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
@@ -171,8 +171,8 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] ptr_mismatch_put IMPORTS.to_string() + code_str! {
         pub fn f() {
-            let (ptr1, Proof(mut token1)) = PPtr::<u32>::empty();
-            let (ptr2, Proof(mut token2)) = PPtr::<u32>::empty();
+            let (ptr1, mut token1) = PPtr::<u32>::empty();
+            let (ptr2, mut token2) = PPtr::<u32>::empty();
             ptr1.put(&mut token2, 5); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
@@ -181,8 +181,8 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] ptr_mismatch_take IMPORTS.to_string() + code_str! {
         pub fn f() {
-            let (ptr1, Proof(mut token1)) = PPtr::<u32>::empty();
-            let (ptr2, Proof(mut token2)) = PPtr::<u32>::empty();
+            let (ptr1, mut token1) = PPtr::<u32>::empty();
+            let (ptr2, mut token2) = PPtr::<u32>::empty();
             ptr1.put(&mut token1, 5);
             ptr2.put(&mut token2, 5);
             let x = ptr1.take(&mut token2); // FAILS
@@ -193,8 +193,8 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] ptr_mismatch_replace IMPORTS.to_string() + code_str! {
         pub fn f() {
-            let (ptr1, Proof(mut token1)) = PPtr::<u32>::empty();
-            let (ptr2, Proof(mut token2)) = PPtr::<u32>::empty();
+            let (ptr1, mut token1) = PPtr::<u32>::empty();
+            let (ptr2, mut token2) = PPtr::<u32>::empty();
             ptr1.put(&mut token1, 5);
             ptr2.put(&mut token2, 5);
             let x = ptr1.replace(&mut token2, 7); // FAILS
@@ -205,8 +205,8 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] ptr_mismatch_borrow IMPORTS.to_string() + code_str! {
         pub fn f() {
-            let (ptr1, Proof(mut token1)) = PPtr::<u32>::empty();
-            let (ptr2, Proof(mut token2)) = PPtr::<u32>::empty();
+            let (ptr1, mut token1) = PPtr::<u32>::empty();
+            let (ptr2, mut token2) = PPtr::<u32>::empty();
             ptr1.put(&mut token1, 5);
             ptr2.put(&mut token2, 5);
             let x = ptr1.borrow(&token2); // FAILS
@@ -217,8 +217,8 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] ptr_mismatch_dispose IMPORTS.to_string() + code_str! {
         pub fn f() {
-            let (ptr1, Proof(mut token1)) = PPtr::<u32>::empty();
-            let (ptr2, Proof(mut token2)) = PPtr::<u32>::empty();
+            let (ptr1, mut token1) = PPtr::<u32>::empty();
+            let (ptr2, mut token2) = PPtr::<u32>::empty();
             ptr1.dispose(token2); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
@@ -227,7 +227,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] ptr_some_put IMPORTS.to_string() + code_str! {
         pub fn f() {
-            let (ptr1, Proof(mut token1)) = PPtr::<u32>::empty();
+            let (ptr1, mut token1) = PPtr::<u32>::empty();
             ptr1.put(&mut token1, 7);
             ptr1.put(&mut token1, 5); // FAILS
         }
@@ -237,7 +237,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] ptr_none_take IMPORTS.to_string() + code_str! {
         pub fn f() {
-            let (ptr1, Proof(mut token1)) = PPtr::<u32>::empty();
+            let (ptr1, mut token1) = PPtr::<u32>::empty();
             let x = ptr1.take(&mut token1); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
@@ -246,7 +246,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] ptr_none_replace IMPORTS.to_string() + code_str! {
         pub fn f() {
-            let (ptr1, Proof(mut token1)) = PPtr::<u32>::empty();
+            let (ptr1, mut token1) = PPtr::<u32>::empty();
             let x = ptr1.replace(&mut token1, 7); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
@@ -255,7 +255,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] ptr_none_borrow IMPORTS.to_string() + code_str! {
         pub fn f() {
-            let (ptr1, Proof(mut token1)) = PPtr::<u32>::empty();
+            let (ptr1, mut token1) = PPtr::<u32>::empty();
             let x = ptr1.borrow(&token1); // FAILS
         }
     } => Err(err) => assert_one_fails(err)
@@ -264,7 +264,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] ptr_some_dispose IMPORTS.to_string() + code_str! {
         pub fn f() {
-            let (ptr1, Proof(mut token1)) = PPtr::<u32>::empty();
+            let (ptr1, mut token1) = PPtr::<u32>::empty();
             ptr1.put(&mut token1, 5);
             ptr1.dispose(token1); // FAILS
         }


### PR DESCRIPTION
Update the pervasive `cell` and `ptr` libs to use `Tracked` and the new `verus!` syntax.

All the clients are updated for the new type signatures, but I didn't move them to the verus syntax yet.