### PR TITLE
better error message on missing parentheses in ghost call

### DIFF
--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -606,6 +606,12 @@ impl VisitMut for Visitor {
                             quote_spanned!(span => #[verifier(ghost_wrapper)] crate::pervasive::modes::ghost_exec(#[verifier(ghost_block_wrapped)] #inner)),
                         );
                     }
+                    (false, (true, false), _) => {
+                        *expr = Expr::Verbatim(
+                            quote_spanned!(span => compile_error!("Expected parentheses")),
+                        );
+                        return;
+                    }
                     (false, (true, true), Expr::Paren(..)) => {
                         // tracked(...)
                         let inner = take_expr(&mut *unary.expr);


### PR DESCRIPTION
Addresses #263 and outputs "Expected parentheses" when a ghost call is missing parentheses