### PR TITLE
Z3 4.9.1 bitvector options, ci script update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: check Z3 version
-        working-directory: ./source   # "cd source"   
-        run: |
-          /home/chanheec/local_bin/z3 --version  # 4.8.5 expected
       # run "cargo test" using our latest rustc binary
-      - name: cargo test with default Z3
+      - name: cargo test
         working-directory: ./source   # "cd source"   
         run: |
           mkdir ../rust
@@ -24,7 +20,7 @@ jobs:
           echo rustc version `../rust/install/bin/rustc --version`           # check rustc version
           RUSTC=../rust/install/bin/rustc ../rust/install/bin/cargo clean    # cargo clean
           RUSTC=../rust/install/bin/rustc ../rust/install/bin/cargo build    # cargo build   
-          VERUS_Z3_PATH="/home/chanheec/local_bin/z3" RUSTC=../rust/install/bin/rustc RUSTDOC=../rust/install/bin/rustdoc  ../rust/install/bin/cargo test
+          VERUS_Z3_PATH="/home/chanheec/local_bin/z3_4_9_1" RUSTC=../rust/install/bin/rustc RUSTDOC=../rust/install/bin/rustdoc  ../rust/install/bin/cargo test
       
       - name: check cargo fmt
         working-directory: ./source   # "cd source"   
@@ -36,20 +32,4 @@ jobs:
         working-directory: ./source
         run: |
           RUSTC=../rust/install/bin/rustc ../rust/install/bin/cargo build --features singular       # build with singular feature 
-          VERUS_SINGULAR_PATH="/usr/bin/Singular" VERUS_Z3_PATH="/home/chanheec/local_bin/z3" RUSTC=../rust/install/bin/rustc RUSTDOC=../rust/install/bin/rustdoc  ../rust/install/bin/cargo test -p rust_verify --features singular
-
-      # Second run with latest Z3
-      - name: cargo test with z3_4_8_17
-        id: z3_4_8_17
-        working-directory: ./source   # "cd source"   
-        continue-on-error: true
-        run: |
-          VERUS_Z3_PATH="/home/chanheec/local_bin/z3_4_8_17" RUSTC=../rust/install/bin/rustc RUSTDOC=../rust/install/bin/rustdoc  ../rust/install/bin/cargo test
-
-      - name: summarize_z3_4_8_17_fail
-        if: steps.z3_4_8_17.outcome != 'success'
-        run: echo '#### cargo test with z3 4.8.17 failed, but marked as suceess' >> $GITHUB_STEP_SUMMARY
-
-      - name: summarize_z3_4_8_17_success
-        if: steps.z3_4_8_17.outcome == 'success'
-        run: echo '### All tests passed! :rocket:' >> $GITHUB_STEP_SUMMARY
+          VERUS_SINGULAR_PATH="/usr/bin/Singular" VERUS_Z3_PATH="/home/chanheec/local_bin/z3_4_9_1" RUSTC=../rust/install/bin/rustc RUSTDOC=../rust/install/bin/rustdoc  ../rust/install/bin/cargo test -p rust_verify --features singular

--- a/source/air/src/context.rs
+++ b/source/air/src/context.rs
@@ -242,12 +242,8 @@ impl Context {
     }
 
     pub(crate) fn set_z3_param_str(&mut self, option: &str, value: &str, write_to_logs: bool) {
-        if option == "tactic.default_tactic" {
-            if write_to_logs {
-                self.log_set_z3_param(option, &value.to_string());
-            }
-        } else {
-            panic!("encountered unexpected z3 option: {} : {}", option, value);
+        if write_to_logs {
+            self.log_set_z3_param(option, &value.to_string());
         }
     }
 
@@ -256,14 +252,14 @@ impl Context {
             self.set_z3_param_bool(option, true, true);
         } else if value == "false" {
             self.set_z3_param_bool(option, false, true);
-        } else if value == "sat" {
-            self.set_z3_param_str(option, value, true);
-        } else if value.contains(".") {
-            let v = value.parse::<f64>().expect(&format!("could not parse option value {}", value));
+        } else if let Ok(v) = value.parse::<f64>() {
             self.set_z3_param_f64(option, v, true);
-        } else {
-            let v = value.parse::<u32>().expect(&format!("could not parse option value {}", value));
+        } else if let Ok(v) = value.parse::<u32>() {
             self.set_z3_param_u32(option, v, true);
+        } else if value.is_ascii() {
+            self.set_z3_param_str(option, value, true);
+        } else {
+            panic!("unexpected z3 param {}", value);
         }
     }
 

--- a/source/air/src/context.rs
+++ b/source/air/src/context.rs
@@ -240,13 +240,13 @@ impl Context {
             self.log_set_z3_param(option, &s);
         }
     }
