### PR TITLE
Use the new Z3 arithmetic solver for nonlinear queries

### DIFF
--- a/source/air/src/context.rs
+++ b/source/air/src/context.rs
@@ -252,10 +252,10 @@ impl Context {
             self.set_z3_param_bool(option, true, true);
         } else if value == "false" {
             self.set_z3_param_bool(option, false, true);
-        } else if let Ok(v) = value.parse::<f64>() {
-            self.set_z3_param_f64(option, v, true);
         } else if let Ok(v) = value.parse::<u32>() {
             self.set_z3_param_u32(option, v, true);
+        } else if let Ok(v) = value.parse::<f64>() {
+            self.set_z3_param_f64(option, v, true);
         } else if value.is_ascii() {
             self.set_z3_param_str(option, value, true);
         } else {

--- a/source/docs/non_linear_arithmetic/fueled_encoding_nl-6.air
+++ b/source/docs/non_linear_arithmetic/fueled_encoding_nl-6.air
@@ -1,0 +1,34 @@
+(declare-fun Mul (Int Int) Int)
+(declare-fun EucDiv (Int Int) Int)
+(declare-fun EucMod (Int Int) Int)
+(declare-const non_linear_encoding Bool)
+(axiom
+ (=> non_linear_encoding
+  (forall ((x Int) (y Int)) (!
+   (= (Mul x y) (* x y))
+   :pattern ((Mul x y))
+   :qid
+   prelude_mul
+   :skolemid
+   skolem_prelude_mul
+))))
+(axiom
+ (=> non_linear_encoding
+  (forall ((x Int) (y Int)) (!
+   (= (EucDiv x y) (div x y))
+   :pattern ((EucDiv x y))
+   :qid
+   prelude_eucdiv
+   :skolemid
+   skolem_prelude_eucdiv
+))))
+(axiom
+ (=> non_linear_encoding
+  (forall ((x Int) (y Int)) (!
+   (= (EucMod x y) (mod x y))
+   :pattern ((EucMod x y))
+   :qid
+   prelude_eucmod
+   :skolemid
+   skolem_prelude_eucmod
+))))

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -872,12 +872,17 @@ fn fn_call_to_vir<'tcx>(
 
         let expr_attrs = bctx.ctxt.tcx.hir().attrs(expr.hir_id);
         let expr_vattrs = get_verifier_attrs(expr_attrs)?;
+        if expr_vattrs.spinoff_prover {
+            return err_span_str(
+                expr.span,
+                "#[verifier(spinoff_prover)] is implied for assert by nonlinear_arith",
+            );
+        }
         return Ok(mk_expr(ExprX::AssertQuery {
             requires,
             ensures,
             proof,
             mode: AssertQueryMode::NonLinear,
-            spinoff_prover: expr_vattrs.spinoff_prover,
         }));
     }
     if is_assert_forall_by {

--- a/source/rust_verify/src/rust_to_vir_func.rs
+++ b/source/rust_verify/src/rust_to_vir_func.rs
@@ -235,6 +235,13 @@ pub(crate) fn check_item_fn<'tcx>(
         let path = autospec_fun(&path, method_name.clone());
         Arc::new(FunX { path, trait_path: trait_path.clone() })
     });
