### PR TITLE
Make termination checks for exec functions, add support for mutable references in parameters, and emit a warning that the check doesn't account for loops

### DIFF
--- a/source/rust_verify/example/recursion.rs
+++ b/source/rust_verify/example/recursion.rs
@@ -91,6 +91,16 @@ fn run_arith_sum(n: u64) -> u64 {
     result
 }
 
+fn exec_with_decreases(n: u64) -> u64
+    decreases 100 - n
+{
+    if n < 100 {
+        exec_with_decreases(n + 1)
+    } else {
+        n
+    }
+}
+
 #[verifier(external)]
 fn main() {
     let args = std::env::args();

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -2260,6 +2260,9 @@ pub(crate) fn expr_to_vir_inner<'tcx>(
             let cond = expr_to_vir(bctx, cond, ExprModifier::REGULAR)?;
             let mut body = expr_to_vir(bctx, body, ExprModifier::REGULAR)?;
             let header = vir::headers::read_header(&mut body)?;
+            if header.decrease.len() > 0 {
+                return err_span_str(expr.span, "termination checking of loops is not supported");
+            }
             let invs = header.invariant;
             Ok(mk_expr(ExprX::While { cond, body, invs }))
         }

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -1159,7 +1159,11 @@ impl Verifier {
         Ok(true)
     }
 
