### PR TITLE
Add "let Ghost" and "let Tracked" syntax

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -272,6 +272,48 @@ impl<A> std::ops::Deref for Tracked<A> {
     }
 }
 
+macro_rules! emit_phantom {
+    ($x:ident) => {
+        PhantomData
+    };
+}
+macro_rules! split_tuple {
+    /*
+        #[inline(always)]
+        pub fn tracked_split_tuple2<A1, A2>(_t: Tracked<(A1, A2)>) -> (Tracked<A1>, Tracked<A2>) {
+            (Tracked { phantom: PhantomData }, Tracked { phantom: PhantomData })
+        }
+    */
+    ($fun:ident, $typ:ident, [$($t:ident)*]) => {
+        #[inline(always)]
+        pub fn $fun
+            <$( $t, )* >
+            (_t: $typ<($( $t, )*)>)
+            ->
+            ($( $typ<$t>, )*) {
+            ($( $typ { phantom: emit_phantom!($t) }, )*)
+        }
+    }
+}
+split_tuple!(ghost_split_tuple0, Ghost, []);
+split_tuple!(ghost_split_tuple1, Ghost, [A1]);
+split_tuple!(ghost_split_tuple2, Ghost, [A1 A2]);
+split_tuple!(ghost_split_tuple3, Ghost, [A1 A2 A3]);
+split_tuple!(ghost_split_tuple4, Ghost, [A1 A2 A3 A4]);
+split_tuple!(ghost_split_tuple5, Ghost, [A1 A2 A3 A4 A5]);
+split_tuple!(ghost_split_tuple6, Ghost, [A1 A2 A3 A4 A5 A6]);
+split_tuple!(ghost_split_tuple7, Ghost, [A1 A2 A3 A4 A5 A6 A7]);
+split_tuple!(ghost_split_tuple8, Ghost, [A1 A2 A3 A4 A5 A6 A7 A8]);
+split_tuple!(tracked_split_tuple0, Tracked, []);
+split_tuple!(tracked_split_tuple1, Tracked, [A1]);
+split_tuple!(tracked_split_tuple2, Tracked, [A1 A2]);
+split_tuple!(tracked_split_tuple3, Tracked, [A1 A2 A3]);
+split_tuple!(tracked_split_tuple4, Tracked, [A1 A2 A3 A4]);
+split_tuple!(tracked_split_tuple5, Tracked, [A1 A2 A3 A4 A5]);
+split_tuple!(tracked_split_tuple6, Tracked, [A1 A2 A3 A4 A5 A6]);
+split_tuple!(tracked_split_tuple7, Tracked, [A1 A2 A3 A4 A5 A6 A7]);
+split_tuple!(tracked_split_tuple8, Tracked, [A1 A2 A3 A4 A5 A6 A7 A8]);
+
 //
 // int and nat
 //

--- a/source/pervasive/modes.rs
+++ b/source/pervasive/modes.rs
@@ -37,10 +37,33 @@ pub fn tracked_get<A>(#[proof] t: Tracked<A>) -> A {
 
 verus! {
 
-pub tracked struct TrackedAndGhost<T, G>(
-    pub tracked T,
-    pub ghost G,
-);
+// REVIEW: consider moving these into builtin and erasing them from the VIR
+pub struct Gho<A>(pub ghost A);
+pub struct Trk<A>(pub tracked A);
+
+#[inline(always)]
+#[verifier(external_body)]
+pub fn ghost_unwrap_gho<A>(a: Ghost<Gho<A>>) -> (ret: Ghost<A>)
+    ensures a.0 === *ret
+{
+    Ghost::assume_new()
+}
+
+#[inline(always)]
+#[verifier(external_body)]
+pub fn tracked_unwrap_gho<A>(a: Tracked<Gho<A>>) -> (ret: Tracked<A>)
+    ensures a.0 === *ret
+{
+    Tracked::assume_new()
+}
+
+#[inline(always)]
+#[verifier(external_body)]
+pub fn tracked_unwrap_trk<A>(a: Tracked<Trk<A>>) -> (ret: Tracked<A>)
+    ensures a.0 === *ret
+{
+    Tracked::assume_new()
+}
 
 } // verus
 

--- a/source/rust_verify/example/syntax.rs
+++ b/source/rust_verify/example/syntax.rs
@@ -367,6 +367,22 @@ fn test_consume(t: Tracked<int>)
     }
 }
 
+/// Exec code can extract individual Ghost and Tracked values from Ghost and Tracked tuples
+/// with "let Ghost((...))" and "let Tracked((...))".
+/// The tuple pattern elements may further match on Trk and Gho from pervasives::modes.
+fn test_ghost_tuple_match(t: Tracked<(bool, bool, Gho<int>, Gho<int>)>) -> Tracked<bool> {
+    let g: Ghost<(int, int)> = ghost((10, 20));
+
+    let Ghost((g1, g2)) = g; // g1 and g2 both have type Ghost<int>
+    assert(*g1 + *g2 == 30);
+
+    let Ghost((g1, g2)): (Ghost<int>, Ghost<int>) = g;
+    assert(*g1 + *g2 == 30);
+
+    let Tracked((b1, b2, Gho(g3), Gho(g4))) = t; // b1, b2: Tracked<bool> and g3, g4: Ghost<int>
+    b2
+}
+
 /// Spec functions are not checked for correctness (although they are checked for termination).
 /// However, marking a spec function as "spec(checked)" enables lightweight "recommends checking"
 /// inside the spec function.


### PR DESCRIPTION
Support extracting tuple components from Ghost and Tracked tuples in exec mode.