### PR TITLE
Add recommends checks for casts

### DIFF
--- a/source/rust_verify/src/attributes.rs
+++ b/source/rust_verify/src/attributes.rs
@@ -167,6 +167,8 @@ pub(crate) enum Attr {
     IntegerRing,
     // Use a new dedicated Z3 process just for this query
     SpinoffProver,
+    // Suppress the recommends check for narrowing casts that may truncate
+    Truncate,
 }
 
 fn get_trigger_arg(span: Span, attr_tree: &AttrTree) -> Result<u64, VirErr> {
@@ -333,6 +335,9 @@ pub(crate) fn parse_attrs(attrs: &[Attribute]) -> Result<Vec<Attr>, VirErr> {
                 Some(box [AttrTree::Fun(_, arg, None)]) if arg == "spinoff_prover" => {
                     v.push(Attr::SpinoffProver)
                 }
+                Some(box [AttrTree::Fun(_, arg, None)]) if arg == "truncate" => {
+                    v.push(Attr::Truncate)
+                }
                 _ => return err_span_str(*span, "unrecognized verifier attribute"),
             },
             _ => {}
@@ -441,6 +446,7 @@ pub(crate) struct VerifierAttrs {
     pub(crate) check_recommends: bool,
     pub(crate) nonlinear: bool,
     pub(crate) spinoff_prover: bool,
+    pub(crate) truncate: bool,
 }
 
 pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, VirErr> {
@@ -469,6 +475,7 @@ pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, V
         check_recommends: false,
         nonlinear: false,
         spinoff_prover: false,
+        truncate: false,
     };
     for attr in parse_attrs(attrs)? {
         match attr {
@@ -498,6 +505,7 @@ pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, V
             Attr::CheckRecommends => vs.check_recommends = true,
             Attr::NonLinear => vs.nonlinear = true,
             Attr::SpinoffProver => vs.spinoff_prover = true,
+            Attr::Truncate => vs.truncate = true,
             _ => {}
         }
     }

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -137,7 +137,7 @@ pub enum UnaryOp {
     /// Each trigger group becomes one SMT trigger containing all the expressions in the trigger group.
     Trigger(TriggerAnnotation),
     /// Force integer value into range given by IntRange (e.g. by using mod)
-    Clip(IntRange),
+    Clip { range: IntRange, truncate: bool },
     /// Operations that coerce from/to builtin::Ghost or builtin::Tracked
     CoerceMode { op_mode: Mode, from_mode: Mode, to_mode: Mode, kind: ModeCoercion },
     /// Internal consistency check to make sure finalize_exp gets called

--- a/source/vir/src/ast_simplify.rs
+++ b/source/vir/src/ast_simplify.rs
@@ -54,7 +54,7 @@ struct LocalCtxt {
 fn is_small_expr(expr: &Expr) -> bool {
     match &expr.x {
         ExprX::Const(_) | ExprX::Var(_) | ExprX::VarAt(..) => true,
-        ExprX::Unary(UnaryOp::Not | UnaryOp::Clip(_), e) => is_small_expr(e),
+        ExprX::Unary(UnaryOp::Not | UnaryOp::Clip { .. }, e) => is_small_expr(e),
         ExprX::UnaryOpr(UnaryOpr::Box(_) | UnaryOpr::Unbox(_), e) => is_small_expr(e),
         ExprX::Loc(_) => panic!("expr is a location"),
         _ => false,

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1018,7 +1018,7 @@ fn expr_to_stm_opt(
                 let has_type = ExpX::UnaryOpr(unary, exp.clone());
                 let has_type = SpannedTyped::new(&expr.span, &Arc::new(TypX::Bool), has_type);
                 let error = air::errors::error(
-                    "recommendation not met: value may be out of range of the target type",
+                    "recommendation not met: value may be out of range of the target type (use `#[verifier(truncate)]` on the cast to silence this warning)",
                     &expr.span,
                 );
                 let assert = StmX::Assert(Some(error), has_type);

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -667,7 +667,7 @@ fn is_small_exp(exp: &Exp) -> bool {
         ExpX::Const(_) => true,
         ExpX::Var(..) | ExpX::VarAt(..) => true,
         ExpX::Old(..) => true,
-        ExpX::Unary(UnaryOp::Not | UnaryOp::Clip(_), e) => is_small_exp_or_loc(e),
+        ExpX::Unary(UnaryOp::Not | UnaryOp::Clip { .. }, e) => is_small_exp_or_loc(e),
         ExpX::UnaryOpr(UnaryOpr::Box(_) | UnaryOpr::Unbox(_), e) => is_small_exp_or_loc(e),
         _ => false,
     }
@@ -1011,7 +1011,9 @@ fn expr_to_stm_opt(
         ExprX::Unary(op, exprr) => {
             let (mut stms, exp) = expr_to_stm_opt(ctx, state, exprr)?;
             let exp = unwrap_or_return_never!(exp, stms);
-            if let (true, UnaryOp::Clip(_)) = (state.checking_recommends(ctx), op) {
+            if let (true, UnaryOp::Clip { truncate: false, .. }) =
+                (state.checking_recommends(ctx), op)
+            {
                 let unary = UnaryOpr::HasType(expr.typ.clone());
                 let has_type = ExpX::UnaryOpr(unary, exp.clone());
                 let has_type = SpannedTyped::new(&expr.span, &Arc::new(TypX::Bool), has_type);

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -300,7 +300,7 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
             let e1 = poly_expr(ctx, state, e1);
             match op {
                 UnaryOp::Not
-                | UnaryOp::Clip(_)
+                | UnaryOp::Clip { .. }
                 | UnaryOp::BitNot
                 | UnaryOp::StrLen
                 | UnaryOp::StrIsAscii => {

--- a/source/vir/src/printer.rs
+++ b/source/vir/src/printer.rs
@@ -240,7 +240,13 @@ fn expr_to_node(expr: &Expr) -> Node {
                     }
                     nodes
                 }
-                UnaryOp::Clip(range) => nodes_vec!(clip {int_range_to_node(range)}),
+                UnaryOp::Clip { range, truncate } => {
+                    let mut nodes = nodes_vec!(clip {int_range_to_node(range)});
+                    if *truncate {
+                        nodes.push(str_to_node("+truncate"));
+                    }
+                    nodes
+                }
                 UnaryOp::CoerceMode { op_mode, from_mode, to_mode, kind } => {
                     nodes_vec!(coerce_mode
                         {str_to_node(&format!("{op_mode}"))}

--- a/source/vir/src/triggers.rs
+++ b/source/vir/src/triggers.rs
@@ -54,7 +54,7 @@ fn check_trigger_expr(
     } else {
         match &exp.x {
             ExpX::Unary(UnaryOp::Trigger(_), _)
-            | ExpX::Unary(UnaryOp::Clip(_), _)
+            | ExpX::Unary(UnaryOp::Clip { .. }, _)
             | ExpX::Binary(BinaryOp::Arith(..), _, _) => {}
             _ => {
                 return err_str(
@@ -104,7 +104,7 @@ fn check_trigger_expr(
                 ExpX::Old(_, _) => panic!("internal error: Old"),
                 ExpX::Unary(op, _) => match op {
                     UnaryOp::Trigger(_)
-                    | UnaryOp::Clip(_)
+                    | UnaryOp::Clip { .. }
                     | UnaryOp::BitNot
                     | UnaryOp::StrLen
                     | UnaryOp::StrIsAscii => Ok(()),
@@ -162,7 +162,7 @@ fn check_trigger_expr(
                 ExpX::VarAt(_, VarAt::Pre) => true,
                 ExpX::Old(_, _) => panic!("internal error: Old"),
                 ExpX::Unary(op, _) => match op {
-                    UnaryOp::Trigger(_) | UnaryOp::Clip(_) | UnaryOp::CoerceMode { .. } => true,
+                    UnaryOp::Trigger(_) | UnaryOp::Clip { .. } | UnaryOp::CoerceMode { .. } => true,
                     UnaryOp::MustBeFinalized => true,
                     UnaryOp::Not | UnaryOp::BitNot | UnaryOp::StrLen | UnaryOp::StrIsAscii => false,
                 },

--- a/source/vir/src/triggers_auto.rs
+++ b/source/vir/src/triggers_auto.rs
@@ -306,7 +306,7 @@ fn gather_terms(ctxt: &mut Ctxt, ctx: &Ctx, exp: &Exp, depth: u64) -> (bool, Ter
         ExpX::Unary(op, e1) => {
             let depth = match op {
                 UnaryOp::Not | UnaryOp::CoerceMode { .. } | UnaryOp::MustBeFinalized => 0,
-                UnaryOp::Trigger(_) | UnaryOp::Clip(_) | UnaryOp::BitNot => 1,
+                UnaryOp::Trigger(_) | UnaryOp::Clip { .. } | UnaryOp::BitNot => 1,
                 UnaryOp::StrIsAscii | UnaryOp::StrLen => fail_on_strop(),
             };
             let (_, term1) = gather_terms(ctxt, ctx, e1, depth);


### PR DESCRIPTION
We _could_ only emit these for narrowing casts (by inspecting the types): do you think it's worth it?