### PR TITLE
Make rust-verify.sh work from any directory

### DIFF
--- a/source/tools/rust-verify.sh
+++ b/source/tools/rust-verify.sh
@@ -1,5 +1,8 @@
 #! /bin/bash
 
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+REPO="$DIR/../.."
+
 case $(uname -m) in
   x86_64)
     ARCH=x86_64
@@ -13,12 +16,19 @@ case $(uname -m) in
     ;;
 esac
 
-if [ `uname` == "Darwin" ]; then
+if [ "$(uname)" == "Darwin" ]; then
     DYN_LIB_EXT=dylib
-    LIB_PATH="DYLD_LIBRARY_PATH=../rust/install/lib/rustlib/${ARCH}-apple-darwin/lib"
-elif [ `uname` == "Linux" ]; then
+    export DYLD_LIBRARY_PATH="$REPO/rust/install/lib/rustlib/${ARCH}-apple-darwin/lib"
+elif [ "$(uname)" == "Linux" ]; then
     DYN_LIB_EXT=so
-    LIB_PATH="LD_LIBRARY_PATH=../rust/install/lib/rustlib/${ARCH}-unknown-linux-gnu/lib"
+    export LD_LIBRARY_PATH="$REPO/rust/install/lib/rustlib/${ARCH}-unknown-linux-gnu/lib"
 fi
 
-eval ""VERUS_Z3_PATH="$(pwd)/z3" $LIB_PATH ../rust/install/bin/rust_verify --pervasive-path pervasive --extern builtin=../rust/install/bin/libbuiltin.rlib --extern builtin_macros=../rust/install/bin/libbuiltin_macros.$DYN_LIB_EXT --extern state_machines_macros=../rust/install/bin/libstate_machines_macros.$DYN_LIB_EXT --edition=2018 -Z proc-macro-backtrace $@""
+export VERUS_Z3_PATH="$REPO/source/z3"
+
+"$REPO"/rust/install/bin/rust_verify \
+  --pervasive-path "$REPO"/source/pervasive \
+  --extern builtin="$REPO"/rust/install/bin/libbuiltin.rlib \
+  --extern builtin_macros="$REPO"/rust/install/bin/libbuiltin_macros.$DYN_LIB_EXT \
+  --extern state_machines_macros="$REPO"/rust/install/bin/libstate_machines_macros.$DYN_LIB_EXT \
+  --edition=2018 -Z proc-macro-backtrace "$@"


### PR DESCRIPTION
As a bonus, the script now passes [shellcheck](https://www.shellcheck.net/).

I did switch to using exported environment variables; was there a reason for the use of `eval`?