+
+    if vattrs.nonlinear && vattrs.spinoff_prover {
+        return err_span_str(
+            sig.span,
+            "#[verifier(spinoff_prover)] is implied for assert by nonlinear_arith",
+        );
+    }
     let fattrs = FunctionAttrsX {
         uses_ghost_blocks: vattrs.verus_macro,
         inline: vattrs.inline,

--- a/source/rust_verify/tests/nonlinear.rs
+++ b/source/rust_verify/tests/nonlinear.rs
@@ -5,14 +5,10 @@
 mod common;
 use common::*;
 
-// TODO: make sure testcases do not timeout
-
 // Test #[verifier(nonlinear)]
 
-// TODO stabilize this with z3 4.8.17
 test_verify_one_file! {
-    // TODO stabilize this with z3 4.8.17
-    #[ignore] #[test] test1 code! {
+    #[test] test1 verus_code! {
         #[verifier(nonlinear)]
         proof fn lemma_mul_upper_bound(x: int, x_bound: int, y: int, y_bound: int)
             requires
@@ -23,11 +19,6 @@ test_verify_one_file! {
             ensures
                 x * y <= x_bound * y_bound,
         {
-            // TODO this attempt to stabilize didn't work
-            // assert(x <= x * x_bound);
-            assert(y <= y * y_bound);
-
-            assert(x * y <= x_bound * y_bound);
         }
     } => Ok(())
 }

--- a/source/rust_verify/tests/z3_restart.rs
+++ b/source/rust_verify/tests/z3_restart.rs
@@ -50,7 +50,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test_with_nlarith verus_code! {
         #[verifier(nonlinear)]
-        #[verifier(spinoff_prover)]
+        // #[verifier(spinoff_prover)] is implied for nonlinear queries
         proof fn lemma_div_pos_is_pos(x: int, d: int)
             requires
                 0 <= x,
@@ -95,7 +95,7 @@ test_verify_one_file! {
 test_verify_one_file! {
     #[test] test2_fails verus_code! {
         #[verifier(nonlinear)]
-        #[verifier(spinoff_prover)]
+        // #[verifier(spinoff_prover)] is implied for nonlinear queries
         proof fn wrong_lemma_2(x: int, y: int, z: int)
             requires
                 x > y,

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -439,13 +439,7 @@ pub enum ExprX {
     /// Sequence of statements, optionally including an expression at the end
     Block(Stmts, Option<Expr>),
     /// assert_by with smt.arith.nl=true
-    AssertQuery {
-        requires: Exprs,
-        ensures: Exprs,
-        proof: Expr,
-        mode: AssertQueryMode,
-        spinoff_prover: bool,
-    },
+    AssertQuery { requires: Exprs, ensures: Exprs, proof: Expr, mode: AssertQueryMode },
 }
 
 /// Statement, similar to rustc_hir::Stmt

--- a/source/vir/src/ast_to_sst.rs
+++ b/source/vir/src/ast_to_sst.rs
@@ -1179,7 +1179,7 @@ fn expr_to_stm_opt(
             stms.push(assume);
             Ok((stms, ReturnValue::ImplicitUnit(expr.span.clone())))
         }
-        ExprX::AssertQuery { requires, ensures, proof, mode, spinoff_prover } => {
+        ExprX::AssertQuery { requires, ensures, proof, mode } => {
             let mut inner_body: Vec<Stm> = Vec::new();
             let mut vars = BTreeMap::new(); // order vars by UniqueIdent
 
@@ -1253,7 +1253,6 @@ fn expr_to_stm_opt(
                     body: inner_body,
                     typ_inv_vars: Arc::new(vars.into_iter().collect()),
                     mode: *mode,
-                    spinoff_prover: *spinoff_prover,
                 },
             );
             Ok((vec![outer_block, nonlinear], ReturnValue::ImplicitUnit(expr.span.clone())))

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -272,7 +272,7 @@ where
                     expr_visitor_control_flow!(expr_visitor_dfs(proof, map, mf));
                     map.pop_scope();
                 }
-                ExprX::AssertQuery { requires, ensures, proof, mode: _, spinoff_prover: _ } => {
+                ExprX::AssertQuery { requires, ensures, proof, mode: _ } => {
                     for req in requires.iter() {
                         expr_visitor_control_flow!(expr_visitor_dfs(req, map, mf));
                     }
@@ -600,7 +600,7 @@ where
             map.pop_scope();
             ExprX::Forall { vars: Arc::new(vars), require, ensure, proof }
         }
-        ExprX::AssertQuery { requires, ensures, proof, mode, spinoff_prover } => {
+        ExprX::AssertQuery { requires, ensures, proof, mode } => {
             let requires = Arc::new(vec_map_result(requires, |e| {
                 map_expr_visitor_env(e, map, env, fe, fs, ft)
             })?);
@@ -608,13 +608,7 @@ where
                 map_expr_visitor_env(e, map, env, fe, fs, ft)
             })?);
             let proof = map_expr_visitor_env(proof, map, env, fe, fs, ft)?;
-            ExprX::AssertQuery {
-                requires,
-                ensures,
-                proof,
-                mode: *mode,
-                spinoff_prover: *spinoff_prover,
-            }
+            ExprX::AssertQuery { requires, ensures, proof, mode: *mode }
         }
         ExprX::AssertBV(e) => {
             let expr1 = map_expr_visitor_env(e, map, env, fe, fs, ft)?;

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -709,7 +709,7 @@ fn check_expr_handle_mut_arg(
             typing.in_forall_stmt = in_forall_stmt;
             Ok(Mode::Proof)
         }
-        ExprX::AssertQuery { requires, ensures, proof, mode: _, spinoff_prover: _ } => {
+        ExprX::AssertQuery { requires, ensures, proof, mode: _ } => {
             if typing.check_ghost_blocks && typing.block_ghostness == Ghost::Exec {
                 return err_str(&expr.span, "cannot use assert in exec mode");
             }

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -439,7 +439,7 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
             let vars = Arc::new(bs);
             mk_expr(ExprX::Forall { vars, require, ensure, proof })
         }
-        ExprX::AssertQuery { requires, ensures, proof, mode, spinoff_prover } => {
+        ExprX::AssertQuery { requires, ensures, proof, mode } => {
             state.types.push_scope(true);
             let requires =
                 requires.iter().map(|e| coerce_expr_to_native(ctx, &poly_expr(ctx, state, e)));
@@ -449,13 +449,7 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
             let ensures = Arc::new(ensures.collect());
             let proof = poly_expr(ctx, state, proof);
             state.types.pop_scope();
-            mk_expr(ExprX::AssertQuery {
-                requires,
-                ensures,
-                proof,
-                mode: *mode,
-                spinoff_prover: *spinoff_prover,
-            })
+            mk_expr(ExprX::AssertQuery { requires, ensures, proof, mode: *mode })
         }
         ExprX::If(e0, e1, None) => {
             let e0 = coerce_expr_to_native(ctx, &poly_expr(ctx, state, e0));

--- a/source/vir/src/printer.rs
+++ b/source/vir/src/printer.rs
@@ -314,12 +314,8 @@ fn expr_to_node(expr: &Expr) -> Node {
         ExprX::Forall { vars, require, ensure, proof } => {
             nodes!(forall {binders_node(vars, &typ_to_node)} {str_to_node(":require")} {expr_to_node(require)} {str_to_node(":ensure")} {expr_to_node(ensure)} {str_to_node(":proof")} {expr_to_node(proof)})
         }
-        ExprX::AssertQuery { requires, ensures, proof, mode, spinoff_prover } => {
-            let mut nodes = nodes_vec!(assertQuery {str_to_node(":requires")} {exprs_to_node(requires)} {str_to_node(":ensures")} {exprs_to_node(ensures)} {str_to_node(":proof")} {expr_to_node(proof)} {str_to_node(":mode")} {str_to_node(&format!("{:?}", mode))});
-            if *spinoff_prover {
-                nodes.push(str_to_node("+spinoff_prover"));
-            }
-            Node::List(nodes)
+        ExprX::AssertQuery { requires, ensures, proof, mode } => {
+            nodes!(assertQuery {str_to_node(":requires")} {exprs_to_node(requires)} {str_to_node(":ensures")} {exprs_to_node(ensures)} {str_to_node(":proof")} {expr_to_node(proof)} {str_to_node(":mode")} {str_to_node(&format!("{:?}", mode))})
         }
         ExprX::AssertBV(expr) => nodes!(assertbv {expr_to_node(expr)}),
         ExprX::If(e0, e1, e2) => {

--- a/source/vir/src/sst.rs
+++ b/source/vir/src/sst.rs
@@ -118,7 +118,6 @@ pub enum StmX {
         mode: AssertQueryMode,
         typ_inv_vars: Arc<Vec<(UniqueIdent, Typ)>>,
         body: Stm,
-        spinoff_prover: bool,
     },
 }
 

--- a/source/vir/src/sst_visitor.rs
+++ b/source/vir/src/sst_visitor.rs
@@ -162,7 +162,7 @@ where
                         expr_visitor_control_flow!(stm_visitor_dfs(rhs, f));
                     }
                 }
-                StmX::AssertQuery { body, mode: _, typ_inv_vars: _, spinoff_prover: _ } => {
+                StmX::AssertQuery { body, mode: _, typ_inv_vars: _ } => {
                     expr_visitor_control_flow!(stm_visitor_dfs(body, f));
                 }
                 StmX::While {
@@ -210,7 +210,7 @@ where
             StmX::AssertBV(exp) => {
                 expr_visitor_control_flow!(exp_visitor_dfs(exp, &mut ScopeMap::new(), f))
             }
-            StmX::AssertQuery { body: _, typ_inv_vars: _, mode: _, spinoff_prover: _ } => (),
+            StmX::AssertQuery { body: _, typ_inv_vars: _, mode: _ } => (),
             StmX::Assume(exp) => {
                 expr_visitor_control_flow!(exp_visitor_dfs(exp, &mut ScopeMap::new(), f))
             }
@@ -548,16 +548,11 @@ where
             );
             fe(&stm)
         }
-        StmX::AssertQuery { mode, typ_inv_vars, body, spinoff_prover } => {
+        StmX::AssertQuery { mode, typ_inv_vars, body } => {
             let body = map_stm_visitor(body, fe)?;
             let stm = Spanned::new(
                 stm.span.clone(),
-                StmX::AssertQuery {
-                    mode: *mode,
-                    typ_inv_vars: typ_inv_vars.clone(),
-                    body,
-                    spinoff_prover: *spinoff_prover,
-                },
+                StmX::AssertQuery { mode: *mode, typ_inv_vars: typ_inv_vars.clone(), body },
             );
             fe(&stm)
         }

--- a/source/vir/src/well_formed.rs
+++ b/source/vir/src/well_formed.rs
@@ -156,7 +156,7 @@ fn check_one_expr(
         ExprX::OpenInvariant(_inv, _binder, body, _atomicity) => {
             assert_no_early_exit_in_inv_block(&body.span, body)?;
         }
-        ExprX::AssertQuery { requires, ensures, proof, mode: _, spinoff_prover: _ } => {
+        ExprX::AssertQuery { requires, ensures, proof, mode: _ } => {
             if function.x.attrs.nonlinear {
                 return err_str(
                     &expr.span,


### PR DESCRIPTION
In my testing it is always either as good or significantly better at discharging nonlinear proof goals.

We need to always spinoff queries using this solver as once a query is run on a z3 instance, requests to change the arithmetic solver are ignored.