### PR TITLE
Allow extern static and GlobalAsm without verification support

### DIFF
--- a/source/rust_verify/src/erase.rs
+++ b/source/rust_verify/src/erase.rs
@@ -1282,6 +1282,7 @@ fn erase_item(ctxt: &Ctxt, mctxt: &mut MCtxt, item: &Item) -> Vec<P<Item>> {
         ItemKind::MacroDef(..) => item.kind.clone(),
         ItemKind::TyAlias(..) => item.kind.clone(),
         ItemKind::Trait(tr) => ItemKind::Trait(erase_trait(ctxt, mctxt, tr)),
+        ItemKind::GlobalAsm(..) => item.kind.clone(),
         _ => {
             unsupported!("unsupported item", item)
         }

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -425,6 +425,11 @@ fn check_item<'tcx>(
             // type alias (like lines of the form `type X = ...;`
             // Nothing to do here - we can rely on Rust's type resolution to handle these
         }
+        ItemKind::GlobalAsm(..) =>
+        //if get_verifier_attrs(ctxt.tcx.hir().attrs(item.hir_id()))?.external =>
+        {
+            return Ok(());
+        }
         _ => {
             unsupported_err!(item.span, "unsupported item", item);
         }

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -426,7 +426,7 @@ fn check_item<'tcx>(
             // Nothing to do here - we can rely on Rust's type resolution to handle these
         }
         ItemKind::GlobalAsm(..) =>
-        //if get_verifier_attrs(ctxt.tcx.hir().attrs(item.hir_id()))?.external =>
+        //TODO(utaal): add a crate-level attribute to enable global_asm
         {
             return Ok(());
         }

--- a/source/rust_verify/src/rust_to_vir.rs
+++ b/source/rust_verify/src/rust_to_vir.rs
@@ -452,8 +452,13 @@ fn check_foreign_item<'tcx>(
                 generics,
             )?;
         }
+        ForeignItemKind::Static(..)
+            if get_verifier_attrs(ctxt.tcx.hir().attrs(item.hir_id()))?.external =>
+        {
+            return Ok(());
+        }
         _ => {
-            unsupported_err!(item.span, "unsupported item", item);
+            unsupported_err!(item.span, "unsupported foreign item", item);
         }
     }
     Ok(())


### PR DESCRIPTION
Those features are important for writing bare-metal code in rust

```
global_asm!(
    "..."
);

extern "C" {
    #[verifier(external)]
    static extern_variable: u64;
}
```
NOTE: Rust compiler will throw away attribute for the builtin macro global_asm