### PR TITLE
Check that the solver version is the one we expect, addresses #235

### DIFF
--- a/source/air/src/context.rs
+++ b/source/air/src/context.rs
@@ -82,6 +82,7 @@ pub struct Context {
     pub(crate) time_smt_init: Duration,
     pub(crate) time_smt_run: Duration,
     pub(crate) state: ContextState,
+    pub(crate) expected_solver_version: Option<String>,
 }
 
 impl Context {
@@ -110,6 +111,7 @@ impl Context {
             time_smt_init: Duration::new(0, 0),
             time_smt_run: Duration::new(0, 0),
             state: ContextState::NotStarted,
+            expected_solver_version: None,
         };
         context.axiom_infos.push_scope(false);
         context.lambda_map.push_scope(false);
@@ -173,6 +175,10 @@ impl Context {
 
     pub fn get_time(&self) -> (Duration, Duration) {
         (self.time_smt_init, self.time_smt_run)
+    }
+
+    pub fn set_expected_solver_version(&mut self, version: String) {
+        self.expected_solver_version = Some(version);
     }
 
     pub fn set_rlimit(&mut self, rlimit: u32) {

--- a/source/rust_verify/src/config.rs
+++ b/source/rust_verify/src/config.rs
@@ -58,6 +58,7 @@ pub struct Args {
     pub profile: bool,
     pub profile_all: bool,
     pub compile: bool,
+    pub solver_version_check: bool,
 }
 
 pub fn enable_default_features(rustc_args: &mut Vec<String>) {
@@ -102,6 +103,7 @@ pub fn parse_args(program: &String, args: impl Iterator<Item = String>) -> (Args
     const OPT_PROFILE: &str = "profile";
     const OPT_PROFILE_ALL: &str = "profile-all";
     const OPT_COMPILE: &str = "compile";
+    const OPT_NO_SOLVER_VERSION_CHECK: &str = "no-solver-version-check";
 
     let mut opts = Options::new();
     opts.optopt("", OPT_PERVASIVE_PATH, "Path of the pervasive module", "PATH");
@@ -167,6 +169,7 @@ pub fn parse_args(program: &String, args: impl Iterator<Item = String>) -> (Args
     );
     opts.optflag("", OPT_PROFILE_ALL, "Always collect and report prover performance data");
     opts.optflag("", OPT_COMPILE, "Run Rustc compiler after verification");
+    opts.optflag("", OPT_NO_SOLVER_VERSION_CHECK, "Skip the check that the solver has the expected version (useful to experiment with different versions of z3)");
     opts.optflag("h", "help", "print this help menu");
 
     let print_usage = || {
@@ -269,6 +272,7 @@ pub fn parse_args(program: &String, args: impl Iterator<Item = String>) -> (Args
         profile: matches.opt_present(OPT_PROFILE),
         profile_all: matches.opt_present(OPT_PROFILE_ALL),
         compile: matches.opt_present(OPT_COMPILE),
+        solver_version_check: !matches.opt_present(OPT_NO_SOLVER_VERSION_CHECK),
     };
 
     (args, unmatched)

--- a/source/rust_verify/src/consts.rs
+++ b/source/rust_verify/src/consts.rs
@@ -1,0 +1,1 @@
+pub const EXPECTED_SOLVER_VERSION: &str = "4.10.1";

--- a/source/rust_verify/src/lib.rs
+++ b/source/rust_verify/src/lib.rs
@@ -23,6 +23,7 @@ extern crate smallvec;
 
 mod attributes;
 pub mod config;
+pub mod consts;
 pub mod context;
 pub mod debugger;
 pub mod def;

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -659,7 +659,10 @@ impl Verifier {
             false,
             PreludeConfig { arch_word_bits: self.args.arch_word_bits },
         )?;
-        air_context.set_expected_solver_version(crate::consts::EXPECTED_SOLVER_VERSION.to_string());
+        if self.args.solver_version_check {
+            air_context
+                .set_expected_solver_version(crate::consts::EXPECTED_SOLVER_VERSION.to_string());
+        }
 
         let mut spunoff_time_smt_init = Duration::ZERO;
         let mut spunoff_time_smt_run = Duration::ZERO;

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -659,6 +659,8 @@ impl Verifier {
             false,
             PreludeConfig { arch_word_bits: self.args.arch_word_bits },
         )?;
+        air_context.set_expected_solver_version(crate::consts::EXPECTED_SOLVER_VERSION.to_string());
+
         let mut spunoff_time_smt_init = Duration::ZERO;
         let mut spunoff_time_smt_run = Duration::ZERO;
 


### PR DESCRIPTION
I've had a few people not noticing they were on an older solver, and they couldn't tell why tests were failing.

This panics by default if the z3 version doesn't match the expected one, but the check can be disabled with `--no-solver-version-check` (for experiments with other solver versions, for example), as suggested by @parno and @tjhance .