### PR TITLE
Add support to spinoff the prover for assert by nonlinear z3 queries

### DIFF
--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -856,22 +856,26 @@ impl VisitMut for Visitor {
                     let span = assert.assert_token.span;
                     let arg = assert.expr;
                     let attrs = assert.attrs;
-                    match (assert.by_token, assert.prover, assert.body) {
+                    if match (assert.by_token, assert.prover, assert.body) {
                         (None, None, None) => {
                             *expr = parse_quote_spanned!(span => crate::pervasive::assert(#arg));
+                            true
                         }
                         (None, _, _) => panic!("missing by token"),
                         (Some(_), None, None) => panic!("extra by token"),
                         (Some(_), None, Some(box (None, block))) => {
                             *expr =
                                 parse_quote_spanned!(span => {::builtin::assert_by(#arg, #block);});
+                            true
                         }
                         (Some(_), Some((_, id)), None) if id.to_string() == "bit_vector" => {
                             *expr =
                                 parse_quote_spanned!(span => ::builtin::assert_bit_vector(#arg));
+                            true
                         }
                         (Some(_), Some((_, id)), None) if id.to_string() == "nonlinear_arith" => {
                             *expr = parse_quote_spanned!(span => ::builtin::assert_nonlinear_by({::builtin::ensures(#arg);}));
+                            true
                         }
                         (Some(_), Some((_, id)), Some(box (requires, mut block)))
                             if id.to_string() == "nonlinear_arith" =>
@@ -882,17 +886,23 @@ impl VisitMut for Visitor {
                             }
                             stmts.push(parse_quote_spanned!(span => ::builtin::ensures(#arg);));
                             block.stmts.splice(0..0, stmts);
-                            *expr = parse_quote_spanned!(span => {::builtin::assert_nonlinear_by(#block);});
+                            let mut assert_nonlinear_by: Expr = parse_quote_spanned!(span => ::builtin::assert_nonlinear_by(#block));
+                            assert_nonlinear_by.replace_attrs(attrs.clone());
+                            *expr = parse_quote_spanned!(span => {#assert_nonlinear_by});
+                            false
                         }
                         (Some(_), Some((_, id)), _) => {
                             let span = id.span();
                             *expr = parse_quote_spanned!(span => compile_error!("unsupported kind of assert-by"));
+                            true
                         }
                         _ => {
                             *expr = parse_quote_spanned!(span => compile_error!("unsupported kind of assert-by"));
+                            true
                         }
+                    } {
+                        expr.replace_attrs(attrs);
                     }
-                    expr.replace_attrs(attrs);
                 }
                 Expr::AssertForall(assert) => {
                     let span = assert.assert_token.span;

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -849,11 +849,15 @@ fn fn_call_to_vir<'tcx>(
         }
         let ensures = header.ensure;
         let proof = vir_expr;
+
+        let expr_attrs = bctx.ctxt.tcx.hir().attrs(expr.hir_id);
+        let expr_vattrs = get_verifier_attrs(expr_attrs)?;
         return Ok(mk_expr(ExprX::AssertQuery {
             requires,
             ensures,
             proof,
             mode: AssertQueryMode::NonLinear,
+            spinoff_prover: expr_vattrs.spinoff_prover,
         }));
     }
     if is_assert_forall_by {

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -424,7 +424,13 @@ pub enum ExprX {
     /// Sequence of statements, optionally including an expression at the end
     Block(Stmts, Option<Expr>),
     /// assert_by with smt.arith.nl=true
-    AssertQuery { requires: Exprs, ensures: Exprs, proof: Expr, mode: AssertQueryMode },
+    AssertQuery {
+        requires: Exprs,
+        ensures: Exprs,
+        proof: Expr,
+        mode: AssertQueryMode,
+        spinoff_prover: bool,
+    },
 }
 
 /// Statement, similar to rustc_hir::Stmt

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1179,7 +1179,7 @@ fn expr_to_stm_opt(
             stms.push(assume);
             Ok((stms, ReturnValue::ImplicitUnit(expr.span.clone())))
         }
-        ExprX::AssertQuery { requires, ensures, proof, mode } => {
+        ExprX::AssertQuery { requires, ensures, proof, mode, spinoff_prover } => {
             let mut inner_body: Vec<Stm> = Vec::new();
             let mut vars = BTreeMap::new(); // order vars by UniqueIdent
 
@@ -1253,6 +1253,7 @@ fn expr_to_stm_opt(
                     body: inner_body,
                     typ_inv_vars: Arc::new(vars.into_iter().collect()),
                     mode: *mode,
+                    spinoff_prover: *spinoff_prover,
                 },
             );
             Ok((vec![outer_block, nonlinear], ReturnValue::ImplicitUnit(expr.span.clone())))

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -272,7 +272,7 @@ where
                     expr_visitor_control_flow!(expr_visitor_dfs(proof, map, mf));
                     map.pop_scope();
                 }
-                ExprX::AssertQuery { requires, ensures, proof, mode: _ } => {
+                ExprX::AssertQuery { requires, ensures, proof, mode: _, spinoff_prover: _ } => {
                     for req in requires.iter() {
                         expr_visitor_control_flow!(expr_visitor_dfs(req, map, mf));
                     }
@@ -602,7 +602,7 @@ where
             map.pop_scope();
             ExprX::Forall { vars: Arc::new(vars), require, ensure, proof }
         }
-        ExprX::AssertQuery { requires, ensures, proof, mode } => {
+        ExprX::AssertQuery { requires, ensures, proof, mode, spinoff_prover } => {
             let requires = Arc::new(vec_map_result(requires, |e| {
                 map_expr_visitor_env(e, map, env, fe, fs, ft)
             })?);
@@ -610,7 +610,13 @@ where
                 map_expr_visitor_env(e, map, env, fe, fs, ft)
             })?);
             let proof = map_expr_visitor_env(proof, map, env, fe, fs, ft)?;
-            ExprX::AssertQuery { requires, ensures, proof, mode: *mode }
+            ExprX::AssertQuery {
+                requires,
+                ensures,
+                proof,
+                mode: *mode,
+                spinoff_prover: *spinoff_prover,
+            }
         }
         ExprX::AssertBV(e) => {
             let expr1 = map_expr_visitor_env(e, map, env, fe, fs, ft)?;

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -663,7 +663,7 @@ fn check_expr_handle_mut_arg(
             typing.in_forall_stmt = in_forall_stmt;
             Ok(Mode::Proof)
         }
-        ExprX::AssertQuery { requires, ensures, proof, mode: _ } => {
+        ExprX::AssertQuery { requires, ensures, proof, mode: _, spinoff_prover: _ } => {
             if typing.check_ghost_blocks && typing.block_ghostness == Ghost::Exec {
                 return err_str(&expr.span, "cannot use assert in exec mode");
             }

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -441,7 +441,7 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
             let vars = Arc::new(bs);
             mk_expr(ExprX::Forall { vars, require, ensure, proof })
         }
-        ExprX::AssertQuery { requires, ensures, proof, mode } => {
+        ExprX::AssertQuery { requires, ensures, proof, mode, spinoff_prover } => {
             state.types.push_scope(true);
             let requires =
                 requires.iter().map(|e| coerce_expr_to_native(ctx, &poly_expr(ctx, state, e)));
@@ -451,7 +451,13 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
             let ensures = Arc::new(ensures.collect());
             let proof = poly_expr(ctx, state, proof);
             state.types.pop_scope();
-            mk_expr(ExprX::AssertQuery { requires, ensures, proof, mode: *mode })
+            mk_expr(ExprX::AssertQuery {
+                requires,
+                ensures,
+                proof,
+                mode: *mode,
+                spinoff_prover: *spinoff_prover,
+            })
         }
         ExprX::If(e0, e1, None) => {
             let e0 = coerce_expr_to_native(ctx, &poly_expr(ctx, state, e0));

--- a/source/vir/src/printer.rs
+++ b/source/vir/src/printer.rs
@@ -312,8 +312,12 @@ fn expr_to_node(expr: &Expr) -> Node {
         ExprX::Forall { vars, require, ensure, proof } => {
             nodes!(forall {binders_node(vars, &typ_to_node)} {str_to_node(":require")} {expr_to_node(require)} {str_to_node(":ensure")} {expr_to_node(ensure)} {str_to_node(":proof")} {expr_to_node(proof)})
         }
-        ExprX::AssertQuery { requires, ensures, proof, mode } => {
-            nodes!(assertQuery {str_to_node(":requires")} {exprs_to_node(requires)} {str_to_node(":ensures")} {exprs_to_node(ensures)} {str_to_node(":proof")} {expr_to_node(proof)} {str_to_node(":mode")} {str_to_node(&format!("{:?}", mode))})
+        ExprX::AssertQuery { requires, ensures, proof, mode, spinoff_prover } => {
+            let mut nodes = nodes_vec!(assertQuery {str_to_node(":requires")} {exprs_to_node(requires)} {str_to_node(":ensures")} {exprs_to_node(ensures)} {str_to_node(":proof")} {expr_to_node(proof)} {str_to_node(":mode")} {str_to_node(&format!("{:?}", mode))});
+            if *spinoff_prover {
+                nodes.push(str_to_node("+spinoff_prover"));
+            }
+            Node::List(nodes)
         }
         ExprX::AssertBV(expr) => nodes!(assertbv {expr_to_node(expr)}),
         ExprX::If(e0, e1, e2) => {

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -118,6 +118,7 @@ pub enum StmX {
         mode: AssertQueryMode,
         typ_inv_vars: Arc<Vec<(UniqueIdent, Typ)>>,
         body: Stm,
+        spinoff_prover: bool,
     },
 }
 

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1283,7 +1283,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
             }
             vec![Arc::new(StmtX::Assert(error, air_expr))]
         }
-        StmX::AssertQuery { typ_inv_vars, body, mode } => {
+        StmX::AssertQuery { typ_inv_vars, body, mode, spinoff_prover } => {
             if ctx.debug {
                 unimplemented!("assert query is unsupported in debugger mode");
             }
@@ -1314,7 +1314,11 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
                             Arc::new(CommandX::CheckValid(query)),
                             mk_option_command("smt.arith.nl", "false"),
                         ]),
-                        ProverChoice::DefaultProver,
+                        if *spinoff_prover {
+                            ProverChoice::Spinoff
+                        } else {
+                            ProverChoice::DefaultProver
+                        },
                     ));
                 }
             }

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -162,7 +162,7 @@ where
                         expr_visitor_control_flow!(stm_visitor_dfs(rhs, f));
                     }
                 }
-                StmX::AssertQuery { body, mode: _, typ_inv_vars: _ } => {
+                StmX::AssertQuery { body, mode: _, typ_inv_vars: _, spinoff_prover: _ } => {
                     expr_visitor_control_flow!(stm_visitor_dfs(body, f));
                 }
                 StmX::While {
@@ -210,7 +210,7 @@ where
             StmX::AssertBV(exp) => {
                 expr_visitor_control_flow!(exp_visitor_dfs(exp, &mut ScopeMap::new(), f))
             }
-            StmX::AssertQuery { body: _, typ_inv_vars: _, mode: _ } => (),
+            StmX::AssertQuery { body: _, typ_inv_vars: _, mode: _, spinoff_prover: _ } => (),
             StmX::Assume(exp) => {
                 expr_visitor_control_flow!(exp_visitor_dfs(exp, &mut ScopeMap::new(), f))
             }
@@ -548,11 +548,16 @@ where
             );
             fe(&stm)
         }
-        StmX::AssertQuery { mode, typ_inv_vars, body } => {
+        StmX::AssertQuery { mode, typ_inv_vars, body, spinoff_prover } => {
             let body = map_stm_visitor(body, fe)?;
             let stm = Spanned::new(
                 stm.span.clone(),
-                StmX::AssertQuery { mode: *mode, typ_inv_vars: typ_inv_vars.clone(), body },
+                StmX::AssertQuery {
+                    mode: *mode,
+                    typ_inv_vars: typ_inv_vars.clone(),
+                    body,
+                    spinoff_prover: *spinoff_prover,
+                },
             );
             fe(&stm)
         }

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -155,7 +155,7 @@ fn check_one_expr(
         ExprX::OpenInvariant(_inv, _binder, body, _atomicity) => {
             assert_no_early_exit_in_inv_block(&body.span, body)?;
         }
-        ExprX::AssertQuery { requires, ensures, proof, mode: _ } => {
+        ExprX::AssertQuery { requires, ensures, proof, mode: _, spinoff_prover: _ } => {
             if function.x.attrs.nonlinear {
                 return err_str(
                     &expr.span,


### PR DESCRIPTION
This enables
```rust
#[verifier(spinoff_prover)] assert(expr) by (nonlinear_arith) { ... }
```

cc/ @Chris-Hawblitzel