### PR TITLE
Skip recommends check for nonlinear arithmetic query, emit note when skipping recommends check

### DIFF
--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -880,12 +880,15 @@ impl Verifier {
                 for command in commands.iter().map(|x| &*x) {
                     let CommandsWithContextX {
                         span,
-                        desc: _,
+                        desc,
                         commands: _,
                         prover_choice,
                         skip_recommends,
                     } = &**command;
                     if recommends_rerun && *skip_recommends {
+                        let multispan = MultiSpan::from_spans(vec![from_raw_span(&span.raw_span)]);
+                        let msg = format!("recommends check skipped: {}", desc);
+                        compiler.diagnostic().span_note_without_error(multispan, &msg);
                         continue;
                     }
                     if *prover_choice == vir::def::ProverChoice::Singular {

--- a/source/vir/src/def.rs
+++ b/source/vir/src/def.rs
@@ -438,6 +438,7 @@ pub struct CommandsWithContextX {
     pub desc: String,
     pub commands: Commands,
     pub prover_choice: ProverChoice,
+    pub skip_recommends: bool,
 }
 
 impl CommandsWithContextX {
@@ -446,12 +447,14 @@ impl CommandsWithContextX {
         desc: String,
         commands: Commands,
         prover_choice: ProverChoice,
+        skip_recommends: bool,
     ) -> CommandsWithContext {
         Arc::new(CommandsWithContextX {
             span: span,
             desc: desc,
             commands: commands,
             prover_choice: prover_choice,
+            skip_recommends: skip_recommends,
         })
     }
 }

--- a/source/vir/src/sst_to_air.rs
+++ b/source/vir/src/sst_to_air.rs
@@ -1317,6 +1317,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
                             mk_option_command("smt.arith.nl", "false"),
                         ]),
                         ProverChoice::DefaultProver,
+                        true,
                     ));
                 }
             }
@@ -1345,6 +1346,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
                 "assert_bit_vector".to_string(),
                 Arc::new(bv_commands),
                 ProverChoice::Spinoff,
+                true,
             ));
 
             vec![Arc::new(StmtX::Assume(exp_to_expr(ctx, &expr, expr_ctxt)?))]
@@ -1510,6 +1512,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Result<Vec<Stmt>, Vi
                 desc: "while loop".to_string(),
                 commands: Arc::new(vec![Arc::new(CommandX::CheckValid(query))]),
                 prover_choice: ProverChoice::DefaultProver,
+                skip_recommends: false,
             }));
 
             // At original site of while loop, assert invariant, havoc, assume invariant + neg_cond
@@ -1858,6 +1861,7 @@ pub fn body_stm_to_air(
             "Singular check valid".to_string(),
             Arc::new(vec![singular_command]),
             ProverChoice::Singular,
+            true,
         ));
     } else {
         let query = Arc::new(QueryX { local: Arc::new(local), assertion });
@@ -1883,6 +1887,7 @@ pub fn body_stm_to_air(
             } else {
                 ProverChoice::DefaultProver
             },
+            is_integer_ring || is_bit_vector_mode || is_nonlinear,
         ));
     }
     Ok((state.commands, state.snap_map))


### PR DESCRIPTION
This pull request is about making
1) non-linear queries to skip recommends check
2) Verus emit notes when skipping recommends check.

As reported by @utaal and  @matthias-brun, `assert_nonlinear_by`'s recommends check often fails to point out the cause of verification failure. It is partially due to the query separation, which makes the separate query miss many facts from the original context. Also, recommends check's purpose might differ from nonlinear queries' purpose, which is often just producing simple facts about nonlinear arithmetic.

