### PR TITLE
remove ty_to_vir in favor of mid_ty_to_vir

### DIFF
--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -43,7 +43,6 @@ fn check_item<'tcx>(
             check_item_fn(
                 ctxt,
                 vir,
-                None,
                 item.def_id.to_def_id(),
                 FunctionKind::Static,
                 visibility,
@@ -309,7 +308,6 @@ fn check_item<'tcx>(
                                             check_item_fn(
                                                 ctxt,
                                                 vir,
-                                                Some(self_typ.clone()),
                                                 impl_item.def_id.to_def_id(),
                                                 kind,
                                                 impl_item_visibility,
@@ -408,7 +406,6 @@ fn check_item<'tcx>(
                         let fun = check_item_fn(
                             ctxt,
                             vir,
-                            None,
                             def_id.to_def_id(),
                             FunctionKind::TraitMethodDecl { trait_path: trait_path.clone() },
                             visibility.clone(),

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -63,6 +63,15 @@ fn check_item<'tcx>(
             // TODO use rustc_middle info here? if sufficient, it may allow for a single code path
             // for definitions of the local crate and imported crates
             // let adt_def = tcx.adt_def(item.def_id);
+            //
+            // UPDATE: We now use _some_ rustc_middle info with the adt_def, which we
+            // use to get rustc_middle types. However, we don't exclusively use
+            // rustc_middle; in fact, we still rely on attributes which we can only
+            // get from the HIR data.
+
+            let tyof = ctxt.tcx.type_of(item.def_id.to_def_id());
+            let adt_def = tyof.ty_adt_def().expect("adt_def");
+
             check_item_struct(
                 ctxt,
                 vir,
@@ -73,9 +82,13 @@ fn check_item<'tcx>(
                 ctxt.tcx.hir().attrs(item.hir_id()),
                 variant_data,
                 generics,
+                adt_def,
             )?;
         }
         ItemKind::Enum(enum_def, generics) => {
+            let tyof = ctxt.tcx.type_of(item.def_id.to_def_id());
+            let adt_def = tyof.ty_adt_def().expect("adt_def");
+
             // TODO use rustc_middle? see `Struct` case
             check_item_enum(
                 ctxt,
@@ -87,6 +100,7 @@ fn check_item<'tcx>(
                 ctxt.tcx.hir().attrs(item.hir_id()),
                 enum_def,
                 generics,
+                adt_def,
             )?;
         }
         ItemKind::Impl(impll) => {

--- a/source/rust_verify/src/rust_to_vir_adts.rs
+++ b/source/rust_verify/src/rust_to_vir_adts.rs
@@ -94,9 +94,11 @@ pub fn check_item_struct<'tcx>(
     assert!(adt_def.is_struct());
 
     let vattrs = get_verifier_attrs(attrs)?;
-    let typ_params = Arc::new(check_generics_bounds(ctxt.tcx, generics, vattrs.external_body)?);
-    let name = hack_get_def_name(ctxt.tcx, id.def_id.to_def_id());
-    let path = def_id_to_vir_path(ctxt.tcx, id.def_id.to_def_id());
+    let def_id = id.def_id.to_def_id();
+    let typ_params =
+        Arc::new(check_generics_bounds(ctxt.tcx, generics, vattrs.external_body, def_id)?);
+    let name = hack_get_def_name(ctxt.tcx, def_id);
+    let path = def_id_to_vir_path(ctxt.tcx, def_id);
     let variant_name = Arc::new(name.clone());
     let (variant, one_field_private) = if vattrs.external_body {
         (ident_binder(&variant_name, &Arc::new(vec![])), false)
@@ -147,8 +149,10 @@ pub fn check_item_enum<'tcx>(
     assert!(adt_def.is_enum());
 
     let vattrs = get_verifier_attrs(attrs)?;
-    let typ_params = Arc::new(check_generics_bounds(ctxt.tcx, generics, vattrs.external_body)?);
-    let path = def_id_to_vir_path(ctxt.tcx, id.def_id.to_def_id());
+    let def_id = id.def_id.to_def_id();
+    let typ_params =
+        Arc::new(check_generics_bounds(ctxt.tcx, generics, vattrs.external_body, def_id)?);
+    let path = def_id_to_vir_path(ctxt.tcx, def_id);
     let (variants, one_field_private): (Vec<_>, Vec<_>) = enum_def
         .variants
         .iter()

--- a/source/rust_verify/src/rust_to_vir_adts.rs
+++ b/source/rust_verify/src/rust_to_vir_adts.rs
@@ -2,7 +2,7 @@ use crate::attributes::{get_mode, get_verifier_attrs};
 use crate::context::Context;
 use crate::rust_to_vir_base::{
     check_generics_bounds, def_id_to_vir_path, hack_get_def_name, is_visibility_private,
-    mk_visibility, ty_to_vir,
+    mid_ty_to_vir, mk_visibility,
 };
 use crate::unsupported_unless;
 use crate::util::spanned_new;
@@ -21,6 +21,7 @@ fn check_variant_data<'tcx>(
     name: &Ident,
     variant_data: &'tcx VariantData<'tcx>,
     in_enum: bool,
+    field_defs: impl Iterator<Item = &'tcx rustc_middle::ty::FieldDef>,
 ) -> (Variant, bool) {
     // TODO handle field visibility; does rustc_middle::ty::Visibility have better visibility
     // information than hir?
@@ -29,12 +30,16 @@ fn check_variant_data<'tcx>(
             unsupported_unless!(!recovered, "recovered_struct", variant_data);
             let (vir_fields, field_private): (Vec<_>, Vec<_>) = fields
                 .iter()
-                .map(|field| {
+                .zip(field_defs)
+                .map(|(field, field_def)| {
+                    assert!(field.ident.name == field_def.ident.name);
+                    let field_ty = ctxt.tcx.type_of(field_def.did);
+
                     (
                         ident_binder(
                             &str_ident(&field.ident.as_str()),
                             &(
-                                ty_to_vir(ctxt.tcx, field.ty),
+                                mid_ty_to_vir(ctxt.tcx, field_ty, false),
                                 get_mode(Mode::Exec, ctxt.tcx.hir().attrs(field.hir_id)),
                                 mk_visibility(&Some(module_path.clone()), &field.vis, !in_enum),
                             ),
@@ -48,13 +53,17 @@ fn check_variant_data<'tcx>(
         VariantData::Tuple(fields, _variant_id) => {
             let (vir_fields, field_private): (Vec<_>, Vec<_>) = fields
                 .iter()
+                .zip(field_defs)
                 .enumerate()
-                .map(|(i, field)| {
+                .map(|(i, (field, field_def))| {
+                    assert!(field.ident.name == field_def.ident.name);
+                    let field_ty = ctxt.tcx.type_of(field_def.did);
+
                     (
                         ident_binder(
                             &positional_field_ident(i),
                             &(
-                                ty_to_vir(ctxt.tcx, field.ty),
+                                mid_ty_to_vir(ctxt.tcx, field_ty, false),
                                 get_mode(Mode::Exec, ctxt.tcx.hir().attrs(field.hir_id)),
                                 mk_visibility(&Some(module_path.clone()), &field.vis, !in_enum),
                             ),
@@ -80,7 +89,10 @@ pub fn check_item_struct<'tcx>(
     attrs: &[Attribute],
     variant_data: &'tcx VariantData<'tcx>,
     generics: &'tcx Generics<'tcx>,
+    adt_def: &'tcx rustc_middle::ty::AdtDef,
 ) -> Result<(), VirErr> {
+    assert!(adt_def.is_struct());
+
     let vattrs = get_verifier_attrs(attrs)?;
     let typ_params = Arc::new(check_generics_bounds(ctxt.tcx, generics, vattrs.external_body)?);
     let name = hack_get_def_name(ctxt.tcx, id.def_id.to_def_id());
@@ -89,7 +101,8 @@ pub fn check_item_struct<'tcx>(
     let (variant, one_field_private) = if vattrs.external_body {
         (ident_binder(&variant_name, &Arc::new(vec![])), false)
     } else {
-        check_variant_data(ctxt, module_path, &variant_name, variant_data, false)
+        let field_defs = adt_def.all_fields();
+        check_variant_data(ctxt, module_path, &variant_name, variant_data, false, field_defs)
     };
     let transparency = if vattrs.external_body {
         DatatypeTransparency::Never
@@ -107,6 +120,18 @@ pub fn check_item_struct<'tcx>(
     Ok(())
 }
 
+pub fn get_mid_variant_def_by_name<'a>(
+    adt_def: &'a rustc_middle::ty::AdtDef,
+    variant_name: &str,
+) -> &'a rustc_middle::ty::VariantDef {
+    for variant_def in adt_def.variants.iter() {
+        if variant_def.ident.name.as_str() == variant_name {
+            return variant_def;
+        }
+    }
+    panic!("get_mid_variant_def_by_name failed to find variant");
+}
+
 pub fn check_item_enum<'tcx>(
     ctxt: &Context<'tcx>,
     vir: &mut KrateX,
@@ -117,7 +142,10 @@ pub fn check_item_enum<'tcx>(
     attrs: &[Attribute],
     enum_def: &'tcx EnumDef<'tcx>,
     generics: &'tcx Generics<'tcx>,
+    adt_def: &'tcx rustc_middle::ty::AdtDef,
 ) -> Result<(), VirErr> {
+    assert!(adt_def.is_enum());
+
     let vattrs = get_verifier_attrs(attrs)?;
     let typ_params = Arc::new(check_generics_bounds(ctxt.tcx, generics, vattrs.external_body)?);
     let path = def_id_to_vir_path(ctxt.tcx, id.def_id.to_def_id());
@@ -125,8 +153,11 @@ pub fn check_item_enum<'tcx>(
         .variants
         .iter()
         .map(|variant| {
-            let variant_name = str_ident(&variant.ident.as_str());
-            check_variant_data(ctxt, module_path, &variant_name, &variant.data, true)
+            let variant_name = &variant.ident.as_str();
+            let variant_def = get_mid_variant_def_by_name(&adt_def, variant_name);
+            let variant_name = str_ident(variant_name);
+            let field_defs = variant_def.fields.iter();
+            check_variant_data(ctxt, module_path, &variant_name, &variant.data, true, field_defs)
         })
         .unzip();
     let one_field_private = one_field_private.into_iter().any(|x| x);

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -441,8 +441,9 @@ fn check_generic_bound<'tcx>(
         // Rust language marker traits are ignored in VIR
         Ok(Arc::new(GenericBoundX::Traits(vec![])))
     } else {
-        // REVIEW: this seems wrong
-        // Why did the previous code here throw away the args?
+        // TODO we will actually need to handle these arguments at some point.
+        // Right now, this is safe only because Verus does not support having
+        // a type implement two instances of the same trait with different type args.
         let _args = args;
 
         let trait_name = def_id_to_vir_path(tcx, trait_def_id);

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -464,7 +464,7 @@ pub(crate) fn check_generics_bounds<'tcx>(
     // so then we can handle the case where a method adds extra bounds to an impl
     // type parameter
 
-    let Generics { params, where_clause, span: _ } = hir_generics;
+    let Generics { params, where_clause: _, span: _ } = hir_generics;
 
     // For each generic param, we're going to collect all the trait bounds here.
     let mut typ_param_bounds: HashMap<String, Vec<vir::ast::GenericBound>> = HashMap::new();
@@ -686,7 +686,6 @@ pub(crate) fn check_generics_bounds<'tcx>(
             _ => unsupported_err!(*span, "complex generics", hir_generics),
         }
     }
-    unsupported_err_unless!(where_clause.predicates.len() == 0, hir_generics.span, "where clause");
     Ok(typ_params)
 }
 

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -100,7 +100,7 @@ fn closure_param_typs<'tcx>(bctx: &BodyCtxt<'tcx>, expr: &Expr<'tcx>) -> Vec<Typ
             let sig = substs.as_closure().sig();
             let args: Vec<Typ> = sig
                 .inputs()
-                .skip_binder()
+                .skip_binder() // REVIEW: rustc docs refer to skip_binder as "dangerous"
                 .iter()
                 .map(|t| mid_ty_to_vir(bctx.ctxt.tcx, t, false /* allow_mut_ref */))
                 .collect();

--- a/source/rust_verify/tests/adts.rs
+++ b/source/rust_verify/tests/adts.rs
@@ -767,11 +767,7 @@ test_verify_one_file! {
             let u = x.u;
             assert(u == 5);
         }
-    } => Ok(())
-}
 
-test_verify_one_file! {
-    #[test] #[ignore] type_alias_with_params code!{
         struct Bar<T> {
             u: T,
         }

--- a/source/rust_verify/tests/traits.rs
+++ b/source/rust_verify/tests/traits.rs
@@ -143,6 +143,20 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] test_not_yet_supported_11 code! {
+        trait T {
+            #[spec]
+            fn f(&self) -> bool { no_method_body() }
+        }
+
+        trait S : T {
+            #[spec]
+            fn g(&self) -> bool { no_method_body() }
+        }
+    } => Err(_)
+}
+
+test_verify_one_file! {
     #[test] test_ill_formed_1 code! {
         trait T1 {
             fn f(&self); // need to call no_method_body()

--- a/source/rust_verify/tests/traits.rs
+++ b/source/rust_verify/tests/traits.rs
@@ -955,3 +955,42 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_fails(err, 3)
 }
+
+test_verify_one_file! {
+    #[test] test_ok_where_clause verus_code! {
+        trait Tr {
+            spec fn f(&self) -> bool;
+        }
+
+        spec fn not_f<S>(x: S) -> bool
+            where S: Tr
+        {
+            !x.f()
+        }
+
+        proof fn foo<S>(x: S, y: S) where S : Tr
+            requires x.f() ==> y.f(),
+            ensures not_f(y) ==> not_f(x),
+        {
+        }
+
+        struct Bar<X>
+        {
+            x: X,
+        }
+
+        impl<X> Bar<X>
+            where X: Tr
+        {
+            spec fn bar_not_f(&self) -> bool {
+                not_f(self.x)
+            }
+
+            proof fn easy_lemma(bar1: &Self, bar2: &Self)
+                requires bar1.x.f() ==> bar2.x.f(),
+                ensures not_f(bar2.x) ==> not_f(bar1.x)
+            {
+            }
+        }
+    } => Ok(())
+}

--- a/source/rust_verify/tests/traits.rs
+++ b/source/rust_verify/tests/traits.rs
@@ -157,6 +157,27 @@ test_verify_one_file! {
 }
 
 test_verify_one_file! {
+    #[test] test_not_yet_supported_12 code!{
+        struct Abc<T> {
+            t: T,
+        }
+
+        trait SomeTrait {
+            #[spec]
+            fn f(&self) -> bool { no_method_body() }
+        }
+
+        impl<S> Abc<S> {
+            fn foo(&self)
+                where S: SomeTrait
+            {
+                assert(self.t.f() == self.t.f());
+            }
+        }
+    } => Err(_)
+}
+
+test_verify_one_file! {
     #[test] test_ill_formed_1 code! {
         trait T1 {
             fn f(&self); // need to call no_method_body()


### PR DESCRIPTION
As discussed with @utaal earlier. This makes for less duplication, plus mid_ty_to_vir supports more features, so for example, this completes the support for type aliases.

Something I forgot to account for in our discussion earlier was generic params. This ended up being the gnarliest part, and I had to rewrite `check_generic_bounds` (commit c0b99f7da9883710bb6e030969852d92d438756a). The rustc_middle `Predicate` type is pretty reasonable - it just comes in a pretty different shape than HIR's AST-based structure.