### PR TITLE
Replace ExprX::Admit with ExprX::AssertAssume

### DIFF
--- a/source/builtin/src/lib.rs
+++ b/source/builtin/src/lib.rs
@@ -171,6 +171,16 @@ pub fn old<A>(_: A) -> A {
 }
 
 #[proof]
+pub fn assume_(_: bool) {
+    unimplemented!();
+}
+
+#[proof]
+pub fn assert_(_: bool) {
+    unimplemented!();
+}
+
+#[proof]
 pub fn assert_by(_: bool, _: ()) {
     unimplemented!();
 }

--- a/source/builtin_macros/src/syntax.rs
+++ b/source/builtin_macros/src/syntax.rs
@@ -976,7 +976,7 @@ impl VisitMut for Visitor {
                     let span = assume.assume_token.span;
                     let arg = assume.expr;
                     let attrs = assume.attrs;
-                    *expr = quote_verbatim!(span, attrs => crate::pervasive::assume(#arg));
+                    *expr = quote_verbatim!(span, attrs => ::builtin::assume_(#arg));
                 }
                 Expr::Assert(assert) => {
                     let span = assert.assert_token.span;
@@ -984,7 +984,7 @@ impl VisitMut for Visitor {
                     let attrs = assert.attrs;
                     match (assert.by_token, assert.prover, assert.requires, assert.body) {
                         (None, None, None, None) => {
-                            *expr = quote_verbatim!(span, attrs => crate::pervasive::assert(#arg));
+                            *expr = quote_verbatim!(span, attrs => ::builtin::assert_(#arg));
                         }
                         (None, _, _, _) => panic!("missing by token"),
                         (Some(_), None, None, None) => panic!("extra by token"),

--- a/source/rust_verify/src/rust_to_vir_expr.rs
+++ b/source/rust_verify/src/rust_to_vir_expr.rs
@@ -461,6 +461,8 @@ fn fn_call_to_vir<'tcx>(
     let is_reveal = f_name == "builtin::reveal";
     let is_reveal_fuel = f_name == "builtin::reveal_with_fuel";
     let is_implies = f_name == "builtin::imply";
+    let is_assume = f_name == "builtin::assume_";
+    let is_assert = f_name == "builtin::assert_";
     let is_assert_by = f_name == "builtin::assert_by";
     let is_assert_nonlinear_by = f_name == "builtin::assert_nonlinear_by";
     let is_assert_bitvector_by = f_name == "builtin::assert_bitvector_by";
@@ -635,6 +637,8 @@ fn fn_call_to_vir<'tcx>(
             || is_choose
             || is_choose_tuple
             || is_with_triggers
+            || is_assume
+            || is_assert
             || is_assert_by
             || is_assert_nonlinear_by
             || is_assert_bitvector_by
@@ -1164,7 +1168,18 @@ fn fn_call_to_vir<'tcx>(
         Ok(mk_expr(ExprX::Header(header)))
     } else if is_admit {
         unsupported_err_unless!(len == 0, expr.span, "expected admit", args);
-        Ok(mk_expr(ExprX::Admit))
+        let f = spanned_typed_new(
+            expr.span,
+            &Arc::new(TypX::Bool),
+            ExprX::Const(Constant::Bool(false)),
+        );
+        Ok(mk_expr(ExprX::AssertAssume { is_assume: true, expr: f }))
+    } else if is_assume {
+        unsupported_err_unless!(len == 1, expr.span, "expected assume", args);
+        Ok(mk_expr(ExprX::AssertAssume { is_assume: true, expr: vir_args[0].clone() }))
+    } else if is_assert {
+        unsupported_err_unless!(len == 1, expr.span, "expected assert", args);
+        Ok(mk_expr(ExprX::AssertAssume { is_assume: false, expr: vir_args[0].clone() }))
     } else if is_spec_cast_integer {
         unsupported_err_unless!(len == 1, expr.span, "spec_cast_integer", args);
         let source_vir = vir_args[0].clone();

--- a/source/rust_verify/src/verifier.rs
+++ b/source/rust_verify/src/verifier.rs
@@ -125,6 +125,10 @@ impl Diagnostics for Compiler {
             let span: Span = from_raw_span(&sp.raw_span);
             v.push(span);
         }
+        while let Some(i) = v.iter().position(|a| v.iter().any(|b| a != b && a.contains(*b))) {
+            // Remove i in favor of the more specific spans contained by i
+            v.remove(i);
+        }
 
         let mut multispan = MultiSpan::from_spans(v);
 

--- a/source/vir/src/ast.rs
+++ b/source/vir/src/ast.rs
@@ -434,8 +434,8 @@ pub enum ExprX {
     /// Note: this only appears temporarily during rust_to_vir construction, and should not
     /// appear in the final Expr produced by rust_to_vir (see vir::headers::read_header).
     Header(HeaderExpr),
-    /// Assume false
-    Admit,
+    /// Assert or assume
+    AssertAssume { is_assume: bool, expr: Expr },
     /// Forall or assert-by statement; proves "forall vars. ensure" via proof.
     Forall { vars: Binders<Typ>, require: Expr, ensure: Expr, proof: Expr },
     /// If-else

--- a/source/vir/src/ast_visitor.rs
+++ b/source/vir/src/ast_visitor.rs
@@ -271,7 +271,9 @@ where
                 ExprX::Header(_) => {
                     panic!("header expression not allowed here: {:?}", &expr.span);
                 }
-                ExprX::Admit => (),
+                ExprX::AssertAssume { is_assume: _, expr: e1 } => {
+                    expr_visitor_control_flow!(expr_visitor_dfs(e1, map, mf));
+                }
                 ExprX::Forall { vars, require, ensure, proof } => {
                     map.push_scope(true);
                     for binder in vars.iter() {
@@ -597,7 +599,10 @@ where
         ExprX::Header(_) => {
             return err_str(&expr.span, "header expression not allowed here");
         }
-        ExprX::Admit => ExprX::Admit,
+        ExprX::AssertAssume { is_assume, expr: e1 } => {
+            let expr1 = map_expr_visitor_env(e1, map, env, fe, fs, ft)?;
+            ExprX::AssertAssume { is_assume: *is_assume, expr: expr1 }
+        }
         ExprX::Forall { vars, require, ensure, proof } => {
             let vars =
                 vec_map_result(&**vars, |x| x.map_result(|t| map_typ_visitor_env(t, env, ft)))?;

--- a/source/vir/src/early_exit_cf.rs
+++ b/source/vir/src/early_exit_cf.rs
@@ -73,7 +73,7 @@ fn expr_get_early_exits_rec(
             | ExprX::WithTriggers { .. }
             | ExprX::Fuel(..)
             | ExprX::Header(..)
-            | ExprX::Admit
+            | ExprX::AssertAssume { .. }
             | ExprX::Forall { .. }
             | ExprX::RevealString(_) => VisitorControlFlow::Return,
             ExprX::AssertQuery { .. } => VisitorControlFlow::Return,

--- a/source/vir/src/modes.rs
+++ b/source/vir/src/modes.rs
@@ -685,10 +685,11 @@ fn check_expr_handle_mut_arg(
         ExprX::Fuel(_, _) => Ok(outer_mode),
         ExprX::RevealString(_) => Ok(outer_mode),
         ExprX::Header(_) => panic!("internal error: Header shouldn't exist here"),
-        ExprX::Admit => {
+        ExprX::AssertAssume { is_assume: _, expr: e } => {
             if typing.check_ghost_blocks && typing.block_ghostness == Ghost::Exec {
-                return err_str(&expr.span, "cannot use admit in exec mode");
+                return err_str(&expr.span, "cannot use assert or assume in exec mode");
             }
+            check_expr_has_mode(typing, Mode::Spec, e, Mode::Spec)?;
             Ok(outer_mode)
         }
         ExprX::Forall { vars, require, ensure, proof } => {

--- a/source/vir/src/poly.rs
+++ b/source/vir/src/poly.rs
@@ -444,7 +444,10 @@ fn poly_expr(ctx: &Ctx, state: &mut State, expr: &Expr) -> Expr {
         ExprX::Fuel(..) => expr.clone(),
         ExprX::RevealString(_) => expr.clone(),
         ExprX::Header(..) => panic!("Header should already be removed"),
-        ExprX::Admit => expr.clone(),
+        ExprX::AssertAssume { is_assume, expr: e1 } => {
+            let e1 = coerce_expr_to_native(ctx, &poly_expr(ctx, state, e1));
+            mk_expr(ExprX::AssertAssume { is_assume: *is_assume, expr: e1 })
+        }
         ExprX::Forall { vars, require, ensure, proof } => {
             let mut bs: Vec<Binder<Typ>> = Vec::new();
             state.types.push_scope(true);

--- a/source/vir/src/printer.rs
+++ b/source/vir/src/printer.rs
@@ -430,7 +430,12 @@ fn expr_to_node(expr: &Expr) -> Node {
             nodes!(str_reveal)
         }
         ExprX::Header(header_expr) => nodes!(header {header_expr_to_node(header_expr)}),
-        ExprX::Admit => node!(admit),
+        ExprX::AssertAssume { is_assume: false, expr: e1 } => {
+            nodes!(assert {expr_to_node(e1)})
+        }
+        ExprX::AssertAssume { is_assume: true, expr: e1 } => {
+            nodes!(assume {expr_to_node(e1)})
+        }
         ExprX::Forall { vars, require, ensure, proof } => {
             nodes!(forall {binders_node(vars, &typ_to_node)} {str_to_node(":require")} {expr_to_node(require)} {str_to_node(":ensure")} {expr_to_node(ensure)} {str_to_node(":proof")} {expr_to_node(proof)})
         }


### PR DESCRIPTION
This replaces `ExprX::Admit`, which meant `assume(false)`, with `ExprX::AssertAssume`, which can assert or assume an expression.  This allows us to put `assert` and `assume` in `builtin` rather than `pervasive`, which removes a dependency that the `verus!` syntax macro had on `pervasive` and is more consistent with the other forms of `assert` (`assert_nonlinear_by`, `assert_bitvector_by`, `assert_forall_by`, `assert_bit_vector`), which are all in `builtin`.  It allows us to write small test cases and examples that use `assert` but don't require all of `pervasive` (particularly in the tutorial; see https://github.com/secure-foundations/verus/blob/main/source/docs/guide/src/getting_started.md and https://github.com/secure-foundations/verus/blob/main/source/rust_verify/example/guide/getting_started.rs , for example).

@channy412 You might want to check that --expand-errors still works as expected; this incorporates a change to the span printing that we discussed earlier so that assertions are still split correctly in --expand-errors.
