### PR TITLE
Cleaner non-recursive implementations of seq, set and map macros

### DIFF
--- a/source/pervasive/map.rs
+++ b/source/pervasive/map.rs
@@ -270,7 +270,7 @@ pub proof fn axiom_map_ext_equal<K, V>(m1: Map<K, V>, m2: Map<K, V>)
 #[doc(hidden)]
 #[macro_export]
 macro_rules! map_internal {
-    [$($key:expr => $value:expr),*] => {
+    [$($key:expr => $value:expr),* $(,)?] => {
         $crate::pervasive::map::Map::empty()
             $(.insert($key, $value))*
     }

--- a/source/pervasive/map.rs
+++ b/source/pervasive/map.rs
@@ -269,15 +269,10 @@ pub proof fn axiom_map_ext_equal<K, V>(m1: Map<K, V>, m2: Map<K, V>)
 
 #[doc(hidden)]
 #[macro_export]
-macro_rules! map_insert_rec {
-    [$val:expr;] => {
-        $val
-    };
-    [$val:expr;$key:expr => $value:expr] => {
-        map_insert_rec![$val.insert($key, $value);]
-    };
-    [$val:expr;$key:expr => $value:expr,$($tail:tt)*] => {
-        map_insert_rec![$val.insert($key, $value);$($tail)*]
+macro_rules! map_internal {
+    [$($key:expr => $value:expr),*] => {
+        $crate::pervasive::map::Map::empty()
+            $(.insert($key, $value))*
     }
 }
 
@@ -291,11 +286,11 @@ macro_rules! map_insert_rec {
 #[macro_export]
 macro_rules! map {
     [$($tail:tt)*] => {
-        ::builtin_macros::verus_proof_macro_exprs!($crate::pervasive::map::map_insert_rec![$crate::pervasive::map::Map::empty();$($tail)*])
-    }
-} 
+        ::builtin_macros::verus_proof_macro_exprs!($crate::pervasive::map::map_internal!($($tail)*))
+    };
+}
 
-pub use map_insert_rec;
+pub use map_internal;
 pub use map;
 
 /// Prove two maps equal by _extensionality_. Usage is:

--- a/source/pervasive/seq.rs
+++ b/source/pervasive/seq.rs
@@ -298,7 +298,7 @@ pub proof fn axiom_seq_add_index2<A>(s1: Seq<A>, s2: Seq<A>, i: int)
 #[doc(hidden)]
 #[macro_export]
 macro_rules! seq_internal {
-    [$($elem:expr),*] => {
+    [$($elem:expr),* $(,)?] => {
         $crate::pervasive::seq::Seq::empty()
             $(.push($elem))*
     }

--- a/source/pervasive/seq.rs
+++ b/source/pervasive/seq.rs
@@ -297,15 +297,10 @@ pub proof fn axiom_seq_add_index2<A>(s1: Seq<A>, s2: Seq<A>, i: int)
 
 #[doc(hidden)]
 #[macro_export]
-macro_rules! seq_insert_rec {
-    [$val:expr;] => {
-        $val
-    };
-    [$val:expr;$elem:expr] => {
-        seq_insert_rec![$val.push($elem);]
-    };
-    [$val:expr;$elem:expr,$($tail:tt)*] => {
-        seq_insert_rec![$val.push($elem);$($tail)*]
+macro_rules! seq_internal {
+    [$($elem:expr),*] => {
+        $crate::pervasive::seq::Seq::empty()
+            $(.push($elem))*
     }
 }
 
@@ -325,11 +320,11 @@ macro_rules! seq_insert_rec {
 #[macro_export]
 macro_rules! seq {
     [$($tail:tt)*] => {
-        ::builtin_macros::verus_proof_macro_exprs!($crate::pervasive::seq::seq_insert_rec![$crate::pervasive::seq::Seq::empty();$($tail)*])
-    }
+        ::builtin_macros::verus_proof_macro_exprs!($crate::pervasive::seq::seq_internal!($($tail)*))
+    };
 }
 
-pub use seq_insert_rec;
+pub use seq_internal;
 pub use seq;
 
 } // verus!

--- a/source/pervasive/set.rs
+++ b/source/pervasive/set.rs
@@ -364,26 +364,21 @@ pub proof fn axiom_set_choose_len<A>(s: Set<A>)
 
 #[doc(hidden)]
 #[macro_export]
-macro_rules! set_insert_rec {
-    [$val:expr;] => {
-        $val
+macro_rules! set_internal {
+    [$($elem:expr),*] => {
+        $crate::pervasive::set::Set::empty()
+            $(.insert($elem))*
     };
-    [$val:expr;$elem:expr] => {
-        set_insert_rec![$val.insert($elem);]
-    };
-    [$val:expr;$elem:expr,$($tail:tt)*] => {
-        set_insert_rec![$val.insert($elem);$($tail)*]
-    }
 }
 
 #[macro_export]
 macro_rules! set {
     [$($tail:tt)*] => {
-        ::builtin_macros::verus_proof_macro_exprs!($crate::pervasive::set::set_insert_rec![$crate::pervasive::set::Set::empty();$($tail)*])
-    }
+        ::builtin_macros::verus_proof_macro_exprs!($crate::pervasive::set::set_internal!($($tail)*))
+    };
 }
 
-pub use set_insert_rec;
+pub use set_internal;
 pub use set;
 
 } // verus!

--- a/source/pervasive/set.rs
+++ b/source/pervasive/set.rs
@@ -365,7 +365,7 @@ pub proof fn axiom_set_choose_len<A>(s: Set<A>)
 #[doc(hidden)]
 #[macro_export]
 macro_rules! set_internal {
-    [$($elem:expr),*] => {
+    [$($elem:expr),* $(,)?] => {
         $crate::pervasive::set::Set::empty()
             $(.insert($elem))*
     };

--- a/source/rust_verify/tests/literals.rs
+++ b/source/rust_verify/tests/literals.rs
@@ -39,6 +39,12 @@ test_verify_one_file! {
             let s2: Set<int> = set![4, 2];
             assert(s1.ext_equal(s2));
         }
+
+        proof fn comma_at_end() {
+            let s1: Set<int> = set![2, 4,];
+            let s2: Set<int> = set![4, 2,];
+            assert(s1.ext_equal(s2));
+        }
     } => Ok(())
 }
 
@@ -51,5 +57,12 @@ test_verify_one_file! {
             let s1: Seq<int> = seq![2, 4, 6, 8, 10];
             assert(s1.index(2) == 6);
         }
+
+
+        proof fn comma_at_end() {
+            let s1: Seq<int> = seq![2, 4, 6, 8, 10,];
+            assert(s1.index(2) == 6);
+        }
+
     } => Ok(())
 }

--- a/source/rust_verify/tests/maps.rs
+++ b/source/rust_verify/tests/maps.rs
@@ -18,6 +18,9 @@ test_verify_one_file! {
             let m3 = map![10int => true ==> false, 20int => false ==> true];
             assert(!m3.index(10));
             assert(m3.index(20));
+            let m4 = map![10int => true ==> false, 20int => false ==> true,];
+            assert(!m4.index(10));
+            assert(m4.index(20));
         }
 
         proof fn testfun_eq() {


### PR DESCRIPTION
This PR replaces the recursive expansion of seq/set/map literals into macros that use repetition patterns. This should reduce the need to increase the `recursion_limit` for large literals.

Additionally, this has the side benefit of simplifying the internal macros to not have the 0-1-many split necessary before.

The expansion produced by the new macros should be exactly equivalent to the previous ones.