-    fn construct_vir_crate<'tcx>(&mut self, tcx: TyCtxt<'tcx>) -> Result<bool, VirErr> {
+    fn construct_vir_crate<'tcx>(
+        &mut self,
+        tcx: TyCtxt<'tcx>,
+        diagnostics: &impl Diagnostics,
+    ) -> Result<bool, VirErr> {
         let autoviewed_call_typs = Arc::new(std::sync::Mutex::new(HashMap::new()));
         if !self.args.no_enhanced_typecheck {
             let _ =
@@ -1218,7 +1222,17 @@ impl Verifier {
             let mut file = self.create_log_file(None, None, crate::config::VIR_FILE_SUFFIX)?;
             vir::printer::write_krate(&mut file, &vir_crate);
         }
-        vir::well_formed::check_crate(&vir_crate)?;
+        let mut check_crate_diags = vec![];
+        let check_crate_result = vir::well_formed::check_crate(&vir_crate, &mut check_crate_diags);
+        for diag in check_crate_diags {
+            match diag {
+                vir::ast::VirErrAs::Warning(err) => {
+                    diagnostics.report_error(&err, ErrorAs::Warning)
+                }
+                vir::ast::VirErrAs::Note(err) => diagnostics.report_error(&err, ErrorAs::Note),
+            }
+        }
+        check_crate_result?;
         let (erasure_modes, inferred_modes) = vir::modes::check_crate(&vir_crate)?;
         let vir_crate = vir::traits::demote_foreign_traits(&vir_crate)?;
 
@@ -1329,7 +1343,7 @@ impl rustc_driver::Callbacks for VerifierCallbacks {
         let _result = queries.global_ctxt().expect("global_ctxt").peek_mut().enter(|tcx| {
             {
                 let mut verifier = self.verifier.lock().expect("verifier mutex");
-                if let Err(err) = verifier.construct_vir_crate(tcx) {
+                if let Err(err) = verifier.construct_vir_crate(tcx, compiler) {
                     compiler.report_error(&err, ErrorAs::Error);
                     verifier.encountered_vir_error = true;
                     return;

--- a/source/rust_verify/tests/loops.rs
+++ b/source/rust_verify/tests/loops.rs
@@ -358,3 +358,17 @@ test_verify_one_file! {
         }
     } => Err(e) => assert_one_fails(e)
 }
+
+test_verify_one_file! {
+    #[test] loop_termination_unsupported verus_code! {
+        fn test() {
+            let mut a: u64 = 0;
+            while a < 100
+                invariant a <= 100
+                decreases 100 - a
+            {
+                a = a + 1;
+            }
+        }
+    } => Err(e) => assert_vir_error(e)
+}

--- a/source/rust_verify/tests/recursion.rs
+++ b/source/rust_verify/tests/recursion.rs
@@ -1064,3 +1064,29 @@ test_verify_one_file! {
         }
     } => Err(err) => assert_one_fails(err)
 }
+
+test_verify_one_file! {
+    #[test] mutable_reference_no_decreases verus_code! {
+        fn e(s: &mut u64, i: usize) -> usize {
+            if i < 10 {
+                e(s, i + 1)
+            } else {
+                i
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_one_file! {
+    #[test] exec_no_decreases verus_code! {
+        fn e(s: &mut u64, i: usize) -> usize
+            decreases 100 - i
+        {
+            if i < 10 {
+                e(s, i + 1)
+            } else {
+                i
+            }
+        }
+    } => Err(e) => assert_vir_error(e)
+}

--- a/source/rust_verify/tests/traits.rs
+++ b/source/rust_verify/tests/traits.rs
@@ -484,11 +484,13 @@ test_verify_one_file! {
         }
         struct S {}
         impl T for S {
-            fn f(&self, x: &Self, n: u64) {
-                self.f(x, n - 1);
+            fn f(&self, x: &Self, n: u64)
+                decreases 0nat
+            {
+                self.f(x, n - 1); // FAILS
             }
         }
-    } => Err(err) => assert_vir_error(err)
+    } => Err(err) => assert_one_fails(err)
 }
 
 test_verify_one_file! {
@@ -535,11 +537,13 @@ test_verify_one_file! {
         }
         struct S {}
         impl T for S {
-            fn f(&self, x: &Self, n: u64) {
-                x.f(self, n - 1);
+            fn f(&self, x: &Self, n: u64)
+                decreases 0nat
+            {
+                x.f(self, n - 1); // FAILS
             }
         }
-    } => Err(err) => assert_vir_error(err)
+    } => Err(err) => assert_one_fails(err)
 }
 
 test_verify_one_file! {

--- a/source/rust_verify/tests/traits_modules.rs
+++ b/source/rust_verify/tests/traits_modules.rs
@@ -497,12 +497,14 @@ test_verify_one_file! {
         mod M2 {
             struct S {}
             impl crate::M1::T for S {
-                fn f(&self, x: &Self, n: u64) {
-                    self.f(x, n - 1);
+                fn f(&self, x: &Self, n: u64)
+                {
+                    builtin::decreases(0);
+                    self.f(x, n - 1); // FAILS
                 }
             }
         }
-    } => Err(err) => assert_vir_error(err)
+    } => Err(err) => assert_one_fails(err)
 }
 
 test_verify_one_file! {
@@ -566,11 +568,12 @@ test_verify_one_file! {
             struct S {}
             impl crate::M1::T for S {
                 fn f(&self, x: &Self, n: u64) {
-                    x.f(self, n - 1);
+                    builtin::decreases(0);
+                    x.f(self, n - 1); // FAILS
                 }
             }
         }
-    } => Err(err) => assert_vir_error(err)
+    } => Err(err) => assert_one_fails(err)
 }
 
 test_verify_one_file! {

--- a/source/rust_verify/tests/traits_modules_pub_crate.rs
+++ b/source/rust_verify/tests/traits_modules_pub_crate.rs
@@ -498,11 +498,12 @@ test_verify_one_file! {
             struct S {}
             impl crate::M1::T for S {
                 fn f(&self, x: &Self, n: u64) {
-                    self.f(x, n - 1);
+                    builtin::decreases(0);
+                    self.f(x, n - 1); // FAILS
                 }
             }
         }
-    } => Err(err) => assert_vir_error(err)
+    } => Err(err) => assert_one_fails(err)
 }
 
 test_verify_one_file! {
@@ -566,11 +567,12 @@ test_verify_one_file! {
             struct S {}
             impl crate::M1::T for S {
                 fn f(&self, x: &Self, n: u64) {
-                    x.f(self, n - 1);
+                    builtin::decreases(0);
+                    x.f(self, n - 1); // FAILS
                 }
             }
         }
-    } => Err(err) => assert_vir_error(err)
+    } => Err(err) => assert_one_fails(err)
 }
 
 test_verify_one_file! {

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -15,6 +15,11 @@ pub use air::ast::{Binder, Binders};
 /// Result<T, VirErr> is used when an error might need to be reported to the user
 pub type VirErr = Error;
 
+pub enum VirErrAs {
+    Warning(VirErr),
+    Note(VirErr),
+}
+
 /// A non-qualified name, such as a local variable name or type parameter name
 pub type Ident = Arc<String>;
 pub type Idents = Arc<Vec<Ident>>;

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -719,7 +719,10 @@ pub fn func_def_to_air(
             state.ret_post = None;
 
             // Check termination
-            let (decls, stm) = if function.x.mode == Mode::Exec || ctx.checking_recommends() {
+            //
+            let no_termination_check =
+                function.x.mode == Mode::Exec && function.x.decrease.len() == 0;
+            let (decls, stm) = if no_termination_check || ctx.checking_recommends() {
                 (vec![], stm)
             } else {
                 crate::recursion::check_termination_stm(ctx, &state.fun_ssts, function, &stm)?

--- a/source/vir/src/func_to_air.rs
+++ b/source/vir/src/func_to_air.rs
@@ -719,7 +719,7 @@ pub fn func_def_to_air(
             state.ret_post = None;
 
             // Check termination
-            let (decls, stm) = if ctx.checking_recommends() {
+            let (decls, stm) = if function.x.mode == Mode::Exec || ctx.checking_recommends() {
                 (vec![], stm)
             } else {
                 crate::recursion::check_termination_stm(ctx, &state.fun_ssts, function, &stm)?

--- a/source/vir/src/recursion.rs
+++ b/source/vir/src/recursion.rs
@@ -141,7 +141,7 @@ fn check_decrease_call(
     let mut decreases_exps: Vec<Exp> = Vec::new();
     for expr in function.x.decrease.iter() {
         let decreases_exp =
-            expr_to_exp(ctxt.ctx, fun_ssts, &params_to_pars(&function.x.params, false), expr)?;
+            expr_to_exp(ctxt.ctx, fun_ssts, &params_to_pars(&function.x.params, true), expr)?;
         let dec_exp = exp_rename_vars(&decreases_exp, &renames);
         let e_decx = ExpX::Bind(
             Spanned::new(span.clone(), BndX::Let(Arc::new(binders.clone()))),
@@ -344,7 +344,7 @@ pub(crate) fn check_termination_exp(
     }
 
     let decreases_exps = vec_map_result(&function.x.decrease, |e| {
-        expr_to_exp(ctx, fun_ssts, &params_to_pars(&function.x.params, false), e)
+        expr_to_exp(ctx, fun_ssts, &params_to_pars(&function.x.params, true), e)
     })?;
     let scc_rep = ctx.global.func_call_graph.get_scc_rep(&Node::Fun(function.x.name.clone()));
     let ctxt =
@@ -417,7 +417,7 @@ pub(crate) fn check_termination_stm(
     }
 
     let decreases_exps = vec_map_result(&function.x.decrease, |e| {
-        expr_to_exp(ctx, fun_ssts, &params_to_pars(&function.x.params, false), e)
+        expr_to_exp(ctx, fun_ssts, &params_to_pars(&function.x.params, true), e)
     })?;
     let scc_rep = ctx.global.func_call_graph.get_scc_rep(&Node::Fun(function.x.name.clone()));
     let ctxt =

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -647,6 +647,15 @@ fn check_function(ctxt: &Ctxt, function: &Function) -> Result<(), VirErr> {
         check_expr(ctxt, function, expr, disallow_private_access)?;
     }
 
+    if function.x.mode == Mode::Exec
+        && (function.x.decrease.len() > 0 || function.x.decrease_by.is_some())
+    {
+        return err_str(
+            &function.span,
+            "decreases and decreases_by are not supported for exec functions",
+        );
+    }
+
     if let Some(body) = &function.x.body {
         // Check that public, non-abstract spec function bodies don't refer to private items:
         let disallow_private_access = function.x.publish.is_some()

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -1,6 +1,6 @@
 use crate::ast::{
     CallTarget, Datatype, Expr, ExprX, FieldOpr, Fun, FunX, Function, FunctionKind, Krate,
-    MaskSpec, Mode, MultiOp, Path, PathX, TypX, UnaryOp, UnaryOpr, VirErr,
+    MaskSpec, Mode, MultiOp, Path, PathX, TypX, UnaryOp, UnaryOpr, VirErr, VirErrAs,
 };
 use crate::ast_util::{err_str, err_string, error, path_as_rust_name, referenced_vars_expr};
 use crate::datatype_to_air::is_datatype_transparent;
@@ -210,7 +210,11 @@ fn check_expr(
     })
 }
 
-fn check_function(ctxt: &Ctxt, function: &Function) -> Result<(), VirErr> {
+fn check_function(
+    ctxt: &Ctxt,
+    function: &Function,
+    diags: &mut Vec<VirErrAs>,
+) -> Result<(), VirErr> {
     if let FunctionKind::TraitMethodDecl { .. } = function.x.kind {
         if function.x.body.is_some() && function.x.mode != Mode::Exec {
             // REVIEW: If we allow default method implementations, we'll need to make sure
@@ -650,10 +654,9 @@ fn check_function(ctxt: &Ctxt, function: &Function) -> Result<(), VirErr> {
     if function.x.mode == Mode::Exec
         && (function.x.decrease.len() > 0 || function.x.decrease_by.is_some())
     {
-        return err_str(
-            &function.span,
-            "decreases and decreases_by are not supported for exec functions",
-        );
+        diags.push(VirErrAs::Warning(
+            error("decreases checks in exec functions do not guarantee termination of functions with loops or of their callers", &function.span),
+        ));
     }
 
     if let Some(body) = &function.x.body {
@@ -760,7 +763,7 @@ fn check_functions_match(
     Ok(())
 }
 
-pub fn check_crate(krate: &Krate) -> Result<(), VirErr> {
+pub fn check_crate(krate: &Krate, diags: &mut Vec<VirErrAs>) -> Result<(), VirErr> {
     let mut funs: HashMap<Fun, Function> = HashMap::new();
     for function in krate.functions.iter() {
         if funs.contains_key(&function.x.name) {
@@ -854,7 +857,7 @@ pub fn check_crate(krate: &Krate) -> Result<(), VirErr> {
 
     let ctxt = Ctxt { funs, dts };
     for function in krate.functions.iter() {
-        check_function(&ctxt, function)?;
+        check_function(&ctxt, function, diags)?;
     }
     for dt in krate.datatypes.iter() {
         check_datatype(dt)?;


### PR DESCRIPTION
I do not believe this opens to any potential unsoundness, especially because it's already possible to write a non-terminating recursive exec function with a loop.

Reported by @matthias-brun.