### PR TITLE
Switch from * to @ for Ghost/Tracked and add borrow/borrow_mut for Ghost/Tracked

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -212,7 +212,7 @@ pub struct Tracked<#[verifier(strictly_positive)] A> {
 
 impl<A> Ghost<A> {
     #[spec]
-    pub fn value(self) -> A {
+    pub fn view(self) -> A {
         unimplemented!()
     }
 
@@ -228,11 +228,25 @@ impl<A> Ghost<A> {
     pub fn assume_new() -> Self {
         Ghost { phantom: PhantomData }
     }
+
+    // note that because we return #[spec], not #[exec], we do not implement the Borrow trait
+    #[spec]
+    #[verifier(external_body)]
+    pub fn borrow(&self) -> &A {
+        unimplemented!()
+    }
+
+    // note that because we return #[spec], not #[exec], we do not implement the BorrowMut trait
+    #[proof]
+    #[verifier(external)]
+    pub fn borrow_mut(#[proof] &mut self) -> &mut A {
+        unimplemented!()
+    }
 }
 
 impl<A> Tracked<A> {
     #[spec]
-    pub fn value(self) -> A {
+    pub fn view(self) -> A {
         unimplemented!()
     }
 
@@ -241,6 +255,29 @@ impl<A> Tracked<A> {
     #[inline(always)]
     pub fn assume_new() -> Self {
         Tracked { phantom: PhantomData }
+    }
+
+    #[proof]
+    #[verifier(external_body)]
+    #[verifier(returns(proof))]
+    pub fn get(#[proof] self) -> A {
+        unimplemented!()
+    }
+
+    // note that because we return #[proof], not #[exec], we do not implement the Borrow trait
+    #[proof]
+    #[verifier(external_body)]
+    #[verifier(returns(proof))]
+    pub fn borrow(#[proof] &self) -> &A {
+        unimplemented!()
+    }
+
+    // note that because we return #[proof], not #[exec], we do not implement the BorrowMut trait
+    #[proof]
+    #[verifier(external_body)]
+    #[verifier(returns(proof))]
+    pub fn borrow_mut(#[proof] &mut self) -> &mut A {
+        unimplemented!()
     }
 }
 
@@ -253,24 +290,6 @@ impl<A> Clone for Ghost<A> {
 }
 
 impl<A> Copy for Ghost<A> {}
-
-impl<A> std::ops::Deref for Ghost<A> {
-    type Target = A;
-    #[spec]
-    #[verifier(external)]
-    fn deref(&self) -> &A {
-        unimplemented!()
-    }
-}
-
-impl<A> std::ops::Deref for Tracked<A> {
-    type Target = A;
-    #[spec]
-    #[verifier(external)]
-    fn deref(&self) -> &A {
-        unimplemented!()
-    }
-}
 
 macro_rules! emit_phantom {
     ($x:ident) => {

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -48,6 +48,8 @@ struct Visitor {
     // Fixed is used for bitwise operations, where we use Rust's native integer literals
     // rather than an int literal.
     inside_arith: InsideArith,
+    // assign_to == true means we're an expression being assigned to by Assign
+    assign_to: bool,
 
     // Add extra verus signature information to the docstring
     rustdoc: bool,
@@ -429,19 +431,39 @@ impl VisitMut for Visitor {
             }
             _ => InsideArith::None,
         };
+        let sub_assign_to = match expr {
+            Expr::Field(..) => self.assign_to,
+            _ => false,
+        };
 
+        // Recursively call visit_expr_mut
         let is_inside_ghost = self.inside_ghost > 0;
         let is_inside_arith = self.inside_arith;
+        let is_assign_to = self.assign_to;
         let use_spec_traits = self.use_spec_traits && is_inside_ghost;
         if mode_block.is_some() || ghost_intrinsic {
             self.inside_ghost += 1;
         }
         self.inside_arith = sub_inside_arith;
+        self.assign_to = sub_assign_to;
+        let assign_left = if let Expr::Assign(assign) = expr {
+            let mut left = take_expr(&mut assign.left);
+            self.assign_to = true;
+            self.visit_expr_mut(&mut left);
+            self.assign_to = false;
+            Some(left)
+        } else {
+            None
+        };
         visit_expr_mut(self, expr);
+        if let Expr::Assign(assign) = expr {
+            assign.left = Box::new(assign_left.expect("assign_left"));
+        }
         if mode_block.is_some() || ghost_intrinsic {
             self.inside_ghost -= 1;
         }
         self.inside_arith = is_inside_arith;
+        self.assign_to = is_assign_to;
 
         if let Expr::Unary(unary) = expr {
             use syn_verus::spanned::Spanned;
@@ -795,11 +817,21 @@ impl VisitMut for Visitor {
                     }
                     expr.replace_attrs(attrs);
                 }
-                Expr::View(view) => {
+                Expr::View(view) if !self.assign_to => {
                     let at_token = view.at_token;
                     let span = at_token.span;
                     let base = view.expr;
                     *expr = parse_quote_spanned!(span => (#base.view()));
+                }
+                Expr::View(view) => {
+                    use syn_verus::spanned::Spanned;
+                    assert!(self.assign_to);
+                    let at_token = view.at_token;
+                    let span1 = at_token.span;
+                    let span2 = view.span();
+                    let base = view.expr;
+                    let borrowed: Expr = parse_quote_spanned!(span1 => #base.borrow_mut());
+                    *expr = parse_quote_spanned!(span2 => (*(#borrowed)));
                 }
                 Expr::Assume(assume) => {
                     let span = assume.assume_token.span;
@@ -1146,6 +1178,7 @@ pub(crate) fn rewrite_items(
         use_spec_traits,
         inside_ghost: 0,
         inside_arith: InsideArith::None,
+        assign_to: false,
         rustdoc: env_rustdoc(),
     };
     for mut item in items.items {
@@ -1169,6 +1202,7 @@ pub(crate) fn rewrite_expr(
         use_spec_traits: true,
         inside_ghost: if inside_ghost { 1 } else { 0 },
         inside_arith: InsideArith::None,
+        assign_to: false,
         rustdoc: env_rustdoc(),
     };
     visitor.visit_expr_mut(&mut expr);
@@ -1244,6 +1278,7 @@ pub(crate) fn proof_macro_exprs(
         use_spec_traits: true,
         inside_ghost: if inside_ghost { 1 } else { 0 },
         inside_arith: InsideArith::None,
+        assign_to: false,
         rustdoc: env_rustdoc(),
     };
     for element in &mut invoke.elements.elements {

--- a/source/pervasive/cell.rs
+++ b/source/pervasive/cell.rs
@@ -86,9 +86,8 @@ impl<V> PCell<V> {
     #[inline(always)]
     #[verifier(external_body)]
     pub fn empty() -> (pt: (PCell<V>, Tracked<Permission<V>>))
-        ensures ((*pt.1) ===
-            Permission{ pcell: pt.0.id(), value: option::Option::None }
-        ),
+        ensures
+            pt.1@ === (Permission{ pcell: pt.0.id(), value: option::Option::None }),
     {
         let p = PCell { ucell: UnsafeCell::new(MaybeUninit::uninit()) };
         (p, Tracked::assume_new())
@@ -98,11 +97,11 @@ impl<V> PCell<V> {
     #[verifier(external_body)]
     pub fn put(&self, perm: &mut Tracked<Permission<V>>, v: V)
         requires
-            self.id() === (**old(perm)).pcell,
-            (**old(perm)).value === option::Option::None,
+            self.id() === old(perm)@.pcell,
+            old(perm)@.value === option::Option::None,
         ensures
-            (**perm).pcell === (**old(perm)).pcell,
-            (**perm).value === option::Option::Some(v),
+            perm@.pcell === old(perm)@.pcell,
+            perm@.value === option::Option::Some(v),
     {
         opens_invariants_none();
 
@@ -115,12 +114,12 @@ impl<V> PCell<V> {
     #[verifier(external_body)]
     pub fn take(&self, perm: &mut Tracked<Permission<V>>) -> (v: V)
         requires
-            self.id() === (**old(perm)).pcell,
-            (**old(perm)).value.is_Some(),
+            self.id() === old(perm)@.pcell,
+            old(perm)@.value.is_Some(),
         ensures
-            (**perm).pcell === (**old(perm)).pcell,
-            (**perm).value === option::Option::None,
-            v === (**old(perm)).value.get_Some_0(),
+            perm@.pcell === old(perm)@.pcell,
+            perm@.value === option::Option::None,
+            v === old(perm)@.value.get_Some_0(),
     {
         opens_invariants_none();
 
@@ -135,12 +134,12 @@ impl<V> PCell<V> {
     #[verifier(external_body)]
     pub fn replace(&self, perm: &mut Tracked<Permission<V>>, in_v: V) -> (out_v: V)
         requires
-            self.id() === (**old(perm)).pcell,
-            (**old(perm)).value.is_Some(),
+            self.id() === old(perm)@.pcell,
+            old(perm)@.value.is_Some(),
         ensures
-            (**perm).pcell === (**old(perm)).pcell,
-            (**perm).value === option::Option::Some(in_v),
-            out_v === (**old(perm)).value.get_Some_0(),
+            perm@.pcell === old(perm)@.pcell,
+            perm@.value === option::Option::Some(in_v),
+            out_v === old(perm)@.value.get_Some_0(),
     {
         opens_invariants_none();
 
@@ -159,10 +158,10 @@ impl<V> PCell<V> {
     #[verifier(external_body)]
     pub fn borrow<'a>(&'a self, perm: &'a Tracked<Permission<V>>) -> (v: &'a V)
         requires
-            self.id() === (**perm).pcell,
-            (**perm).value.is_Some(),
+            self.id() === perm@.pcell,
+            perm@.value.is_Some(),
         ensures
-            *v === (**perm).value.get_Some_0(),
+            *v === perm@.value.get_Some_0(),
     {
         opens_invariants_none();
 
@@ -177,10 +176,10 @@ impl<V> PCell<V> {
     #[inline(always)]
     pub fn into_inner(self, perm: Tracked<Permission<V>>) -> (v: V)
         requires
-            self.id() === (*perm).pcell,
-            (*perm).value.is_Some(),
+            self.id() === perm@.pcell,
+            perm@.value.is_Some(),
         ensures
-            v === (*perm).value.get_Some_0(),
+            v === perm@.value.get_Some_0(),
     {
         opens_invariants_none();
 
@@ -190,7 +189,8 @@ impl<V> PCell<V> {
 
     #[inline(always)]
     pub fn new(v: V) -> (pt: (PCell<V>, Tracked<Permission<V>>))
-        ensures ((*pt.1) === Permission{ pcell: pt.0.id(), value: option::Option::Some(v) }),
+        ensures
+            pt.1@ === (Permission{ pcell: pt.0.id(), value: option::Option::Some(v) }),
     {
         let (p, mut t) = Self::empty();
         p.put(&mut t, v);

--- a/source/pervasive/mod.rs
+++ b/source/pervasive/mod.rs
@@ -105,7 +105,7 @@ pub fn print_u64(i: u64) {
 /// ```
 
 #[macro_export]
-macro_rules! assert_by_contradiction {
+macro_rules! assert_by_contradiction_macro {
     ($predicate:expr, $bblock:block) => {
         ::builtin::assert_by($predicate, {
             if !$predicate {
@@ -113,5 +113,11 @@ macro_rules! assert_by_contradiction {
                 crate::pervasive::assert(false);
             }
         });
+    }
+}
+#[macro_export]
+macro_rules! assert_by_contradiction {
+    ($($a:tt)*) => {
+        verus_proof_macro_exprs!(assert_by_contradiction_macro!($($a)*))
     }
 }

--- a/source/pervasive/modes.rs
+++ b/source/pervasive/modes.rs
@@ -3,36 +3,28 @@
 #[allow(unused_imports)] use crate::pervasive::*;
 use std::marker::PhantomData;
 
-// TODO: the *_exec* and tracked_get functions would be better in builtin,
+// TODO: the *_exec* functions would be better in builtin,
 // but it's painful to implement the support in erase.rs at the moment.
 #[verifier(external_body)]
 pub fn ghost_exec<A>(#[spec] a: A) -> Ghost<A> {
-    ensures(|s: Ghost<A>| equal(a, s.value()));
+    ensures(|s: Ghost<A>| equal(a, s.view()));
     Ghost::assume_new()
 }
 
 #[verifier(external_body)]
 pub fn tracked_exec<A>(#[proof] a: A) -> Tracked<A> {
-    ensures(|s: Tracked<A>| equal(a, s.value()));
+    ensures(|s: Tracked<A>| equal(a, s.view()));
     opens_invariants_none();
     Tracked::assume_new()
 }
 
 #[verifier(external_body)]
 pub fn tracked_exec_borrow<'a, A>(#[proof] a: &'a A) -> &'a Tracked<A> {
-    ensures(|s: Tracked<A>| equal(*a, s.value()));
+    ensures(|s: Tracked<A>| equal(*a, s.view()));
     opens_invariants_none();
 
     // TODO: implement this (using unsafe) or mark function as ghost (if supported by Rust)
     unimplemented!();
-}
-
-#[proof]
-#[verifier(external_body)]
-#[verifier(returns(proof))]
-pub fn tracked_get<A>(#[proof] t: Tracked<A>) -> A {
-    ensures(|a: A| equal(a, *t));
-    unimplemented!()
 }
 
 verus! {
@@ -44,7 +36,7 @@ pub struct Trk<A>(pub tracked A);
 #[inline(always)]
 #[verifier(external_body)]
 pub fn ghost_unwrap_gho<A>(a: Ghost<Gho<A>>) -> (ret: Ghost<A>)
-    ensures a.0 === *ret
+    ensures a@.0 === ret@
 {
     Ghost::assume_new()
 }
@@ -52,7 +44,7 @@ pub fn ghost_unwrap_gho<A>(a: Ghost<Gho<A>>) -> (ret: Ghost<A>)
 #[inline(always)]
 #[verifier(external_body)]
 pub fn tracked_unwrap_gho<A>(a: Tracked<Gho<A>>) -> (ret: Tracked<A>)
-    ensures a.0 === *ret
+    ensures a@.0 === ret@
 {
     Tracked::assume_new()
 }
@@ -60,7 +52,7 @@ pub fn tracked_unwrap_gho<A>(a: Tracked<Gho<A>>) -> (ret: Tracked<A>)
 #[inline(always)]
 #[verifier(external_body)]
 pub fn tracked_unwrap_trk<A>(a: Tracked<Trk<A>>) -> (ret: Tracked<A>)
-    ensures a.0 === *ret
+    ensures a@.0 === ret@
 {
     Tracked::assume_new()
 }

--- a/source/pervasive/ptr.rs
+++ b/source/pervasive/ptr.rs
@@ -216,7 +216,7 @@ impl<V> PPtr<V> {
     #[inline(always)]
     #[verifier(external_body)]
     pub fn empty() -> (pt: (PPtr<V>, Tracked<Permission<V>>))
-        ensures (*pt.1 === Permission{ pptr: pt.0.id(), value: option::Option::None }),
+        ensures (pt.1@ === Permission{ pptr: pt.0.id(), value: option::Option::None }),
     {
         opens_invariants_none();
 
@@ -253,11 +253,11 @@ impl<V> PPtr<V> {
     #[verifier(external_body)]
     pub fn put(&self, perm: &mut Tracked<Permission<V>>, v: V)
         requires
-            self.id() === (**old(perm)).pptr,
-            (**old(perm)).value === option::Option::None,
+            self.id() === old(perm)@.pptr,
+            old(perm)@.value === option::Option::None,
         ensures
-            (**perm).pptr === (**old(perm)).pptr,
-            (**perm).value === option::Option::Some(v),
+            perm@.pptr === old(perm)@.pptr,
+            perm@.value === option::Option::Some(v),
     {
         opens_invariants_none();
 
@@ -278,12 +278,12 @@ impl<V> PPtr<V> {
     #[verifier(external_body)]
     pub fn take(&self, perm: &mut Tracked<Permission<V>>) -> (v: V)
         requires
-            self.id() === (**old(perm)).pptr,
-            (**old(perm)).value.is_Some(),
+            self.id() === old(perm)@.pptr,
+            old(perm)@.value.is_Some(),
         ensures
-            (**perm).pptr === (**old(perm)).pptr,
-            (**perm).value === option::Option::None,
-            v === (**old(perm)).value.get_Some_0(),
+            perm@.pptr === old(perm)@.pptr,
+            perm@.value === option::Option::None,
+            v === old(perm)@.value.get_Some_0(),
     {
         opens_invariants_none();
 
@@ -301,12 +301,12 @@ impl<V> PPtr<V> {
     #[verifier(external_body)]
     pub fn replace(&self, perm: &mut Tracked<Permission<V>>, in_v: V) -> (out_v: V)
         requires
-            self.id() === (**old(perm)).pptr,
-            (**old(perm)).value.is_Some(),
+            self.id() === old(perm)@.pptr,
+            old(perm)@.value.is_Some(),
         ensures
-            (**perm).pptr === (**old(perm)).pptr,
-            (**perm).value === option::Option::Some(in_v),
-            out_v === (**old(perm)).value.get_Some_0(),
+            perm@.pptr === old(perm)@.pptr,
+            perm@.value === option::Option::Some(in_v),
+            out_v === old(perm)@.value.get_Some_0(),
     {
         opens_invariants_none();
 
@@ -326,9 +326,9 @@ impl<V> PPtr<V> {
     #[verifier(external_body)]
     pub fn borrow<'a>(&self, perm: &'a Tracked<Permission<V>>) -> (v: &'a V)
         requires
-            self.id() === (**perm).pptr,
-            (**perm).value.is_Some(),
-        ensures *v === (**perm).value.get_Some_0(),
+            self.id() === perm@.pptr,
+            perm@.value.is_Some(),
+        ensures *v === perm@.value.get_Some_0(),
     {
         opens_invariants_none();
         
@@ -347,8 +347,8 @@ impl<V> PPtr<V> {
     #[verifier(external_body)]
     pub fn dispose(&self, perm: Tracked<Permission<V>>)
         requires
-            self.id() === (*perm).pptr,
-            (*perm).value === option::Option::None,
+            self.id() === perm@.pptr,
+            perm@.value === option::Option::None,
     {
         opens_invariants_none();
 
@@ -369,10 +369,10 @@ impl<V> PPtr<V> {
     #[inline(always)]
     pub fn into_inner(self, perm: Tracked<Permission<V>>) -> (v: V)
         requires
-            self.id() === (*perm).pptr,
-            (*perm).value.is_Some(),
+            self.id() === perm@.pptr,
+            perm@.value.is_Some(),
         ensures
-            v === (*perm).value.get_Some_0(),
+            v === perm@.value.get_Some_0(),
     {
         opens_invariants_none();
 
@@ -388,7 +388,7 @@ impl<V> PPtr<V> {
     #[inline(always)]
     pub fn new(v: V) -> (pt: (PPtr<V>, Tracked<Permission<V>>))
         ensures
-            (*pt.1 === Permission{ pptr: pt.0.id(), value: option::Option::Some(v) }),
+            (pt.1@ === Permission{ pptr: pt.0.id(), value: option::Option::Some(v) }),
     {
         let (p, mut t) = Self::empty();
         p.put(&mut t, v);

--- a/source/rust_verify/example/cells.rs
+++ b/source/rust_verify/example/cells.rs
@@ -18,5 +18,5 @@ fn main() {
 
     pcell.put(&mut token, x);
 
-    assert(equal((*token).value, option::Option::Some(X { i : 5 })));
+    assert(equal(token.view().value, option::Option::Some(X { i : 5 })));
 }

--- a/source/rust_verify/example/doubly_linked_xor.rs
+++ b/source/rust_verify/example/doubly_linked_xor.rs
@@ -19,10 +19,13 @@ use crate::pervasive::{modes::*};
 // TODO should really use usize, bit-vector operations aren't supported right now, so we
 // use u64 and assume it's equivalent to usize.
 
+verus! {
+
 #[verifier(external_body)]
-#[proof]
-fn lemma_usize_u64(x: u64) {
-    ensures(x as usize as u64 == x);
+proof fn lemma_usize_u64(x: u64)
+    ensures
+        x as usize as u64 == x,
+{
     unimplemented!();
 }
 
@@ -38,161 +41,147 @@ struct Node<V> {
 // and in ghost code, tracks all the pointers and all the permissions to access the nodes
 
 struct DListXor<V> {
-    #[spec] ptrs: Seq<PPtr<Node<V>>>,
-    #[proof] perms: Map<nat, Permission<Node<V>>>,
+    ptrs: Ghost<Seq<PPtr<Node<V>>>>,
+    perms: Tracked<Map<nat, Permission<Node<V>>>>,
 
     head: u64,
     tail: u64,
 }
 
 impl<V> DListXor<V> {
-    #[spec]
-    fn wf_perms(&self) -> bool {
-        forall(|i: nat| (0 <= i && i < self.ptrs.len()) >>= self.wf_perm(i))
+    spec fn wf_perms(&self) -> bool {
+        forall|i: nat| 0 <= i < self.ptrs@.len() ==> self.wf_perm(i)
     }
 
-    #[spec]
-    fn prev_of(&self, i: nat) -> u64 {
-        recommends(i < self.ptrs.len());
-
+    spec fn prev_of(&self, i: nat) -> u64
+        recommends i < self.ptrs@.len()
+    {
         if i == 0 {
             0
         } else {
-            self.ptrs.index(i as int - 1).id() as u64
+            self.ptrs@[i - 1].id() as u64
         }
     }
 
-    #[spec]
-    fn next_of(&self, i: nat) -> u64 {
-        recommends(i < self.ptrs.len());
-
-        if i + 1 == self.ptrs.len() {
+    spec fn next_of(&self, i: nat) -> u64
+        recommends i < self.ptrs@.len()
+    {
+        if i + 1 == self.ptrs@.len() {
             0
         } else {
-            self.ptrs.index(i as int + 1).id() as u64
+            self.ptrs@[i + 1int].id() as u64
         }
     }
 
-
-    #[spec]
-    fn wf_perm(&self, i: nat) -> bool {
-        recommends(i < self.ptrs.len());
-
-        self.perms.dom().contains(i)
-        &&
-        equal(self.perms.index(i).pptr, self.ptrs.index(i).id())
-        &&
-        0 < self.ptrs.index(i).id()
-        &&
-        self.ptrs.index(i).id() < 0x10000000000000000
-        &&
-        self.perms.index(i).value.is_Some()
-        &&
-        self.perms.index(i).value.get_Some_0().xored == (
+    spec fn wf_perm(&self, i: nat) -> bool
+        recommends i < self.ptrs@.len()
+    {
+        &&& self.perms@.dom().contains(i)
+        &&& self.perms@[i].pptr === self.ptrs@[i as int].id()
+        &&& 0 < self.ptrs@[i as int].id()
+        &&& self.ptrs@[i as int].id() < 0x10000000000000000
+        &&& self.perms@[i].value.is_Some()
+        &&& self.perms@[i].value.get_Some_0().xored == (
             self.prev_of(i) ^ self.next_of(i)
         )
     }
 
-    #[spec]
-    fn wf_head(&self) -> bool {
-        if self.ptrs.len() == 0 {
+    spec fn wf_head(&self) -> bool {
+        if self.ptrs@.len() == 0 {
             self.head == 0
         } else {
-            self.head as int == self.ptrs.index(0).id()
+            self.head == self.ptrs@[0].id()
         }
     }
 
-    #[spec]
-    fn wf_tail(&self) -> bool {
-        if self.ptrs.len() == 0 {
+    spec fn wf_tail(&self) -> bool {
+        if self.ptrs@.len() == 0 {
             self.tail == 0
         } else {
-            self.tail as int == self.ptrs.index(self.ptrs.len() as int - 1).id()
+            self.tail == self.ptrs@[self.ptrs@.len() - 1].id()
         }
     }
 
 
-    #[spec]
-    fn wf(&self) -> bool {
+    spec fn wf(&self) -> bool {
         self.wf_perms() && self.wf_head() && self.wf_tail()
     }
 
-    #[spec]
-    fn view(&self) -> Seq<V> {
-        recommends(self.wf());
+    spec fn view(&self) -> Seq<V>
+        recommends self.wf()
+    {
 
-        Seq::<V>::new(self.ptrs.len(), |i: int| {
-            self.perms.index(i as nat).value.get_Some_0().v
+        Seq::<V>::new(self.ptrs@.len(), |i: int| {
+            self.perms@[i as nat].value.get_Some_0().v
         })
     }
 
-    #[exec]
-    fn new() -> Self {
-        ensures(|s: Self| [
-            s.wf() && s.view().len() == 0
-        ]);
-
+    fn new() -> (s: Self)
+        ensures
+            s.wf(),
+            s@.len() == 0,
+    {
         DListXor {
-            ptrs: Seq::empty(),
-            perms: Map::tracked_empty(),
+            ptrs: ghost(Seq::empty()),
+            perms: tracked(Map::tracked_empty()),
             head: 0,
             tail: 0,
         }
     }
 
-    #[exec]
-    fn push_first(&mut self, v: V) {
-        requires([
+    fn push_first(&mut self, v: V)
+        requires
             old(self).wf(),
-            old(self).ptrs.len() == 0,
-        ]);
-        ensures([
+            old(self).ptrs@.len() == 0,
+        ensures
             self.wf(),
-            equal(self.view(), old(self).view().push(v)),
-        ]);
-
+            self@ === old(self)@.push(v),
+    {
         let (ptr, perm) = PPtr::new(
             Node::<V> { xored: 0, v }
         );
-        #[proof] let perm = tracked_get(perm);
-        perm.is_nonnull();
-        let perm = tracked_exec(perm);
-
-        self.ptrs = self.ptrs.push(ptr);
-        self.perms.tracked_insert(self.ptrs.len() - 1, tracked_get(perm));
+        proof {
+            self.ptrs@ = self.ptrs@.push(ptr);
+            let tracked perm = (tracked perm).get();
+            (tracked &perm).is_nonnull();
+            (tracked self.perms.borrow_mut())
+                .tracked_insert((self.ptrs@.len() - 1) as nat, tracked perm);
+        }
 
         self.tail = ptr.to_usize() as u64;
         self.head = self.tail;
 
-        assert_bit_vector(0 as u64 ^ 0 as u64 == 0 as u64);
-        assert(self.view().ext_equal(old(self).view().push(v)));
+        assert(0u64 ^ 0u64 == 0u64) by(bit_vector);
+        assert(self@.ext_equal(old(self)@.push(v)));
     }
 
-    #[exec]
-    fn push_back(&mut self, v: V) {
-        requires(old(self).wf());
-        ensures([
+    fn push_back(&mut self, v: V)
+        requires
+            old(self).wf(),
+        ensures
             self.wf(),
-            equal(self.view(), old(self).view().push(v)),
-        ]);
-
+            self@ === old(self)@.push(v),
+    {
         if self.tail == 0 {
             // Special case: list is empty
 
-            assert_by_contradiction!(self.ptrs.len() == 0, {
-                assert(self.wf_perm(self.ptrs.len() - 1));
-            });
+            proof {
+                assert_by_contradiction!(self.ptrs@.len() == 0, {
+                    assert(self.wf_perm((self.ptrs@.len() - 1) as nat));
+                });
+            }
 
             self.push_first(v);
         } else {
-            assert(self.ptrs.len() > 0);
-            assert(self.wf_perm(self.ptrs.len() - 1));
+            assert(self.ptrs@.len() > 0);
+            assert(self.wf_perm((self.ptrs@.len() - 1) as nat));
 
             let tail_ptr_u64 = self.tail;
-            lemma_usize_u64(tail_ptr_u64);
+            proof { lemma_usize_u64(tail_ptr_u64); }
             let tail_ptr = PPtr::<Node<V>>::from_usize(tail_ptr_u64 as usize);
-            #[proof] let tail_perm = self.perms.tracked_remove(self.ptrs.len() - 1);
-            let mut tail_perm = tracked_exec(tail_perm);
+            let mut tail_perm: Tracked<Permission<Node<V>>> = tracked(
+                (tracked self.perms.borrow_mut()).tracked_remove((self.ptrs@.len() - 1) as nat)
+            );
             let mut tail_node = tail_ptr.take(&mut tail_perm);
             let second_to_last_ptr = tail_node.xored;
 
@@ -200,149 +189,160 @@ impl<V> DListXor<V> {
                 Node::<V> { xored: tail_ptr_u64, v }
             );
 
-            #[proof] let perm = tracked_get(perm);
-            perm.is_nonnull();
-            let perm = tracked_exec(perm);
+            proof {
+                (tracked perm.borrow()).is_nonnull();
+            }
 
             let new_ptr_u64 = ptr.to_usize() as u64;
 
             tail_node.xored = second_to_last_ptr ^ new_ptr_u64;
             tail_ptr.put(&mut tail_perm, tail_node);
-            self.perms.tracked_insert(self.ptrs.len() - 1, tracked_get(tail_perm));
-            self.perms.tracked_insert(self.ptrs.len(), tracked_get(perm));
-            self.ptrs = self.ptrs.push(ptr);
+            proof {
+                (tracked self.perms.borrow_mut())
+                    .tracked_insert((self.ptrs@.len() - 1) as nat, (tracked tail_perm).get());
+                (tracked self.perms.borrow_mut())
+                    .tracked_insert(self.ptrs@.len(), (tracked perm).get());
+                self.ptrs@ = self.ptrs@.push(ptr);
+            }
             self.tail = new_ptr_u64;
 
-            assert_bit_vector(tail_ptr_u64 ^ 0 == tail_ptr_u64);
+            proof {
+                assert(tail_ptr_u64 ^ 0 == tail_ptr_u64) by(bit_vector);
 
-            #[spec] let i = self.ptrs.len() - 2;
-            //assert(self.perms.dom().contains(i));
-            //assert(equal(self.perms.index(i).pptr, self.ptrs.index(i).view()));
-            //assert(self.perms.index(i).value.is_Some());
-            #[spec] let prev_of_i = self.prev_of(i);
-            assert_bit_vector(prev_of_i ^ 0 == prev_of_i);
-            //assert(self.prev_of(i) == second_to_last_ptr);
-            //assert(self.next_of(i) == new_ptr_int);
-            //assert(self.perms.index(i).value.get_Some_0().xored == (
-            //    self.prev_of(i) ^ self.next_of(i)
-            //));
+                let i = (self.ptrs@.len() - 2) as nat;
+                //assert(self.perms@.dom().contains(i));
+                //assert(self.perms@[i].pptr === self.ptrs@[i]@);
+                //assert(self.perms@[i].value.is_Some());
+                let prev_of_i = self.prev_of(i);
+                assert_bit_vector(prev_of_i ^ 0 == prev_of_i);
+                //assert(self.prev_of(i) == second_to_last_ptr);
+                //assert(self.next_of(i) == new_ptr_int);
+                //assert(self.perms@[i].value.get_Some_0().xored == (
+                //    self.prev_of(i) ^ self.next_of(i)
+                //));
 
-            assert(self.wf_perm(self.ptrs.len() - 2));
-            assert(self.wf_perm(self.ptrs.len() - 1));
-            assert(forall(|i: nat| i < self.ptrs.len() >>=
-                old(self).wf_perm(i) >>= self.wf_perm(i)));
-            assert(self.wf_perms());
-            assert(self.wf_tail());
+                assert(self.wf_perm((self.ptrs@.len() - 2) as nat));
+                assert(self.wf_perm((self.ptrs@.len() - 1) as nat));
+                assert(forall|i: nat| i < self.ptrs@.len() ==>
+                    old(self).wf_perm(i) ==> self.wf_perm(i));
+                assert(self.wf_perms());
+                assert(self.wf_tail());
 
-            assert(equal(self.view().index(self.ptrs.len() as int - 1), v));
-            assert_forall_by(|i: nat| {
-                requires(i < self.ptrs.len() - 1);
-                ensures(equal(
-                    old(self).view().index(i),
-                    self.view().index(i)
-                ));
-                assert(old(self).wf_perm(i)); // trigger
-            });
-            assert(self.view().ext_equal(old(self).view().push(v)));
+                assert(self@[self.ptrs@.len() - 1] === v);
+                assert forall|i: int| 0 <= i < self.ptrs@.len() - 1 implies old(self)@[i] === self@[i] by {
+                    assert(old(self).wf_perm(i as nat)); // trigger
+                };
+                assert(self@.ext_equal(old(self)@.push(v)));
+            }
         }
     }
 
-    #[exec]
-    fn pop_back(&mut self) -> V {
-        requires([
+    fn pop_back(&mut self) -> (v: V)
+        requires
             old(self).wf(),
-            old(self).view().len() > 0,
-        ]);
-        ensures(|v: V| [
+            old(self)@.len() > 0,
+        ensures
             self.wf(),
-            equal(self.view(), old(self).view().drop_last()),
-            equal(v, old(self).view().index(old(self).view().len() as int - 1)),
-        ]);
-
-        assert(self.wf_perm(self.ptrs.len() - 1));
+            self@ === old(self)@.drop_last(),
+            v === old(self)@[old(self)@.len() - 1],
+    {
+        assert(self.wf_perm((self.ptrs@.len() - 1) as nat));
 
         let last_u64 = self.tail;
-        lemma_usize_u64(last_u64);
+        proof { lemma_usize_u64(last_u64); }
         let last_ptr = PPtr::<Node<V>>::from_usize(last_u64 as usize);
-        #[proof] let last_perm = self.perms.tracked_remove(self.ptrs.len() - 1);
-        let last_node = last_ptr.into_inner(tracked_exec(last_perm));
+        let last_perm: Tracked<Permission<Node<V>>> = tracked(
+            (tracked self.perms.borrow_mut()).tracked_remove((self.ptrs@.len() - 1) as nat)
+        );
+        let last_node = last_ptr.into_inner(last_perm);
 
         let penult_u64 = last_node.xored;
         let v = last_node.v;
 
-        #[spec] let self_head = self.head;
-        assert_bit_vector(self_head ^ 0 == self_head);
-        assert_bit_vector(0 as u64 ^ 0 == 0);
+        proof {
+            let self_head = self.head;
+            assert(self_head ^ 0 == self_head) by(bit_vector);
+            assert(0u64 ^ 0 == 0) by(bit_vector);
+        }
 
         if penult_u64 == 0 {
             self.tail = 0;
             self.head = 0;
 
-            assert_by_contradiction!(self.ptrs.len() == 1, {
-                assert(old(self).wf_perm(self.ptrs.len() - 2));
-                #[spec] let actual_penult_u64 = self.prev_of(self.ptrs.len() - 1);
-                assert_bit_vector(actual_penult_u64 ^ 0 == actual_penult_u64);
-            });
+            proof {
+                assert_by_contradiction!(self.ptrs@.len() == 1, {
+                    assert(old(self).wf_perm((self.ptrs@.len() - 2) as nat));
+                    #[spec] let actual_penult_u64 = self.prev_of((self.ptrs@.len() - 1) as nat);
+                    assert_bit_vector(actual_penult_u64 ^ 0 == actual_penult_u64);
+                });
+            }
         } else {
             self.tail = penult_u64;
 
-            assert(old(self).view().len() != 1);
-            assert(old(self).view().len() >= 2);
-            assert(old(self).wf_perm(self.ptrs.len() - 2));
+            assert(old(self)@.len() != 1);
+            assert(old(self)@.len() >= 2);
+            assert(old(self).wf_perm((self.ptrs@.len() - 2) as nat));
 
-            #[spec] let actual_penult_u64 = self.prev_of(self.ptrs.len() - 1);
-            assert_bit_vector(actual_penult_u64 ^ 0 == actual_penult_u64);
+            proof {
+                let actual_penult_u64 = self.prev_of((self.ptrs@.len() - 1) as nat);
+                assert(actual_penult_u64 ^ 0 == actual_penult_u64) by(bit_vector);
 
-            lemma_usize_u64(penult_u64);
+                lemma_usize_u64(penult_u64);
+            }
             let penult_ptr = PPtr::<Node<V>>::from_usize(penult_u64 as usize);
-            #[proof] let penult_perm = self.perms.tracked_remove(self.ptrs.len() - 2);
-            let mut penult_perm = tracked_exec(penult_perm);
+            let mut penult_perm = tracked(
+                (tracked self.perms.borrow_mut()).tracked_remove((self.ptrs@.len() - 2) as nat)
+            );
             let mut penult_node = penult_ptr.take(&mut penult_perm);
-
-            #[spec] let t = self.prev_of(self.ptrs.len() - 2);
-            assert_bit_vector((t ^ last_u64) ^ last_u64 == t ^ 0);
+            let t: Ghost<u64> = ghost(self.prev_of((self.ptrs@.len() - 2) as nat));
+            assert((t@ ^ last_u64) ^ last_u64 == t@ ^ 0) by(bit_vector);
 
             penult_node.xored = penult_node.xored ^ last_u64;
 
-            assert(penult_node.xored == t ^ 0);
+            assert(penult_node.xored == t@ ^ 0);
 
             penult_ptr.put(&mut penult_perm, penult_node);
-            self.perms.tracked_insert(self.ptrs.len() - 2, tracked_get(penult_perm));
+            proof {
+                (tracked self.perms.borrow_mut())
+                    .tracked_insert((self.ptrs@.len() - 2) as nat, (tracked penult_perm).get());
+            }
         }
 
-        self.ptrs = self.ptrs.drop_last();
-
-        assert(self.wf_head());
-        assert(self.wf_tail());
-
-        if self.ptrs.len() > 0 {
-            /*#[spec] let i = self.ptrs.len() - 1;
-            assert(self.ptrs.len() == old(self).ptrs.len() - 1);
-            assert(self.perms.dom().contains(i));
-            assert(equal(self.perms.index(i).pptr, self.ptrs.index(i).view()));
-            assert(0 < self.ptrs.index(i).view());
-            assert(self.ptrs.index(i).view() < 0x10000000000000000);
-            assert(self.perms.index(i).value.is_Some());
-            assert(self.perms.index(i).value.get_Some_0().xored == (
-                self.prev_of(i) ^ self.next_of(i)
-            ));*/
-            assert(self.wf_perm(self.ptrs.len() - 1));
+        proof {
+            self.ptrs@ = self.ptrs@.drop_last();
         }
 
-        assert(forall(|i| 0 <= i && i < self.view().len() >>=
-            old(self).wf_perm(i) >>= self.wf_perm(i)));
-        assert(self.wf_perms());
+        proof {
+            assert(self.wf_head());
+            assert(self.wf_tail());
 
-        assert_forall_by(|i: int| {
-            requires(0 <= i && i < self.view().len());
-            ensures(equal(
-                self.view().index(i),
-                old(self).view().drop_last().index(i),
-            ));
-            assert(old(self).wf_perm(i as nat)); // trigger
-        });
+            if self.ptrs@.len() > 0 {
+                /*#[spec] let i = self.ptrs@.len() - 1;
+                assert(self.ptrs@.len() == old(self).ptrs@.len() - 1);
+                assert(self.perms@.dom().contains(i));
+                assert(self.perms@[i].pptr === self.ptrs@[i]@);
+                assert(0 < self.ptrs@[i]@);
+                assert(self.ptrs@[i]@ < 0x10000000000000000);
+                assert(self.perms@[i].value.is_Some());
+                assert(self.perms@[i].value.get_Some_0().xored == (
+                    self.prev_of(i) ^ self.next_of(i)
+                ));*/
+                assert(self.wf_perm((self.ptrs@.len() - 1) as nat));
+            }
 
-        assert(self.view().ext_equal(old(self).view().drop_last()));
+            assert(forall|i: nat| i < self@.len() ==>
+                old(self).wf_perm(i) ==> self.wf_perm(i));
+            assert(self.wf_perms());
+
+            assert forall|i: int|
+                0 <= i < self@.len() implies
+                #[trigger] self@[i] === old(self)@.drop_last()[i] by
+            {
+                assert(old(self).wf_perm(i as nat)); // trigger
+            }
+
+            assert(self@.ext_equal(old(self)@.drop_last()));
+        }
 
         v
     }
@@ -361,3 +361,5 @@ fn main() {
     assert(x == 7);
     assert(y == 5);
 }
+
+} // verus!

--- a/source/rust_verify/example/external.rs
+++ b/source/rust_verify/example/external.rs
@@ -7,7 +7,7 @@ verus! {
 #[verifier(external_body)]
 fn test(n: u64, s: Ghost<int>)
     requires
-        n > 10 && s >= n,
+        n > 10 && s@ >= n,
 {
     println!("hello {}", n);
 }

--- a/source/rust_verify/example/state_machines/rc.rs
+++ b/source/rust_verify/example/state_machines/rc.rs
@@ -278,10 +278,10 @@ impl<S> MyRc<S> {
 
         #[proof] let (inst, mut rc_token, _) = RefCounter::Instance::initialize_empty(Option::None);
         
-        #[proof] let ptr_perm = tracked_get(ptr_perm);
+        #[proof] let ptr_perm = ptr_perm.get();
         #[proof] let reader = inst.do_deposit(ptr_perm, &mut rc_token, ptr_perm);
 
-        #[proof] let g = GhostStuff::<S> { rc_perm: tracked_get(rc_perm), rc_token };
+        #[proof] let g = GhostStuff::<S> { rc_perm: rc_perm.get(), rc_token };
 
         #[proof] let inv = LocalInvariant::new(g,
             |g: GhostStuff<S>|
@@ -328,7 +328,7 @@ impl<S> MyRc<S> {
                 &mut rc_token,
                 &self.reader);
                 
-            g = GhostStuff { rc_perm: tracked_get(rc_perm), rc_token };
+            g = GhostStuff { rc_perm: rc_perm.get(), rc_token };
         });
 
         MyRc {
@@ -380,7 +380,7 @@ impl<S> MyRc<S> {
                 ptr.dispose(inner_rc_perm);
             }
 
-            g = GhostStuff { rc_perm: tracked_get(rc_perm), rc_token };
+            g = GhostStuff { rc_perm: rc_perm.get(), rc_token };
         });
     }
 }

--- a/source/rust_verify/example/state_machines/tutorial/fifo.rs
+++ b/source/rust_verify/example/state_machines/tutorial/fifo.rs
@@ -576,7 +576,7 @@ pub fn new_queue<T>(len: usize) -> (Producer<T>, Consumer<T>) {
         let (cell, cell_perm) = PCell::empty();
         backing_cells_vec.push(cell);
 
-        perms.tracked_insert(i, tracked_get(cell_perm));
+        perms.tracked_insert(i, cell_perm.get());
     }
 
     // Vector for ids
@@ -672,7 +672,7 @@ impl<T> Producer<T> {
                 // from uninitialized to initialized (to the value t).
                 let mut cell_perm = tracked_exec(cell_perm);
                 queue.buffer.index(self.tail).put(&mut cell_perm, t);
-                #[proof] let cell_perm = tracked_get(cell_perm);
+                #[proof] let cell_perm = cell_perm.get();
 
                 // Store the updated tail to the shared `tail` atomic,
                 // while performing the `produce_end` transition.
@@ -726,7 +726,7 @@ impl<T> Consumer<T> {
                 };
                 let mut cell_perm = tracked_exec(cell_perm);
                 let t = queue.buffer.index(self.head).take(&mut cell_perm);
-                #[proof] let cell_perm = tracked_get(cell_perm);
+                #[proof] let cell_perm = cell_perm.get();
 
                 atomic_with_ghost!(&queue.head => store(next_head as u64); ghost head_token => {
                     queue.instance.consume_end(cell_perm,

--- a/source/rust_verify/example/state_machines/tutorial/pcell_example.rs
+++ b/source/rust_verify/example/state_machines/tutorial/pcell_example.rs
@@ -16,7 +16,7 @@ fn main() {
 
     // Initially, cell is unitialized, and the `perm` token
     // represents that as the value `None`.
-    assert((*perm).value === Option::None);
+    assert(perm@.value === Option::None);
 
     // We can write a value to the pcell (thus initializing it).
     // This only requires an `&` reference to the PCell, but it does
@@ -24,14 +24,14 @@ fn main() {
     pcell.put(&mut perm, 5); 
 
     // Having written the value, this is reflected in the token:
-    assert((*perm).value === Option::Some(5));
+    assert(perm@.value === Option::Some(5));
 
     // We can take the value back out:
     let x = pcell.take(&mut perm); 
 
     // Which leaves it uninitialized again:
     assert(x == 5);
-    assert((*perm).value === Option::None);
+    assert(perm@.value === Option::None);
 }
 // ANCHOR_END: example
 

--- a/source/rust_verify/example/state_machines/tutorial/unverified_fifo.rs
+++ b/source/rust_verify/example/state_machines/tutorial/unverified_fifo.rs
@@ -73,7 +73,7 @@ impl<T> Producer<T> {
             if head != next_tail as u64 {
                 // Here's the unsafe part: writing the given `t` value into the `UnsafeCell`.
                 unsafe {
-                    (*tracked_get(self.queue.buffer[self.tail])).write(t);
+                    (*self.queue.buffer[self.tail].get()).write(t);
                 }
 
                 // Update the `tail` (both the shared atomic and our local copy).
@@ -108,7 +108,7 @@ impl<T> Consumer<T> {
                 // (replacing it with "uninitialized" memory).
                 let t = unsafe {
                     let mut tmp = MaybeUninit::uninit();
-                    std::mem::swap(&mut *tracked_get(self.queue.buffer[self.head]), &mut tmp);
+                    std::mem::swap(&mut *self.queue.buffer[self.head].get(), &mut tmp);
                     tmp.assume_init()
                 };
 

--- a/source/rust_verify/example/vectors.rs
+++ b/source/rust_verify/example/vectors.rs
@@ -33,7 +33,7 @@ fn binary_search(v: &Vec<u64>, k: u64) -> (r: usize)
             i2 = ix;
         }
 
-        assert(i2 - i1 < *d);
+        assert(i2 - i1 < d@);
     }
     i1
 }
@@ -49,9 +49,9 @@ fn reverse(v: &mut Vec<u64>)
     while n < length / 2
         invariant
             length == v.len(),
-            forall|i: int| 0 <= i < n ==> v[i] == v1[length - i - 1],
-            forall|i: int| 0 <= i < n ==> v1[i] == v[length - i - 1],
-            forall|i: int| n <= i && i + n < length ==> #[trigger] v[i] == v1[i],
+            forall|i: int| 0 <= i < n ==> v[i] == v1@[length - i - 1],
+            forall|i: int| 0 <= i < n ==> v1@[i] == v[length - i - 1],
+            forall|i: int| n <= i && i + n < length ==> #[trigger] v[i] == v1@[i],
     {
         let x = *v.index(n);
         let y = *v.index(length - 1 - n);
@@ -70,12 +70,12 @@ fn pusher() -> Vec<u64> {
     v.push(3);
     v.push(4);
     let goal: Ghost<Seq<u64>> = ghost(Seq::new(5, |i: int| i as u64));
-    assert(v@.ext_equal(*goal));
+    assert(v@.ext_equal(goal@));
     assert(v[2] == 2);
 
     v.pop();
     v.push(4);
-    assert(v@.ext_equal(*goal));
+    assert(v@.ext_equal(goal@));
 
     v
 }

--- a/source/rust_verify/src/rust_to_vir_base.rs
+++ b/source/rust_verify/src/rust_to_vir_base.rs
@@ -17,7 +17,7 @@ use rustc_span::symbol::{kw, Ident};
 use rustc_span::Span;
 use rustc_trait_selection::infer::InferCtxtExt;
 use std::sync::Arc;
-use vir::ast::{GenericBoundX, IntRange, Mode, Path, PathX, Typ, TypBounds, TypX, Typs, VirErr};
+use vir::ast::{GenericBoundX, IntRange, Path, PathX, Typ, TypBounds, TypX, Typs, VirErr};
 use vir::ast_util::types_equal;
 
 pub(crate) fn def_path_to_vir_path<'tcx>(tcx: TyCtxt<'tcx>, def_path: DefPath) -> Path {
@@ -244,25 +244,6 @@ pub(crate) fn mid_ty_simplify<'tcx>(
             }
         }
         _ => ty,
-    }
-}
-
-pub(crate) fn mid_ty_to_mode<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    ty: rustc_middle::ty::Ty<'tcx>,
-) -> Option<Mode> {
-    match ty.kind() {
-        TyKind::Adt(AdtDef { did, .. }, _args) => {
-            let def_name = vir::ast_util::path_as_rust_name(&def_id_to_vir_path(tcx, *did));
-            if def_name == "builtin::Ghost" {
-                Some(Mode::Spec)
-            } else if def_name == "builtin::Tracked" {
-                Some(Mode::Proof)
-            } else {
-                None
-            }
-        }
-        _ => None,
     }
 }
 

--- a/source/rust_verify/tests/adts.rs
+++ b/source/rust_verify/tests/adts.rs
@@ -485,7 +485,7 @@ test_verify_one_file! {
 
             let s1 = S { a: 10, b: ghost(20) };
             let s2 = s1;
-            assert(*s1.b == *s2.b);
+            assert(s1.b@ == s2.b@);
             let b = s1.equals(&s2); assert(b);
             (s1, s2)
         }

--- a/source/rust_verify/tests/basic.rs
+++ b/source/rust_verify/tests/basic.rs
@@ -217,13 +217,17 @@ test_verify_one_file! {
             assert(y == z);
             assert((x == 1) == !a);
         }
+    } => Ok(())
+}
 
+test_verify_one_file! {
+    #[test] test_short_circuit1 code! {
         fn f3(a: bool, b: bool) {
-            let mut x: Ghost<u64> = ghost(0);
-            let y: Ghost<bool> = ghost(a ==> b);
-            let z: Ghost<bool> = ghost(a ==> { x = Ghost::new((*x + 1) as u64); b });
-            assert(*y == *z);
-            assert((*x == 1) == a);
+            #[spec] let mut x: u64 = 0;
+            #[spec] let y: bool = imply(a, b);
+            #[spec] let z: bool = imply(a, { x = x + 1; b });
+            assert(y == z);
+            assert((x == 1) == a);
         }
     } => Ok(())
 }

--- a/source/rust_verify/tests/cell_lib.rs
+++ b/source/rust_verify/tests/cell_lib.rs
@@ -23,24 +23,24 @@ fn test_body(tests: &str, contradiction_smoke_test: bool) -> String {
 
 const CELL_TEST: &str = code_str! {
     let (cell, mut token) = PCell::<u32>::empty();
-    assert(equal((*token).pcell, cell.id()));
-    assert(equal((*token).value, option::Option::None));
+    assert(equal(token.view().pcell, cell.id()));
+    assert(equal(token.view().value, option::Option::None));
 
     cell.put(&mut token, 5);
-    assert(equal((*token).pcell, cell.id()));
-    assert(equal((*token).value, option::Option::Some(5)));
+    assert(equal(token.view().pcell, cell.id()));
+    assert(equal(token.view().value, option::Option::Some(5)));
 
     let x = cell.replace(&mut token, 7);
-    assert(equal((*token).pcell, cell.id()));
-    assert(equal((*token).value, option::Option::Some(7)));
+    assert(equal(token.view().pcell, cell.id()));
+    assert(equal(token.view().value, option::Option::Some(7)));
     assert(equal(x, 5));
 
     let t = cell.borrow(&token);
     assert(equal(*t, 7));
 
     let x = cell.take(&mut token);
-    assert(equal((*token).pcell, cell.id()));
-    assert(equal((*token).value, option::Option::None));
+    assert(equal(token.view().pcell, cell.id()));
+    assert(equal(token.view().value, option::Option::None));
     assert(equal(x, 7));
 };
 
@@ -54,24 +54,24 @@ test_verify_one_file! {
 
 const PTR_TEST: &str = code_str! {
     let (ptr, mut token) = PPtr::<u32>::empty();
-    assert(equal((*token).pptr, ptr.id()));
-    assert(equal((*token).value, option::Option::None));
+    assert(equal(token.view().pptr, ptr.id()));
+    assert(equal(token.view().value, option::Option::None));
 
     ptr.put(&mut token, 5);
-    assert(equal((*token).pptr, ptr.id()));
-    assert(equal((*token).value, option::Option::Some(5)));
+    assert(equal(token.view().pptr, ptr.id()));
+    assert(equal(token.view().value, option::Option::Some(5)));
 
     let x = ptr.replace(&mut token, 7);
-    assert(equal((*token).pptr, ptr.id()));
-    assert(equal((*token).value, option::Option::Some(7)));
+    assert(equal(token.view().pptr, ptr.id()));
+    assert(equal(token.view().value, option::Option::Some(7)));
     assert(equal(x, 5));
 
     let t = ptr.borrow(&token);
     assert(equal(*t, 7));
 
     let x = ptr.take(&mut token);
-    assert(equal((*token).pptr, ptr.id()));
-    assert(equal((*token).value, option::Option::None));
+    assert(equal(token.view().pptr, ptr.id()));
+    assert(equal(token.view().value, option::Option::None));
     assert(equal(x, 7));
 
     ptr.dispose(token);

--- a/source/rust_verify/tests/loops.rs
+++ b/source/rust_verify/tests/loops.rs
@@ -265,9 +265,11 @@ test_verify_one_file! {
         fn test() {
             let mut a: Ghost<int> = ghost(5);
             loop
-                invariant *a > 0
+                invariant a@ > 0
             {
-                a = ghost(*a + 1);
+                proof {
+                    a@ = a@ + 1;
+                }
             }
         }
     } => Ok(())

--- a/source/rust_verify/tests/summer_school.rs
+++ b/source/rust_verify/tests/summer_school.rs
@@ -1025,7 +1025,7 @@ test_verify_one_file! {
                         assert(view_u64(haystack.view())[mid as int] <= view_u64(haystack.view())[i]);
                     }
                 }
-                assert(high - low < *decreases); // Termination check
+                assert(high - low < decreases@); // Termination check
             }
             low
         }

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -106,6 +106,14 @@ pub enum TriggerAnnotation {
     Trigger(Option<u64>),
 }
 
+/// Operations on Ghost and Tracked
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ModeCoercion {
+    DerefMut,
+    BorrowMut,
+    Other,
+}
+
 /// Primitive unary operations
 /// (not arbitrary user-defined functions -- these are represented by ExprX::Call)
 #[derive(Copy, Clone, Debug)]
@@ -120,7 +128,7 @@ pub enum UnaryOp {
     /// Force integer value into range given by IntRange (e.g. by using mod)
     Clip(IntRange),
     /// Operations that coerce from/to builtin::Ghost or builtin::Tracked
-    CoerceMode { op_mode: Mode, from_mode: Mode, to_mode: Mode },
+    CoerceMode { op_mode: Mode, from_mode: Mode, to_mode: Mode, kind: ModeCoercion },
     /// Internal consistency check to make sure finalize_exp gets called
     /// (appears only briefly in SST before finalize_exp is called)
     MustBeFinalized,
@@ -391,8 +399,7 @@ pub enum ExprX {
     WithTriggers { triggers: Arc<Vec<Exprs>>, body: Expr },
     /// Assign to local variable
     /// init_not_mut = true ==> a delayed initialization of a non-mutable variable
-    /// lhs_type_mode = Some(mode) ==> assignment to Ghost<t> or Tracked<t>
-    Assign { init_not_mut: bool, lhs_type_mode: Option<Mode>, lhs: Expr, rhs: Expr },
+    Assign { init_not_mut: bool, lhs: Expr, rhs: Expr },
     /// Reveal definition of an opaque function with some integer fuel amount
     Fuel(Fun, u32),
     /// Header, which must appear at the beginning of a function or while loop.

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -109,8 +109,11 @@ pub enum TriggerAnnotation {
 /// Operations on Ghost and Tracked
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ModeCoercion {
-    DerefMut,
+    /// Mutable borrows (Ghost::borrow_mut and Tracked::borrow_mut) are treated specially by
+    /// the mode checker when checking assignments.
     BorrowMut,
+    /// All other cases are treated uniformly by the mode checker based on their op/from/to-mode.
+    /// (This includes Ghost::borrow, Tracked::get, etc.)
     Other,
 }
 

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -796,7 +796,7 @@ fn expr_to_stm_opt(
             let e0 = unwrap_or_return_never!(e0, stms);
             Ok((stms, ReturnValue::Some(mk_exp(ExpX::Loc(e0)))))
         }
-        ExprX::Assign { init_not_mut, lhs_type_mode: _, lhs: lhs_expr, rhs: expr2 } => {
+        ExprX::Assign { init_not_mut, lhs: lhs_expr, rhs: expr2 } => {
             let (mut stms, lhs_exp) = expr_to_stm_opt(ctx, state, lhs_expr)?;
             let lhs_exp = lhs_exp.expect_value();
             match expr_must_be_call_stm(ctx, state, expr2)? {

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -250,7 +250,7 @@ where
                     }
                     expr_visitor_control_flow!(expr_visitor_dfs(body, map, mf));
                 }
-                ExprX::Assign { init_not_mut: _, lhs_type_mode: _, lhs: e1, rhs: e2 } => {
+                ExprX::Assign { init_not_mut: _, lhs: e1, rhs: e2 } => {
                     expr_visitor_control_flow!(expr_visitor_dfs(e1, map, mf));
                     expr_visitor_control_flow!(expr_visitor_dfs(e2, map, mf));
                 }
@@ -577,12 +577,10 @@ where
             let body = map_expr_visitor_env(body, map, env, fe, fs, ft)?;
             ExprX::WithTriggers { triggers, body }
         }
-        ExprX::Assign { init_not_mut, lhs_type_mode, lhs: e1, rhs: e2 } => {
+        ExprX::Assign { init_not_mut, lhs: e1, rhs: e2 } => {
             let expr1 = map_expr_visitor_env(e1, map, env, fe, fs, ft)?;
             let expr2 = map_expr_visitor_env(e2, map, env, fe, fs, ft)?;
-            let init_not_mut = *init_not_mut;
-            let lhs_type_mode = *lhs_type_mode;
-            ExprX::Assign { init_not_mut, lhs_type_mode, lhs: expr1, rhs: expr2 }
+            ExprX::Assign { init_not_mut: *init_not_mut, lhs: expr1, rhs: expr2 }
         }
         ExprX::Fuel(path, fuel) => ExprX::Fuel(path.clone(), *fuel),
         ExprX::Header(_) => {

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -267,12 +267,7 @@ fn get_var_loc_mode(
             x_mode
         }
         ExprX::Unary(
-            UnaryOp::CoerceMode {
-                op_mode,
-                from_mode,
-                to_mode,
-                kind: ModeCoercion::BorrowMut,
-            },
+            UnaryOp::CoerceMode { op_mode, from_mode, to_mode, kind: ModeCoercion::BorrowMut },
             e1,
         ) => {
             assert!(!init_not_mut);

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -271,7 +271,7 @@ fn get_var_loc_mode(
                 op_mode,
                 from_mode,
                 to_mode,
-                kind: ModeCoercion::DerefMut | ModeCoercion::BorrowMut,
+                kind: ModeCoercion::BorrowMut,
             },
             e1,
         ) => {

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -411,16 +411,14 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
             let body = poly_expr(ctx, state, body);
             mk_expr(ExprX::WithTriggers { triggers, body })
         }
-        ExprX::Assign { init_not_mut, lhs_type_mode, lhs: e1, rhs: e2 } => {
+        ExprX::Assign { init_not_mut, lhs: e1, rhs: e2 } => {
             let e1 = poly_expr(ctx, state, e1);
             let e2 = if typ_is_poly(ctx, &e1.typ) {
                 coerce_expr_to_poly(ctx, &poly_expr(ctx, state, e2))
             } else {
                 coerce_expr_to_native(ctx, &poly_expr(ctx, state, e2))
             };
-            let init_not_mut = *init_not_mut;
-            let lhs_type_mode = *lhs_type_mode;
-            mk_expr(ExprX::Assign { init_not_mut, lhs_type_mode, lhs: e1, rhs: e2 })
+            mk_expr(ExprX::Assign { init_not_mut: *init_not_mut, lhs: e1, rhs: e2 })
         }
         ExprX::AssertBV(e) => mk_expr(ExprX::AssertBV(poly_expr(ctx, state, e))),
         ExprX::Fuel(..) => expr.clone(),

--- a/source/vir/src/printer.rs
+++ b/source/vir/src/printer.rs
@@ -231,8 +231,13 @@ fn expr_to_node(expr: &Expr) -> Node {
                     nodes
                 }
                 UnaryOp::Clip(range) => nodes_vec!(clip {int_range_to_node(range)}),
-                UnaryOp::CoerceMode { op_mode, from_mode, to_mode } => {
-                    nodes_vec!(coerce_mode {str_to_node(&format!("{op_mode}"))} {str_to_node(&format!("{from_mode}"))} {str_to_node(&format!("{to_mode}"))})
+                UnaryOp::CoerceMode { op_mode, from_mode, to_mode, kind } => {
+                    nodes_vec!(coerce_mode
+                        {str_to_node(&format!("{op_mode}"))}
+                        {str_to_node(&format!("{from_mode}"))}
+                        {str_to_node(&format!("{to_mode}"))}
+                        {str_to_node(&format!("{:?}", kind))}
+                    )
                 }
                 UnaryOp::MustBeFinalized => nodes_vec!(MustBeFinalized),
             };
@@ -292,13 +297,10 @@ fn expr_to_node(expr: &Expr) -> Node {
             let ts = Node::List(triggers.iter().map(exprs_to_node).collect());
             nodes!(with_triggers {ts} {expr_to_node(body)})
         }
-        ExprX::Assign { init_not_mut, lhs_type_mode, lhs: e0, rhs: e1 } => {
+        ExprX::Assign { init_not_mut, lhs: e0, rhs: e1 } => {
             let mut nodes = nodes_vec!(assign);
             if *init_not_mut {
                 nodes.push(str_to_node(":init_not_mut"));
-            }
-            if let Some(mode) = lhs_type_mode {
-                nodes.push(str_to_node(&format!("{:?}", mode)));
             }
             nodes.push(expr_to_node(e0));
             nodes.push(expr_to_node(e1));

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -1,6 +1,6 @@
 use crate::ast::{
     CallTarget, Datatype, Expr, ExprX, FieldOpr, Fun, FunX, Function, FunctionKind, Krate,
-    MaskSpec, Mode, MultiOp, Path, PathX, TypX, UnaryOpr, VirErr,
+    MaskSpec, Mode, MultiOp, Path, PathX, TypX, UnaryOp, UnaryOpr, VirErr,
 };
 use crate::ast_util::{err_str, err_string, error, path_as_rust_name, referenced_vars_expr};
 use crate::datatype_to_air::is_datatype_transparent;
@@ -74,7 +74,10 @@ fn check_one_expr(
                 fn is_ok(e: &Expr) -> bool {
                     match &e.x {
                         ExprX::VarLoc(_) => true,
+                        ExprX::Unary(UnaryOp::CoerceMode { .. }, e1) => is_ok(e1),
                         ExprX::UnaryOpr(UnaryOpr::Field { .. }, base) => is_ok(base),
+                        ExprX::Block(stmts, Some(e1)) if stmts.len() == 0 => is_ok(e1),
+                        ExprX::Ghost { alloc_wrapper: None, tracked: true, expr: e1 } => is_ok(e1),
                         _ => false,
                     }
                 }


### PR DESCRIPTION
This PR revamps the operations on the `Ghost` and `Tracked` wrapper types.  For example, where we used to write:

```
    let u: Ghost<int> = ghost(my_spec_fun(x as int, y as int));
    let mut v: Ghost<int> = ghost(*u + 1);
    assert(*v == x + y + 1);
    proof {
        v = Ghost::new(*v + 1); // proof code may assign to exec variables of type Ghost/Tracked
    }
```

we now write:

```
    let u: Ghost<int> = ghost(my_spec_fun(x as int, y as int));
    let mut v: Ghost<int> = ghost(u@ + 1);
    assert(v@ == x + y + 1);
    proof {
        v@ = v@ + 1; // proof code may assign to the view of exec variables of type Ghost/Tracked
    }
```

Previously, we relied on `Deref` for `Ghost` and `Tracked`, which could become problematic as we improve support for traits, since `Ghost` and `Tracked` didn't provide an exec implementation of `deref`, but rather just `unimplemented!()`.  Now we use `view` instead of `deref`, since `view` is a `spec` method rather than an `exec` method.  (Introducing a `spec_deref` spec method did not seem helpful, since our syntax macro doesn't have a good way to decide which `*` would be `deref`, as with `&` types, or `spec_deref`, as with `Ghost` and `Tracked`.)

This PR also adds `borrow` and `borrow_mut` methods for `Ghost` and `Tracked`.  As syntactic sugar, when you write `v@` on the  left side of an assignment, it gets desugared to `*(v.borrow_mut())` rather than `v.view()`.  This allows programmers to write things like `v@ = v@ + 1`, which seems more natural than the previous `v = Ghost::new(*v + 1)`.  You can also access fields this way (e.g. `v@.field = v@.field + 1`).

In the translation to VIR,  `Ghost<T>` and `Tracked<T>` are erased to `T`, and operations on them are erased to no-ops, so that `*(v.borrow_mut()) = v.view() + 1` simply becomes `v = v + 1`, leading to efficient SMT encodings.