-    
+
     pub(crate) fn set_z3_param_str(&mut self, option: &str, value: &str, write_to_logs: bool) {
-        if option == "tactic.default_tactic"  {
+        if option == "tactic.default_tactic" {
             if write_to_logs {
                 self.log_set_z3_param(option, &value.to_string());
             }
-        } else {            
+        } else {
             panic!("encountered unexpected z3 option: {} : {}", option, value);
         }
     }

--- a/source/air/src/context.rs
+++ b/source/air/src/context.rs
@@ -240,12 +240,24 @@ impl Context {
             self.log_set_z3_param(option, &s);
         }
     }
+    
+    pub(crate) fn set_z3_param_str(&mut self, option: &str, value: &str, write_to_logs: bool) {
+        if option == "tactic.default_tactic"  {
+            if write_to_logs {
+                self.log_set_z3_param(option, &value.to_string());
+            }
+        } else {            
+            panic!("encountered unexpected z3 option: {} : {}", option, value);
+        }
+    }
 
     pub fn set_z3_param(&mut self, option: &str, value: &str) {
         if value == "true" {
             self.set_z3_param_bool(option, true, true);
         } else if value == "false" {
             self.set_z3_param_bool(option, false, true);
+        } else if value == "sat" {
+            self.set_z3_param_str(option, value, true);
         } else if value.contains(".") {
             let v = value.parse::<f64>().expect(&format!("could not parse option value {}", value));
             self.set_z3_param_f64(option, v, true);

--- a/source/rust_verify/example/integer_ring/integer_ring_bound_check.rs
+++ b/source/rust_verify/example/integer_ring/integer_ring_bound_check.rs
@@ -23,7 +23,7 @@ fn ModAfterMul(x: int, y: int, z:int, m:int){
 
 // bound check lemmas
 #[verifier(nonlinear)]  
-// #[verifier(external_body)]
+#[verifier(external_body)]
 #[proof]
 fn LemmaMulUpperBound(x: int, XBound: int, y: int, YBound: int) {
     requires([

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1183,11 +1183,13 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
                 stm.span.clone(),
                 "assert_bit_vector".to_string(),
                 Arc::new(vec![
+                    mk_option_command("sat.euf", "true"),
+                    mk_option_command("tactic.default_tactic", "sat"),
+                    mk_option_command("smt.ematching", "false"),
                     mk_option_command("smt.case_split", "0"),
                     Arc::new(CommandX::CheckValid(query)),
-                    mk_option_command("smt.case_split", "3"),
                 ]),
-                ProverChoice::DefaultProver,
+                ProverChoice::Spinoff,
             ));
 
             vec![Arc::new(StmtX::Assume(exp_to_expr(ctx, &expr, expr_ctxt)))]
@@ -1710,9 +1712,11 @@ pub fn body_stm_to_air(
             ]
         } else if is_bit_vector_mode {
             vec![
+                mk_option_command("sat.euf", "true"),
+                mk_option_command("tactic.default_tactic", "sat"),
+                mk_option_command("smt.ematching", "false"),
                 mk_option_command("smt.case_split", "0"),
                 Arc::new(CommandX::CheckValid(query)),
-                mk_option_command("smt.case_split", "3"),
             ]
         } else {
             vec![Arc::new(CommandX::CheckValid(query))]
@@ -1721,7 +1725,7 @@ pub fn body_stm_to_air(
             func_span.clone(),
             "function body check".to_string(),
             Arc::new(commands),
-            if is_spinoff_prover { ProverChoice::Spinoff } else { ProverChoice::DefaultProver },
+            if is_spinoff_prover || is_bit_vector_mode { ProverChoice::Spinoff } else { ProverChoice::DefaultProver },
         ));
     }
     (state.commands, state.snap_map)

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1725,7 +1725,11 @@ pub fn body_stm_to_air(
             func_span.clone(),
             "function body check".to_string(),
             Arc::new(commands),
-            if is_spinoff_prover || is_bit_vector_mode { ProverChoice::Spinoff } else { ProverChoice::DefaultProver },
+            if is_spinoff_prover || is_bit_vector_mode {
+                ProverChoice::Spinoff
+            } else {
+                ProverChoice::DefaultProver
+            },
         ));
     }
     (state.commands, state.snap_map)


### PR DESCRIPTION
(wants to merge to `z3-4.9.1` branch) 

1. Updated bit-vector option in Z3 

I encountered this comment 
`Note: at this point tactic.default_tactic=sat sat.euf=true smt.ematching=false works best.`(https://github.com/Z3Prover/z3/issues/5660) that describes the option for bit-vector reasoning.

The garbage-collecting example that used to be working in Z3 4.8.5 fails in the latest(4.9.1) version. When I introduce the above options, it works again. 

One downside is that this option `sat.euf=true` seems not backward compatible. (When I ran the `root.smt2` with z3 4.8.5, I got the unrecognized option error for that option -- which will make Verus panic when it is with Z3 4.8.5)

I am worried that the newly introduced options might affect some internal states of Z3, affecting other parts. Therefore, I updated all bit-vector queries to be `spinoff_prover` by default.   

  

2. CI script update for Z3 4.9.1

